### PR TITLE
fix(pg-delta): avoid recreating identical materialized views

### DIFF
--- a/.changeset/fix-materialized-view-search-path.md
+++ b/.changeset/fix-materialized-view-search-path.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Stabilize materialized view definition extraction by deparsing with an isolated search path, preventing identical materialized views from being dropped and recreated when sessions have different `search_path` values.

--- a/packages/pg-delta/src/core/objects/materialized-view/materialized-view.model.ts
+++ b/packages/pg-delta/src/core/objects/materialized-view/materialized-view.model.ts
@@ -181,6 +181,8 @@ with extension_oids as (
   where
     d.refclassid = 'pg_extension'::regclass
     and d.classid = 'pg_class'::regclass
+), deparse_settings as (
+  select set_config('search_path', '', true)
 )
 select
   c.relnamespace::regnamespace::text as schema,
@@ -278,6 +280,7 @@ select
   ) as security_labels
 from
   pg_catalog.pg_class c
+  cross join deparse_settings
   left outer join extension_oids e on c.oid = e.objid
   left join pg_attribute a on a.attrelid = c.oid and a.attnum > 0 and not a.attisdropped
   left join pg_attrdef ad on a.attrelid = ad.adrelid and a.attnum = ad.adnum

--- a/packages/pg-delta/tests/integration/materialized-view-operations.test.ts
+++ b/packages/pg-delta/tests/integration/materialized-view-operations.test.ts
@@ -4,6 +4,8 @@
 
 import { describe, expect, test } from "bun:test";
 import dedent from "dedent";
+import { createPlan } from "../../src/core/plan/create.ts";
+import { flattenPlanStatements } from "../../src/core/plan/render.ts";
 import { POSTGRES_VERSIONS } from "../constants.ts";
 import { withDb, withDbIsolated } from "../utils.ts";
 import { roundtripFidelityTest } from "./roundtrip.ts";
@@ -395,6 +397,44 @@ for (const pgVersion of POSTGRES_VERSIONS) {
             expect(statements).toStrictEqual([]);
           },
         });
+      }),
+    );
+
+    test(
+      "semantically identical materialized view definition does not trigger a diff",
+      withDb(pgVersion, async (db) => {
+        const setup = dedent`
+            CREATE TABLE public.recipe (
+              id integer PRIMARY KEY,
+              name text,
+              notes text
+            );
+
+            CREATE MATERIALIZED VIEW IF NOT EXISTS public.recipe_search AS (
+              WITH joined AS (
+                SELECT recipe.id, name AS search_text FROM public.recipe WHERE name IS NOT NULL AND name != ''
+                UNION
+                SELECT recipe.id, notes FROM public.recipe WHERE notes IS NOT NULL AND notes != ''
+              )
+
+              SELECT
+                id,
+                search_text
+              FROM joined
+            );
+          `;
+        await db.main.query(setup);
+        await db.branch.query(setup);
+
+        await db.main.query("SET search_path = public");
+        await db.branch.query("SET search_path = ''");
+
+        const planResult = await createPlan(db.main, db.branch);
+        const statements = planResult
+          ? flattenPlanStatements(planResult.plan)
+          : [];
+
+        expect(statements).toStrictEqual([]);
       }),
     );
   });


### PR DESCRIPTION
## What
- Stabilize materialized view definition extraction by forcing an isolated `search_path` while calling `pg_get_viewdef`.
- Add an integration regression for identical materialized views extracted from sessions with different `search_path` values.
- Add a pg-delta patch changeset.

## Why
`pg_get_viewdef` can deparse the same materialized view as `recipe` or `public.recipe` depending on the session search path. That made pg-delta treat identical materialized views as definition changes and emit DROP/CREATE.

## Validation
- RED: the new regression previously emitted `DROP MATERIALIZED VIEW public.recipe_search` + `CREATE MATERIALIZED VIEW public.recipe_search ...`.
- `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=15,17,18 bun run test --test-name-pattern "semantically identical materialized view definition" tests/integration/materialized-view-operations.test.ts`
- `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=17 bun run test tests/integration/materialized-view-operations.test.ts`
- `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=17 bun run test:pg-delta`
- `bun run format-and-lint`
- `bun run check-types`
- `bun run --filter '@supabase/pg-delta' knip`

Fixes #301
