### PR TITLE
fix(pg-delta): handle leading enum additions

### DIFF
--- a/.changeset/fix-leading-enum-values.md
+++ b/.changeset/fix-leading-enum-values.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix enum additions that insert multiple new labels before the first existing label.

--- a/.changeset/fix-leading-enum-values.md
+++ b/.changeset/fix-leading-enum-values.md
@@ -2,4 +2,4 @@
 "@supabase/pg-delta": patch
 ---
 
-Fix enum additions that insert multiple new labels before the first existing label.
+Fix enum additions that insert multiple new labels before the first existing label, and preserve empty enum types and empty-string enum labels during extraction and serialization.

--- a/.changeset/fix-leading-enum-values.md
+++ b/.changeset/fix-leading-enum-values.md
@@ -2,4 +2,4 @@
 "@supabase/pg-delta": patch
 ---
 
-Fix enum additions that insert multiple new labels before the first existing label, and preserve empty enum types and empty-string enum labels during extraction and serialization.
+Fix enum additions that insert multiple new labels before the first existing label, preserve empty enum types and empty-string enum labels during extraction and serialization, reject unsupported existing-label reordering explicitly, and restore enum security labels when replacing enums for removed labels.

--- a/packages/pg-delta/src/core/objects/type/enum/changes/enum.alter.test.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/changes/enum.alter.test.ts
@@ -106,6 +106,29 @@ describe.concurrent("enum", () => {
       );
     });
 
+    test("add value after empty label", async () => {
+      const props: EnumProps = {
+        schema: "public",
+        name: "test_enum",
+        owner: "test",
+        labels: [{ sort_order: 1, label: "" }],
+        comment: null,
+        privileges: [],
+      };
+      const main = new Enum(props);
+      const change = new AlterEnumAddValue({
+        enum: main,
+        newValue: "value1",
+        position: { after: "" },
+      });
+
+      await assertValidSql(change.serialize());
+
+      expect(change.serialize()).toBe(
+        "ALTER TYPE public.test_enum ADD VALUE 'value1' AFTER ''",
+      );
+    });
+
     test("complex enum changes are not auto-replaced", async () => {
       expect(1).toBe(1);
     });

--- a/packages/pg-delta/src/core/objects/type/enum/changes/enum.alter.test.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/changes/enum.alter.test.ts
@@ -129,6 +129,29 @@ describe.concurrent("enum", () => {
       );
     });
 
+    test("add value before empty label", async () => {
+      const props: EnumProps = {
+        schema: "public",
+        name: "test_enum",
+        owner: "test",
+        labels: [{ sort_order: 1, label: "" }],
+        comment: null,
+        privileges: [],
+      };
+      const main = new Enum(props);
+      const change = new AlterEnumAddValue({
+        enum: main,
+        newValue: "value1",
+        position: { before: "" },
+      });
+
+      await assertValidSql(change.serialize());
+
+      expect(change.serialize()).toBe(
+        "ALTER TYPE public.test_enum ADD VALUE 'value1' BEFORE ''",
+      );
+    });
+
     test("complex enum changes are not auto-replaced", async () => {
       expect(1).toBe(1);
     });

--- a/packages/pg-delta/src/core/objects/type/enum/changes/enum.alter.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/changes/enum.alter.ts
@@ -84,9 +84,9 @@ export class AlterEnumAddValue extends AlterEnumChange {
       quoteLiteral(this.newValue),
     ];
 
-    if (this.position?.before) {
+    if (this.position?.before !== undefined) {
       parts.push("BEFORE", quoteLiteral(this.position.before));
-    } else if (this.position?.after) {
+    } else if (this.position?.after !== undefined) {
       parts.push("AFTER", quoteLiteral(this.position.after));
     }
 

--- a/packages/pg-delta/src/core/objects/type/enum/changes/enum.create.test.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/changes/enum.create.test.ts
@@ -28,4 +28,23 @@ describe("enum", () => {
       "CREATE TYPE public.test_enum AS ENUM ('value1', 'value2', 'value3')",
     );
   });
+
+  test("create empty enum", async () => {
+    const enumType = new Enum({
+      schema: "public",
+      name: "test_enum",
+      owner: "test",
+      labels: [],
+      comment: null,
+      privileges: [],
+    });
+
+    const change = new CreateEnum({
+      enum: enumType,
+    });
+
+    await assertValidSql(change.serialize());
+
+    expect(change.serialize()).toBe("CREATE TYPE public.test_enum AS ENUM ()");
+  });
 });

--- a/packages/pg-delta/src/core/objects/type/enum/enum.diff.test.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/enum.diff.test.ts
@@ -15,6 +15,7 @@ import {
   RevokeEnumPrivileges,
   RevokeGrantOptionEnumPrivileges,
 } from "./changes/enum.privilege.ts";
+import { CreateSecurityLabelOnEnum } from "./changes/enum.security-label.ts";
 import { diffEnums } from "./enum.diff.ts";
 import { Enum, type EnumProps } from "./enum.model.ts";
 
@@ -317,6 +318,26 @@ describe.concurrent("enum.diff", () => {
     }
   });
 
+  test("throws on reordered existing enum labels", () => {
+    expect(() =>
+      diffEnums(
+        testContext,
+        { [testEnum(["a", "b"]).stableId]: testEnum(["a", "b"]) },
+        { [testEnum(["b", "a"]).stableId]: testEnum(["b", "a"]) },
+      ),
+    ).toThrow(/Cannot reorder existing enum labels/);
+  });
+
+  test("throws on added enum labels when existing labels are reordered", () => {
+    expect(() =>
+      diffEnums(
+        testContext,
+        { [testEnum(["a", "b"]).stableId]: testEnum(["a", "b"]) },
+        { [testEnum(["b", "a", "c"]).stableId]: testEnum(["b", "a", "c"]) },
+      ),
+    ).toThrow(/Cannot reorder existing enum labels/);
+  });
+
   test("create with comment emits CreateCommentOnEnum", () => {
     const e = new Enum({
       schema: "public",
@@ -416,6 +437,39 @@ describe.concurrent("enum.diff", () => {
     expect(changes[1]).toBeInstanceOf(CreateEnum);
     expect(changes.some((c) => c instanceof CreateCommentOnEnum)).toBe(true);
     expect(changes.some((c) => c instanceof GrantEnumPrivileges)).toBe(true);
+  });
+
+  test("alter with removed labels preserves security labels", () => {
+    const main = new Enum({
+      schema: "public",
+      name: "e1",
+      owner: "o1",
+      labels: [
+        { label: "a", sort_order: 1 },
+        { label: "b", sort_order: 2 },
+      ],
+      comment: null,
+      privileges: [],
+    });
+    const branch = new Enum({
+      schema: "public",
+      name: "e1",
+      owner: "o1",
+      labels: [{ label: "a", sort_order: 1 }],
+      comment: null,
+      privileges: [],
+      security_labels: [{ provider: "dummy", label: "secret" }],
+    });
+    const changes = diffEnums(
+      testContext,
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+    expect(changes[0]).toBeInstanceOf(DropEnum);
+    expect(changes[1]).toBeInstanceOf(CreateEnum);
+    expect(changes.some((c) => c instanceof CreateSecurityLabelOnEnum)).toBe(
+      true,
+    );
   });
 
   test("alter comment emits create and drop comment", () => {

--- a/packages/pg-delta/src/core/objects/type/enum/enum.diff.test.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/enum.diff.test.ts
@@ -261,9 +261,19 @@ describe.concurrent("enum.diff", () => {
         expected: ["ALTER TYPE public.e1 ADD VALUE 'a' AFTER ''"],
       },
       {
+        main: [""],
+        branch: ["a", ""],
+        expected: ["ALTER TYPE public.e1 ADD VALUE 'a' BEFORE ''"],
+      },
+      {
         main: ["a"],
         branch: ["", "a"],
         expected: ["ALTER TYPE public.e1 ADD VALUE '' BEFORE 'a'"],
+      },
+      {
+        main: ["a"],
+        branch: ["a", ""],
+        expected: ["ALTER TYPE public.e1 ADD VALUE '' AFTER 'a'"],
       },
       {
         main: ["c"],

--- a/packages/pg-delta/src/core/objects/type/enum/enum.diff.test.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/enum.diff.test.ts
@@ -25,6 +25,30 @@ const testContext = {
   mainRoles: {},
 };
 
+function testEnum(labels: string[]): Enum {
+  return new Enum({
+    schema: "public",
+    name: "e1",
+    owner: "o1",
+    labels: labels.map((label, index) => ({
+      label,
+      sort_order: index + 1,
+    })),
+    comment: null,
+    privileges: [],
+  });
+}
+
+function serializedAddValueChanges(main: Enum, branch: Enum): string[] {
+  return diffEnums(
+    testContext,
+    { [main.stableId]: main },
+    { [branch.stableId]: branch },
+  )
+    .filter((change) => change instanceof AlterEnumAddValue)
+    .map((change) => change.serialize());
+}
+
 describe.concurrent("enum.diff", () => {
   test("create and drop", () => {
     const props: EnumProps = {
@@ -196,6 +220,91 @@ describe.concurrent("enum.diff", () => {
     expect(add).toBeDefined();
     expect(add?.position?.after).toBe("b");
     expect(add?.position?.before).toBeUndefined();
+  });
+
+  test("orders added enum labels using only existing anchors", () => {
+    const cases = [
+      {
+        main: ["b"],
+        branch: ["a", "b"],
+        expected: ["ALTER TYPE public.e1 ADD VALUE 'a' BEFORE 'b'"],
+      },
+      {
+        main: [],
+        branch: ["a"],
+        expected: ["ALTER TYPE public.e1 ADD VALUE 'a'"],
+      },
+      {
+        main: [],
+        branch: [""],
+        expected: ["ALTER TYPE public.e1 ADD VALUE ''"],
+      },
+      {
+        main: [],
+        branch: ["a", "b"],
+        expected: [
+          "ALTER TYPE public.e1 ADD VALUE 'a'",
+          "ALTER TYPE public.e1 ADD VALUE 'b' AFTER 'a'",
+        ],
+      },
+      {
+        main: ["a"],
+        branch: ["a", "b", "c"],
+        expected: [
+          "ALTER TYPE public.e1 ADD VALUE 'b' AFTER 'a'",
+          "ALTER TYPE public.e1 ADD VALUE 'c' AFTER 'b'",
+        ],
+      },
+      {
+        main: [""],
+        branch: ["", "a"],
+        expected: ["ALTER TYPE public.e1 ADD VALUE 'a' AFTER ''"],
+      },
+      {
+        main: ["a"],
+        branch: ["", "a"],
+        expected: ["ALTER TYPE public.e1 ADD VALUE '' BEFORE 'a'"],
+      },
+      {
+        main: ["c"],
+        branch: ["a", "b", "c"],
+        expected: [
+          "ALTER TYPE public.e1 ADD VALUE 'b' BEFORE 'c'",
+          "ALTER TYPE public.e1 ADD VALUE 'a' BEFORE 'b'",
+        ],
+      },
+      {
+        main: ["d"],
+        branch: ["a", "b", "c", "d"],
+        expected: [
+          "ALTER TYPE public.e1 ADD VALUE 'c' BEFORE 'd'",
+          "ALTER TYPE public.e1 ADD VALUE 'b' BEFORE 'c'",
+          "ALTER TYPE public.e1 ADD VALUE 'a' BEFORE 'b'",
+        ],
+      },
+      {
+        main: ["a", "d"],
+        branch: ["a", "b", "c", "d"],
+        expected: [
+          "ALTER TYPE public.e1 ADD VALUE 'b' AFTER 'a'",
+          "ALTER TYPE public.e1 ADD VALUE 'c' AFTER 'b'",
+        ],
+      },
+      {
+        main: ["b"],
+        branch: ["a", "b", "c"],
+        expected: [
+          "ALTER TYPE public.e1 ADD VALUE 'a' BEFORE 'b'",
+          "ALTER TYPE public.e1 ADD VALUE 'c' AFTER 'b'",
+        ],
+      },
+    ];
+
+    for (const { main, branch, expected } of cases) {
+      expect(
+        serializedAddValueChanges(testEnum(main), testEnum(branch)),
+      ).toEqual(expected);
+    }
   });
 
   test("create with comment emits CreateCommentOnEnum", () => {

--- a/packages/pg-delta/src/core/objects/type/enum/enum.diff.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/enum.diff.ts
@@ -150,6 +150,15 @@ export function diffEnums(
         changes.push(new CreateCommentOnEnum({ enum: branchEnum }));
       }
 
+      for (const label of branchEnum.security_labels) {
+        changes.push(
+          new CreateSecurityLabelOnEnum({
+            enum: branchEnum,
+            securityLabel: label,
+          }),
+        );
+      }
+
       const effectiveDefaults = ctx.defaultPrivilegeState.getEffectiveDefaults(
         ctx.currentUser,
         "enum",
@@ -289,12 +298,18 @@ function diffEnumLabels(mainEnum: Enum, branchEnum: Enum): EnumChange[] {
   const branchOrdered = [...branchEnum.labels].sort(
     (a, b) => a.sort_order - b.sort_order,
   );
+  const branchOrderedLabels = branchOrdered.map((label) => label.label);
   const branchIndexByLabel = new Map(
     branchOrdered.map((label, index) => [label.label, index]),
   );
   const workingLabels = [...mainEnum.labels]
     .sort((a, b) => a.sort_order - b.sort_order)
     .map((label) => label.label);
+  if (!preservesExistingLabelOrder(workingLabels, branchOrderedLabels)) {
+    throw new Error(
+      `Cannot reorder existing enum labels for ${mainEnum.schema}.${mainEnum.name}`,
+    );
+  }
   const pendingValues = branchOrdered
     .map((label) => label.label)
     .filter((label) => !mainLabelMap.has(label));
@@ -358,4 +373,28 @@ function diffEnumLabels(mainEnum: Enum, branchEnum: Enum): EnumChange[] {
   // We intentionally avoid emitting drop+create to prevent data loss.
 
   return changes;
+}
+
+function preservesExistingLabelOrder(
+  mainLabels: string[],
+  branchLabels: string[],
+): boolean {
+  let branchIndex = 0;
+
+  for (const label of mainLabels) {
+    while (
+      branchIndex < branchLabels.length &&
+      branchLabels[branchIndex] !== label
+    ) {
+      branchIndex += 1;
+    }
+
+    if (branchIndex >= branchLabels.length) {
+      return false;
+    }
+
+    branchIndex += 1;
+  }
+
+  return true;
 }

--- a/packages/pg-delta/src/core/objects/type/enum/enum.diff.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/enum.diff.ts
@@ -284,54 +284,74 @@ function diffEnumLabels(mainEnum: Enum, branchEnum: Enum): EnumChange[] {
   const mainLabelMap = new Map(
     mainEnum.labels.map((label) => [label.label, label.sort_order]),
   );
-  const branchLabelMap = new Map(
-    branchEnum.labels.map((label) => [label.label, label.sort_order]),
-  );
-
-  // Find added values (values in branch but not in main)
-  const addedValues = Array.from(branchLabelMap.keys()).filter(
-    (label) => !mainLabelMap.has(label),
-  );
-
   // Maintain a working list of labels (by name) to calculate correct BEFORE/AFTER
   // anchors as we simulate applying the additions in order.
   const branchOrdered = [...branchEnum.labels].sort(
     (a, b) => a.sort_order - b.sort_order,
   );
-  const workingLabels = [...mainEnum.labels].map((l) => l.label);
+  const branchIndexByLabel = new Map(
+    branchOrdered.map((label, index) => [label.label, index]),
+  );
+  const workingLabels = [...mainEnum.labels]
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .map((label) => label.label);
+  const pendingValues = branchOrdered
+    .map((label) => label.label)
+    .filter((label) => !mainLabelMap.has(label));
 
-  for (const newValue of addedValues) {
-    const branchIdx = branchOrdered.findIndex((l) => l.label === newValue);
-    if (branchIdx === -1) continue;
+  while (pendingValues.length > 0) {
+    if (workingLabels.length === 0) {
+      const newValue = pendingValues.shift();
+      if (newValue === undefined) break;
 
-    const prevBranch = branchOrdered[branchIdx - 1]?.label;
-    const nextBranch = branchOrdered[branchIdx + 1]?.label;
-
-    let position: { before?: string; after?: string } | undefined;
-
-    // Prefer AFTER when prevBranch exists in workingLabels (more natural for sequential additions)
-    // Use BEFORE only when we need to insert before the first value or when prevBranch doesn't exist
-    if (prevBranch && workingLabels.includes(prevBranch)) {
-      position = { after: prevBranch };
-      // Insert after the previous label in our working list
-      const prevIdx = workingLabels.indexOf(prevBranch);
-      workingLabels.splice(prevIdx + 1, 0, newValue);
-    } else if (nextBranch && workingLabels.includes(nextBranch)) {
-      // Insert before nextBranch when prevBranch doesn't exist (e.g., adding at beginning)
-      position = { before: nextBranch };
-      const nextIdx = workingLabels.indexOf(nextBranch);
-      workingLabels.splice(nextIdx, 0, newValue);
-    } else if (nextBranch) {
-      // nextBranch exists but not in workingLabels yet (shouldn't happen in normal flow)
-      position = { before: nextBranch };
       workingLabels.push(newValue);
-    } else {
-      // Fallback: append to the end
-      position = { after: workingLabels[workingLabels.length - 1] };
-      workingLabels.push(newValue);
+      changes.push(new AlterEnumAddValue({ enum: mainEnum, newValue }));
+      continue;
     }
 
-    changes.push(new AlterEnumAddValue({ enum: mainEnum, newValue, position }));
+    let emittedInPass = false;
+
+    for (let i = 0; i < pendingValues.length; i += 1) {
+      const newValue = pendingValues[i];
+      const branchIdx = branchIndexByLabel.get(newValue);
+      if (branchIdx === undefined) continue;
+
+      const prevBranch = branchOrdered[branchIdx - 1]?.label;
+      const nextBranch = branchOrdered[branchIdx + 1]?.label;
+
+      let position: { before?: string; after?: string } | undefined;
+      let insertIdx: number | undefined;
+
+      // Prefer AFTER when prevBranch is already materialized. Otherwise, use
+      // BEFORE only when nextBranch is already materialized. This guarantees
+      // each emitted anchor exists at the point PostgreSQL executes the ALTER.
+      if (prevBranch !== undefined && workingLabels.includes(prevBranch)) {
+        position = { after: prevBranch };
+        insertIdx = workingLabels.indexOf(prevBranch) + 1;
+      } else if (
+        nextBranch !== undefined &&
+        workingLabels.includes(nextBranch)
+      ) {
+        position = { before: nextBranch };
+        insertIdx = workingLabels.indexOf(nextBranch);
+      } else {
+        continue;
+      }
+
+      workingLabels.splice(insertIdx, 0, newValue);
+      pendingValues.splice(i, 1);
+      changes.push(
+        new AlterEnumAddValue({ enum: mainEnum, newValue, position }),
+      );
+      emittedInPass = true;
+      i -= 1;
+    }
+
+    if (!emittedInPass) {
+      throw new Error(
+        `Could not find an existing enum label anchor for added values: ${pendingValues.join(", ")}`,
+      );
+    }
   }
 
   // Complex changes (removals, resorting) are currently not auto-handled.

--- a/packages/pg-delta/src/core/objects/type/enum/enum.model.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/enum.model.ts
@@ -121,8 +121,8 @@ export async function extractEnums(pool: Pool): Promise<Enum[]> {
   const { rows: enumRows } = await pool.query<{
     schema: string;
     name: string;
-    sort_order: number;
-    label: string;
+    sort_order: number | null;
+    label: string | null;
     owner: string;
     comment: string | null;
     privileges: { grantee: string; privilege: string; grantable: boolean }[];
@@ -171,10 +171,11 @@ select
     '[]'::json
   ) as security_labels
 from
-  pg_catalog.pg_enum e
-  inner join pg_catalog.pg_type t on t.oid = e.enumtypid
+  pg_catalog.pg_type t
+  left join pg_catalog.pg_enum e on e.enumtypid = t.oid
   left outer join extension_oids ext on t.oid = ext.objid
-  where not t.typnamespace::regnamespace::text like any(array['pg\\_%', 'information\\_schema'])
+  where t.typtype = 'e'
+  and not t.typnamespace::regnamespace::text like any(array['pg\\_%', 'information\\_schema'])
   and ext.objid is null
 order by
   1, 2, 3
@@ -208,7 +209,9 @@ order by
         security_labels: e.security_labels,
       };
     }
-    grouped[key].labels.push({ sort_order: e.sort_order, label: e.label });
+    if (e.sort_order !== null && e.label !== null) {
+      grouped[key].labels.push({ sort_order: e.sort_order, label: e.label });
+    }
   }
   // Validate and parse each enum using the Zod schema
   const validatedEnums = Object.values(grouped).map((e) =>

--- a/packages/pg-delta/tests/integration/catalog-model.test.ts
+++ b/packages/pg-delta/tests/integration/catalog-model.test.ts
@@ -190,6 +190,42 @@ for (const pgVersion of POSTGRES_VERSIONS) {
     );
 
     test(
+      "extract enum types with empty labels",
+      withDb(pgVersion, async (db) => {
+        await db.main.query(`
+        CREATE SCHEMA test_schema;
+        CREATE TYPE test_schema.status AS ENUM ('active', 'inactive', 'pending');
+        CREATE TYPE test_schema.empty_status AS ENUM ();
+        CREATE TYPE test_schema.blank_status AS ENUM ('');
+      `);
+
+        const catalog = await extractCatalog(db.main);
+
+        const enumType = Object.values(catalog.enums).find(
+          (type) => type.schema === "test_schema" && type.name === "status",
+        );
+        expect(enumType).toBeDefined();
+        expect(enumType?.labels.map((l) => l.label)).toEqual([
+          "active",
+          "inactive",
+          "pending",
+        ]);
+        const emptyEnumType = Object.values(catalog.enums).find(
+          (type) =>
+            type.schema === "test_schema" && type.name === "empty_status",
+        );
+        expect(emptyEnumType).toBeDefined();
+        expect(emptyEnumType?.labels.map((l) => l.label)).toEqual([]);
+        const blankEnumType = Object.values(catalog.enums).find(
+          (type) =>
+            type.schema === "test_schema" && type.name === "blank_status",
+        );
+        expect(blankEnumType).toBeDefined();
+        expect(blankEnumType?.labels.map((l) => l.label)).toEqual([""]);
+      }),
+    );
+
+    test(
       "extract database objects",
       withDb(pgVersion, async (db) => {
         // Create sequences, indexes, triggers, and procedures

--- a/packages/pg-delta/tests/integration/type-operations.test.ts
+++ b/packages/pg-delta/tests/integration/type-operations.test.ts
@@ -28,6 +28,24 @@ for (const pgVersion of POSTGRES_VERSIONS) {
       }),
     );
     test(
+      "create empty enum type",
+      withDb(pgVersion, async (db) => {
+        await db.branch.query("CREATE TYPE public.empty_status AS ENUM ();");
+
+        const planResult = await createPlan(db.main, db.branch);
+        expect(planResult).toBeDefined();
+        if (!planResult) {
+          throw new Error("Expected planResult to be defined");
+        }
+
+        expect(flattenPlanStatements(planResult.plan)).toMatchInlineSnapshot(`
+          [
+            "CREATE TYPE public.empty_status AS ENUM ()",
+          ]
+        `);
+      }),
+    );
+    test(
       "add enum value before setting default to the new value",
       withDb(pgVersion, async (db) => {
         const initialSetup = `

--- a/packages/pg-delta/tests/integration/type-operations.test.ts
+++ b/packages/pg-delta/tests/integration/type-operations.test.ts
@@ -121,6 +121,59 @@ for (const pgVersion of POSTGRES_VERSIONS) {
     );
 
     test(
+      "add enum values to an empty enum",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: "CREATE TYPE public.empty_enum_status AS ENUM ();",
+          testSql: dedent`
+            DROP TYPE public.empty_enum_status;
+            CREATE TYPE public.empty_enum_status AS ENUM (
+              '',
+              'ready'
+            );
+          `,
+          assertSqlStatements: (sqlStatements) => {
+            expect(sqlStatements).toMatchInlineSnapshot(`
+              [
+                "ALTER TYPE public.empty_enum_status ADD VALUE ''",
+                "ALTER TYPE public.empty_enum_status ADD VALUE 'ready' AFTER ''",
+              ]
+            `);
+          },
+        });
+      }),
+    );
+
+    test(
+      "add enum values around an empty-string label",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: "CREATE TYPE public.empty_anchor_status AS ENUM ('');",
+          testSql: dedent`
+            DROP TYPE public.empty_anchor_status;
+            CREATE TYPE public.empty_anchor_status AS ENUM (
+              'queued',
+              '',
+              'ready'
+            );
+          `,
+          assertSqlStatements: (sqlStatements) => {
+            expect(sqlStatements).toMatchInlineSnapshot(`
+              [
+                "ALTER TYPE public.empty_anchor_status ADD VALUE 'queued' BEFORE ''",
+                "ALTER TYPE public.empty_anchor_status ADD VALUE 'ready' AFTER ''",
+              ]
+            `);
+          },
+        });
+      }),
+    );
+
+    test(
       "create domain type with constraint",
       withDb(pgVersion, async (db) => {
         await roundtripFidelityTest({

--- a/packages/pg-delta/tests/integration/type-operations.test.ts
+++ b/packages/pg-delta/tests/integration/type-operations.test.ts
@@ -192,6 +192,22 @@ for (const pgVersion of POSTGRES_VERSIONS) {
     );
 
     test(
+      "reject reordered enum values",
+      withDb(pgVersion, async (db) => {
+        await db.main.query(
+          "CREATE TYPE public.reordered_status AS ENUM ('queued', 'ready');",
+        );
+        await db.branch.query(
+          "CREATE TYPE public.reordered_status AS ENUM ('ready', 'queued');",
+        );
+
+        await expect(createPlan(db.main, db.branch)).rejects.toThrow(
+          /Cannot reorder existing enum labels/,
+        );
+      }),
+    );
+
+    test(
       "create domain type with constraint",
       withDb(pgVersion, async (db) => {
         await roundtripFidelityTest({

--- a/packages/pg-delta/tests/integration/type-operations.test.ts
+++ b/packages/pg-delta/tests/integration/type-operations.test.ts
@@ -93,6 +93,34 @@ for (const pgVersion of POSTGRES_VERSIONS) {
     );
 
     test(
+      "add multiple enum values before the first existing label",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup:
+            "CREATE TYPE public.issue_304_status AS ENUM ('ready');",
+          testSql: dedent`
+            DROP TYPE public.issue_304_status;
+            CREATE TYPE public.issue_304_status AS ENUM (
+              'queued',
+              'blocked',
+              'ready'
+            );
+          `,
+          assertSqlStatements: (sqlStatements) => {
+            expect(sqlStatements).toMatchInlineSnapshot(`
+              [
+                "ALTER TYPE public.issue_304_status ADD VALUE 'blocked' BEFORE 'ready'",
+                "ALTER TYPE public.issue_304_status ADD VALUE 'queued' BEFORE 'blocked'",
+              ]
+            `);
+          },
+        });
+      }),
+    );
+
+    test(
       "create domain type with constraint",
       withDb(pgVersion, async (db) => {
         await roundtripFidelityTest({


### PR DESCRIPTION
## Summary

- Fix enum ADD VALUE planning so every BEFORE/AFTER anchor already exists when emitted.
- Preserve empty enum extraction and empty-string enum labels.
- Reject unsupported existing enum label reorders instead of silently producing no-op or incorrect append-only plans.
- Restore enum security labels when removed-label replacement recreates the type.

Closes #304

## Testing

- `bun test packages/pg-delta/src/core/objects/type/enum/enum.diff.test.ts packages/pg-delta/src/core/objects/type/enum/changes/enum.alter.test.ts packages/pg-delta/src/core/objects/type/enum/changes/enum.create.test.ts` from `/tmp` using the worktree Bun binary: 24 pass, 0 fail.

Note: the normal `cd packages/pg-delta && bun run test ...` path hung after starting these unit files, consistent with the repo note that package-local pg-delta test execution can enter the Docker/global-setup path. I interrupted that run and used the documented unit-only workaround from outside the package directory.