### PR TITLE
fix(pg-delta): guard identity/generated columns through type changes

### DIFF
--- a/.changeset/identity-column-type-change.md
+++ b/.changeset/identity-column-type-change.md
@@ -1,0 +1,11 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix unappliable plans when an identity or generated column changes type (e.g.
+widening `integer GENERATED ALWAYS AS IDENTITY` to `bigint`). The leading
+`ALTER COLUMN … DROP DEFAULT` is now skipped for such columns (PostgreSQL
+rejects it outright), the `USING` cast is dropped for generated columns (also
+rejected), and an identity column's sequence bounds are now emitted *after* the
+`TYPE` change instead of before it, where `SET MAXVALUE` was out of range for
+the not-yet-retyped sequence.

--- a/.changeset/identity-column-type-change.md
+++ b/.changeset/identity-column-type-change.md
@@ -5,7 +5,16 @@
 Fix unappliable plans when an identity or generated column changes type (e.g.
 widening `integer GENERATED ALWAYS AS IDENTITY` to `bigint`). The leading
 `ALTER COLUMN … DROP DEFAULT` is now skipped for such columns (PostgreSQL
-rejects it outright), the `USING` cast is dropped for generated columns (also
-rejected), and an identity column's sequence bounds are now emitted *after* the
-`TYPE` change instead of before it, where `SET MAXVALUE` was out of range for
-the not-yet-retyped sequence.
+rejects it outright), and the `USING` cast is dropped for generated columns
+(also rejected).
+
+The `DROP DEFAULT` gate reads the *desired* identity state, not the source one:
+identity add/drop deltas order before the type change, so a plain column that
+gains identity in the same plan is already an identity column by then and the
+`DROP DEFAULT` was rejected.
+
+An identity column's sequence bounds are also positioned relative to the `TYPE`
+change by direction. Widening emits them *after* it (the desired bounds need not
+fit the old type). Narrowing emits them *before* it, because an explicit bound
+that overflows the new type made the retype itself fail (`MAXVALUE (5000000000)
+is out of range for sequence data type integer`).

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -649,3 +649,35 @@ round's finding was locally valid, but the sum re-litigated the writer's
 contract one exotic corner at a time. When a bot's findings drift from the
 issue's scope — or start finding bugs only in the previous round's fix — stop
 patching, decide the contract explicitly, and record it here.
+
+## PR #379 review triage (Codex) — identity columns through a type change
+
+PR #379 made identity/generated columns survive a `type` change. Two Codex P1
+findings were fixed in the PR (the `DROP DEFAULT` gate now reads the *desired*
+identity side; identity bounds move *before* the `TYPE` when narrowing — both
+covered by corpus scenarios `identity-operations--add-identity-with-type-change`
+and `identity-operations--widen-identity-explicit-bounds`). Two adjacent corners
+are **deliberately deferred** — they are pre-existing ordering gaps that the PR
+merely brings within reach, not defects in what it adds. If an automated review
+re-flags one, link here instead of re-fixing.
+
+- **Adding identity to a NULLABLE plain column fails.** Identity columns are
+  implicitly `NOT NULL`, so the plan carries both an `identity` add and a
+  `notNull` set. The differ emits a fact's attributes alphabetically
+  (`identity` < `notNull`), so `ADD … AS IDENTITY` runs first and PostgreSQL
+  rejects it on a nullable column. This is the same emission-order gap as the
+  fixed `type` case, but fixing it needs the `notNull` rule to know an identity
+  add is pending (or an ordering edge between two attribute deltas on one fact)
+  — a broader change than this PR's scope. Workaround: declare the source column
+  `NOT NULL`. The new corpus scenario does exactly that, deliberately.
+
+- **Plain column → identity with inline bounds exceeding the CURRENT column
+  type fails.** `ADD … AS IDENTITY (MAXVALUE 5000000000)` on an `integer` column
+  that is *also* widening to `bigint` in the same plan is rejected at the ADD:
+  inline identity options are validated against the not-yet-retyped column, and
+  the `identity` delta orders before the `type` delta. The narrowing fix does
+  not cover this because there are no source bounds to move — the bounds arrive
+  inline with the ADD. A fix would have to split the ADD into a bare
+  `ADD … AS IDENTITY` plus a post-retype chained `SET`, i.e. teach
+  `identity.alter` about a concurrent widening; deferred until a real schema
+  needs it.

--- a/packages/pg-delta/corpus/identity-operations--add-identity-with-type-change/a.sql
+++ b/packages/pg-delta/corpus/identity-operations--add-identity-with-type-change/a.sql
@@ -1,0 +1,14 @@
+-- plain integer column that gains identity AND widens to bigint in one plan
+CREATE SCHEMA app;
+
+-- NOT NULL is deliberate on this plain side: identity columns are implicitly
+-- NOT NULL, so declaring it here makes both sides agree and keeps the
+-- pre-existing `identity`-before-`notNull` ordering gap (alphabetical emission
+-- puts ADD … AS IDENTITY before SET NOT NULL) out of this scenario. The point
+-- here is the DROP DEFAULT bookend of the `type` change: ADD IDENTITY orders
+-- before the type delta, so DROP DEFAULT must be gated on the DESIRED-side
+-- identity, not the source one.
+CREATE TABLE app.counters (
+  id integer NOT NULL,
+  label text
+);

--- a/packages/pg-delta/corpus/identity-operations--add-identity-with-type-change/b.sql
+++ b/packages/pg-delta/corpus/identity-operations--add-identity-with-type-change/b.sql
@@ -1,0 +1,8 @@
+-- same column, now a bigint identity: `identity` (add) and `type` (widen) both
+-- change on the SAME column fact
+CREATE SCHEMA app;
+
+CREATE TABLE app.counters (
+  id bigint GENERATED ALWAYS AS IDENTITY,
+  label text
+);

--- a/packages/pg-delta/corpus/identity-operations--add-identity-with-type-change/seed.sql
+++ b/packages/pg-delta/corpus/identity-operations--add-identity-with-type-change/seed.sql
@@ -1,0 +1,5 @@
+-- `id integer NOT NULL` has no default, so the proof loop's autoseed
+-- (INSERT … DEFAULT VALUES) cannot seed this table — seed it explicitly so the
+-- data-preservation proof has teeth in the FORWARD direction. The b-side
+-- identity column accepts DEFAULT VALUES, so no seed-b.sql is needed.
+INSERT INTO app.counters (id) VALUES (1);

--- a/packages/pg-delta/corpus/identity-operations--widen-identity-column/a.sql
+++ b/packages/pg-delta/corpus/identity-operations--widen-identity-column/a.sql
@@ -1,0 +1,17 @@
+-- integer identity + integer STORED generated column (narrow state)
+CREATE SCHEMA app;
+
+-- widening this column moves BOTH the column type and the implicit identity
+-- sequence's MAXVALUE, so `type` and `identity` change on the SAME column fact
+CREATE TABLE app.counters (
+  id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  label text
+);
+
+-- the generation expression renders identically for integer and bigint, so only
+-- `type` changes here: PostgreSQL rejects both DROP DEFAULT and a USING cast on
+-- a generated column
+CREATE TABLE app.measurements (
+  reading integer,
+  doubled integer GENERATED ALWAYS AS (reading * 2) STORED
+);

--- a/packages/pg-delta/corpus/identity-operations--widen-identity-column/b.sql
+++ b/packages/pg-delta/corpus/identity-operations--widen-identity-column/b.sql
@@ -1,0 +1,12 @@
+-- same shape widened to bigint (identity column and generated column)
+CREATE SCHEMA app;
+
+CREATE TABLE app.counters (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  label text
+);
+
+CREATE TABLE app.measurements (
+  reading integer,
+  doubled bigint GENERATED ALWAYS AS (reading * 2) STORED
+);

--- a/packages/pg-delta/corpus/identity-operations--widen-identity-explicit-bounds/a.sql
+++ b/packages/pg-delta/corpus/identity-operations--widen-identity-explicit-bounds/a.sql
@@ -1,0 +1,7 @@
+-- integer identity with the type's default bounds
+CREATE SCHEMA app;
+
+CREATE TABLE app.counters (
+  id integer GENERATED ALWAYS AS IDENTITY,
+  label text
+);

--- a/packages/pg-delta/corpus/identity-operations--widen-identity-explicit-bounds/b.sql
+++ b/packages/pg-delta/corpus/identity-operations--widen-identity-explicit-bounds/b.sql
@@ -1,0 +1,12 @@
+-- bigint identity carrying an EXPLICIT MAXVALUE that does not fit an integer
+-- sequence. The reverse (narrowing) direction is the interesting one: retyping
+-- the column to integer while the sequence still declares MAXVALUE
+-- 5000000000 fails ("MAXVALUE … is out of range for sequence data type
+-- integer"), so the identity bounds must be set BEFORE the type change when
+-- narrowing (and after it when widening).
+CREATE SCHEMA app;
+
+CREATE TABLE app.counters (
+  id bigint GENERATED ALWAYS AS IDENTITY (MAXVALUE 5000000000),
+  label text
+);

--- a/packages/pg-delta/src/plan/identity-options.test.ts
+++ b/packages/pg-delta/src/plan/identity-options.test.ts
@@ -132,9 +132,17 @@ describe("identity column sequence options", () => {
 
 /** A column type change is sandwiched DROP DEFAULT → TYPE … USING → SET DEFAULT,
  *  but PostgreSQL rejects DROP DEFAULT on an identity or generated column, and
- *  rejects the USING cast on a generated one. Widening an identity column also
- *  moves its implicit sequence's bounds — those must run AFTER the type change,
- *  not in the differ's alphabetical `identity` < `type` order. */
+ *  rejects the USING cast on a generated one. Identity add/drop deltas order
+ *  BEFORE the type action (the differ emits attributes on one fact
+ *  alphabetically, `identity` < `type`, and the topo tie-break is emission
+ *  index), so the DROP DEFAULT gate must read the DESIRED-side identity — that
+ *  is the column's state by the time the type action runs.
+ *
+ *  Changing an identity column's type also moves its implicit sequence's
+ *  bounds. Those ride relative to the TYPE statement by direction: AFTER when
+ *  widening (the desired values may not fit the old type yet), BEFORE when
+ *  narrowing (an out-of-range explicit bound would make the retype itself
+ *  fail). */
 describe("identity / generated columns through a type change", () => {
   const bareCol = (type: string, extra: Record<string, unknown>): Fact => ({
     id: colId,
@@ -162,6 +170,26 @@ describe("identity / generated columns through a type change", () => {
     // integer-typed before it ("MAXVALUE … is out of range")
     expect(boundsAt).toBeGreaterThan(typeAt);
     // and only once — identity.alter must not emit its own copy
+    expect(sql.filter((s) => s.includes("SET MAXVALUE"))).toHaveLength(1);
+  });
+
+  test("NARROWING an identity column emits the bounds BEFORE the TYPE", () => {
+    // bigint identity with an explicit MAXVALUE 5000000000 → integer. Retyping
+    // first fails ("MAXVALUE (5000000000) is out of range for sequence data
+    // type integer"), so the in-range desired bound must land first. Valid in
+    // this direction because the desired values fit the narrower type, which is
+    // a subset of the old (wider) type's range.
+    const sql = plan(
+      base([colFact({ maxValue: "5000000000" }, "bigint")]),
+      base([colFact({ maxValue: "2147483647" })]),
+    ).actions.map((a) => a.sql);
+    const typeAt = sql.findIndex((s) => s.includes("TYPE integer"));
+    const boundsAt = sql.findIndex((s) =>
+      s.includes("SET MAXVALUE 2147483647"),
+    );
+    expect(typeAt).toBeGreaterThanOrEqual(0);
+    expect(boundsAt).toBeGreaterThanOrEqual(0);
+    expect(boundsAt).toBeLessThan(typeAt);
     expect(sql.filter((s) => s.includes("SET MAXVALUE"))).toHaveLength(1);
   });
 
@@ -194,17 +222,55 @@ describe("identity / generated columns through a type change", () => {
     expect(typeAt).toBe(dropAt + 1);
   });
 
-  test("the DROP DEFAULT gate reads the SOURCE side, not the desired one", () => {
-    // identity is dropped AND the type changes in the same plan: DROP IDENTITY
-    // runs first, so the statement order is only valid if the gate looks at the
-    // source column (identity) — the desired one carries `identity: null`.
+  // The DROP DEFAULT gate reads the DESIRED-side identity: identity add/drop
+  // deltas order BEFORE the type action, so the desired identity state is the
+  // column's actual state when DROP DEFAULT runs. All four quadrants:
+
+  test("gate quadrant identity→identity: no DROP DEFAULT", () => {
+    const sql = plan(
+      base([colFact({ maxValue: "2147483647" })]),
+      base([colFact({ maxValue: "9223372036854775807" }, "bigint")]),
+    ).actions.map((a) => a.sql);
+    expect(sql.some((s) => s.includes("DROP DEFAULT"))).toBe(false);
+  });
+
+  test("gate quadrant plain→plain: DROP DEFAULT is emitted", () => {
+    const sql = plan(
+      base([bareCol("integer", {})]),
+      base([bareCol("bigint", {})]),
+    ).actions.map((a) => a.sql);
+    expect(sql.some((s) => s.includes("DROP DEFAULT"))).toBe(true);
+  });
+
+  test("gate quadrant plain→identity: no DROP DEFAULT (ADD IDENTITY already ran)", () => {
+    // A plain column gains identity AND changes type in one plan. `identity` <
+    // `type`, so `ADD … AS IDENTITY` executes first; a DROP DEFAULT gated on the
+    // SOURCE side would then hit an identity column and PostgreSQL rejects it
+    // ("column \"id\" of relation \"t\" is an identity column").
+    const sql = plan(
+      base([bareCol("integer", {})]),
+      base([colFact({ maxValue: "9223372036854775807" }, "bigint")]),
+    ).actions.map((a) => a.sql);
+    expect(
+      sql.some((s) => s.includes("ADD GENERATED ALWAYS AS IDENTITY")),
+    ).toBe(true);
+    expect(sql.some((s) => s.includes("DROP DEFAULT"))).toBe(false);
+  });
+
+  test("gate quadrant identity→plain: DROP DEFAULT is emitted (harmless no-op)", () => {
+    // DROP IDENTITY runs first (identity < type), so by the time the type action
+    // executes the column is plain and DROP DEFAULT is a valid no-op.
     const sql = plan(
       base([colFact({})]),
       base([bareCol("bigint", {})]),
     ).actions.map((a) => a.sql);
-    expect(sql).toContain(
+    const dropIdentityAt = sql.indexOf(
       `ALTER TABLE "app"."t" ALTER COLUMN "id" DROP IDENTITY`,
     );
-    expect(sql.some((s) => s.includes("DROP DEFAULT"))).toBe(false);
+    const dropDefaultAt = sql.indexOf(
+      `ALTER TABLE "app"."t" ALTER COLUMN "id" DROP DEFAULT`,
+    );
+    expect(dropIdentityAt).toBeGreaterThanOrEqual(0);
+    expect(dropDefaultAt).toBeGreaterThan(dropIdentityAt);
   });
 });

--- a/packages/pg-delta/src/plan/identity-options.test.ts
+++ b/packages/pg-delta/src/plan/identity-options.test.ts
@@ -30,11 +30,11 @@ const colId: StableId = {
   table: "t",
   name: "id",
 };
-const colFact = (options: Record<string, unknown>): Fact => ({
+const colFact = (options: Record<string, unknown>, type = "integer"): Fact => ({
   id: colId,
   parent: tableId,
   payload: {
-    type: "integer",
+    type,
     notNull: false,
     collation: null,
     generatedExpr: null,
@@ -127,5 +127,84 @@ describe("identity column sequence options", () => {
     expect(idAlters[0]).toContain("SET MAXVALUE 200");
     expect(idAlters[0]).toContain("SET START WITH 60");
     expect(idAlters[0]).not.toContain("RESTART");
+  });
+});
+
+/** A column type change is sandwiched DROP DEFAULT → TYPE … USING → SET DEFAULT,
+ *  but PostgreSQL rejects DROP DEFAULT on an identity or generated column, and
+ *  rejects the USING cast on a generated one. Widening an identity column also
+ *  moves its implicit sequence's bounds — those must run AFTER the type change,
+ *  not in the differ's alphabetical `identity` < `type` order. */
+describe("identity / generated columns through a type change", () => {
+  const bareCol = (type: string, extra: Record<string, unknown>): Fact => ({
+    id: colId,
+    parent: tableId,
+    payload: {
+      type,
+      notNull: false,
+      collation: null,
+      generatedExpr: null,
+      identity: null,
+      ...extra,
+    },
+  });
+
+  test("widening an identity column emits TYPE first, then the bounds, and no DROP DEFAULT", () => {
+    const sql = plan(
+      base([colFact({ maxValue: "2147483647" })]),
+      base([colFact({ maxValue: "9223372036854775807" }, "bigint")]),
+    ).actions.map((a) => a.sql);
+    expect(sql.some((s) => s.includes("DROP DEFAULT"))).toBe(false);
+    const typeAt = sql.findIndex((s) => s.includes("TYPE bigint"));
+    const boundsAt = sql.findIndex((s) => s.includes("SET MAXVALUE"));
+    expect(typeAt).toBeGreaterThanOrEqual(0);
+    // the bounds must FOLLOW the retype: the backing sequence is still
+    // integer-typed before it ("MAXVALUE … is out of range")
+    expect(boundsAt).toBeGreaterThan(typeAt);
+    // and only once — identity.alter must not emit its own copy
+    expect(sql.filter((s) => s.includes("SET MAXVALUE"))).toHaveLength(1);
+  });
+
+  test("a generated column's type change carries neither DROP DEFAULT nor a USING cast", () => {
+    const generated = (type: string) =>
+      bareCol(type, { generatedExpr: "(qty * 2)" });
+    const sql = plan(
+      base([generated("integer")]),
+      base([generated("bigint")]),
+    ).actions.map((a) => a.sql);
+    expect(sql).toContain(
+      `ALTER TABLE "app"."t" ALTER COLUMN "id" TYPE bigint`,
+    );
+    expect(sql.some((s) => s.includes("DROP DEFAULT"))).toBe(false);
+    expect(sql.some((s) => s.includes("USING"))).toBe(false);
+  });
+
+  test("a plain column's type change keeps the DROP DEFAULT → TYPE … USING sandwich", () => {
+    const sql = plan(
+      base([bareCol("integer", {})]),
+      base([bareCol("bigint", {})]),
+    ).actions.map((a) => a.sql);
+    const dropAt = sql.indexOf(
+      `ALTER TABLE "app"."t" ALTER COLUMN "id" DROP DEFAULT`,
+    );
+    const typeAt = sql.indexOf(
+      `ALTER TABLE "app"."t" ALTER COLUMN "id" TYPE bigint USING "id"::bigint`,
+    );
+    expect(dropAt).toBeGreaterThanOrEqual(0);
+    expect(typeAt).toBe(dropAt + 1);
+  });
+
+  test("the DROP DEFAULT gate reads the SOURCE side, not the desired one", () => {
+    // identity is dropped AND the type changes in the same plan: DROP IDENTITY
+    // runs first, so the statement order is only valid if the gate looks at the
+    // source column (identity) — the desired one carries `identity: null`.
+    const sql = plan(
+      base([colFact({})]),
+      base([bareCol("bigint", {})]),
+    ).actions.map((a) => a.sql);
+    expect(sql).toContain(
+      `ALTER TABLE "app"."t" ALTER COLUMN "id" DROP IDENTITY`,
+    );
+    expect(sql.some((s) => s.includes("DROP DEFAULT"))).toBe(false);
   });
 });

--- a/packages/pg-delta/src/plan/rules/helpers.ts
+++ b/packages/pg-delta/src/plan/rules/helpers.ts
@@ -184,6 +184,26 @@ const IDENTITY_TYPE_MAX: Record<string, string> = {
   bigint: "9223372036854775807",
 };
 
+/** true when an identity column's type change NARROWS its value range (the new
+ *  type's max is strictly below the old one's). Used to position the identity
+ *  bounds relative to the `ALTER COLUMN … TYPE`: narrowing must set the bounds
+ *  FIRST (an explicit bound that overflows the new type makes the retype itself
+ *  fail — "MAXVALUE … is out of range for sequence data type integer"), while
+ *  widening must set them AFTER (the desired values need not fit the old type).
+ *  Returns false when either type is unmapped, keeping the widening/after
+ *  behavior as the conservative default. Maxima reach
+ *  9223372036854775807, past Number's safe-integer range, so compare with
+ *  BigInt. */
+export function isNarrowingIdentityTypeChange(
+  fromType: string,
+  toType: string,
+): boolean {
+  const fromMax = IDENTITY_TYPE_MAX[fromType];
+  const toMax = IDENTITY_TYPE_MAX[toType];
+  if (fromMax === undefined || toMax === undefined) return false;
+  return BigInt(toMax) < BigInt(fromMax);
+}
+
 /** true when the identity sequence carries exactly the parameters PostgreSQL
  *  picks for a bare `GENERATED … AS IDENTITY` of the given column type, so the
  *  clause can stay bare (no churn for ordinary identity columns). */

--- a/packages/pg-delta/src/plan/rules/tables.ts
+++ b/packages/pg-delta/src/plan/rules/tables.ts
@@ -238,10 +238,19 @@ export const tableRules: Record<string, KindRules> = {
     attributes: {
       type: {
         // delta-set shape: defaults can't be cast through a type change, so
-        // the change is sandwiched DROP DEFAULT → TYPE … USING → SET DEFAULT
+        // the change is sandwiched DROP DEFAULT → TYPE … USING → SET DEFAULT.
+        // Identity and generated columns take neither bookend (they can't hold a
+        // default and PostgreSQL rejects the statements outright) — see below.
         alter: (fact, _from, to, view, sourceView) => {
           const { schema, table, column } = columnRef(fact);
           const target = `ALTER TABLE ${rel(schema, table)} ALTER COLUMN ${qid(column)}`;
+          // `fact` is the DESIRED-side column; the statements below run BEFORE
+          // the type change, so anything conditional on the column's shape must
+          // read the SOURCE side (identity may be added/dropped in the same
+          // plan, by a delta the graph orders independently).
+          const sourceColumn = sourceView.get(fact.id) ?? fact;
+          const sourceIdentity = sourceColumn.payload["identity"] ?? null;
+          const sourceGenerated = sourceColumn.payload["generatedExpr"] != null;
           // Foreign tables have no local storage, so PostgreSQL rejects the
           // USING cast clause ("<rel> is not a table", 42809) — it would force a
           // rewrite. The plain TYPE change is metadata-only and carries no
@@ -255,18 +264,49 @@ export const tableRules: Record<string, KindRules> = {
           // dropped in extract), so a plain widening leaves both sets empty.
           const consumes = dependencyConsumes(view, fact.id);
           const releases = dependencyConsumes(sourceView, fact.id);
-          const typeSpec: ActionSpec = isForeign
-            ? { sql: `${target} TYPE ${str(to)}` }
-            : {
-                sql: `${target} TYPE ${str(to)} USING ${qid(column)}::${str(to)}`,
-                rewriteRisk: true,
-              };
+          // A generated column also rejects the USING clause ("cannot specify
+          // USING when altering type of generated column") — PostgreSQL
+          // recomputes the value from the generation expression. That still
+          // rewrites the table, so rewriteRisk stays (unlike the foreign case).
+          const usingCast =
+            isForeign || sourceGenerated
+              ? ""
+              : ` USING ${qid(column)}::${str(to)}`;
+          const typeSpec: ActionSpec = {
+            sql: `${target} TYPE ${str(to)}${usingCast}`,
+            ...(isForeign ? {} : { rewriteRisk: true }),
+          };
           if (consumes.length > 0) typeSpec.consumes = consumes;
           if (releases.length > 0) typeSpec.releases = releases;
-          const specs: ActionSpec[] = [
-            { sql: `${target} DROP DEFAULT` },
-            typeSpec,
-          ];
+          const specs: ActionSpec[] = [];
+          // DROP DEFAULT is a harmless no-op on a plain column that has none,
+          // but PostgreSQL REJECTS it on an identity column ("… is an identity
+          // column") or a generated column ("… is a generated column") whether
+          // or not a default exists — and neither kind can carry one anyway.
+          if (sourceIdentity == null && !sourceGenerated) {
+            specs.push({ sql: `${target} DROP DEFAULT` });
+          }
+          specs.push(typeSpec);
+          // An identity column's implicit sequence is typed after the column, so
+          // widening moves the column type AND the identity bounds. Both deltas
+          // land on the SAME fact with no edge between them and the differ emits
+          // attributes alphabetically (`identity` < `type`), so `SET MAXVALUE`
+          // would run while the sequence still has the old type ("MAXVALUE … is
+          // out of range for sequence data type integer"). Fold the bounds in
+          // AFTER the type change instead — `identity.alter` skips them when a
+          // `type` delta is present. Correct in both directions: PostgreSQL
+          // re-derives an at-type-max bound from the new type, and the explicit
+          // SET then converges the exact desired values.
+          const desiredIdentity = fact.payload["identity"] ?? null;
+          if (sourceIdentity != null && desiredIdentity != null) {
+            specs.push(
+              ...identityOptionAlterSpecs(
+                target,
+                identityOptions(sourceIdentity),
+                identityOptions(desiredIdentity),
+              ),
+            );
+          }
           const desiredDefault = view
             .childrenOf(fact.id)
             .find((c) => c.id.kind === "default");
@@ -298,7 +338,7 @@ export const tableRules: Record<string, KindRules> = {
         },
       },
       identity: {
-        alter: (fact, from, to) => {
+        alter: (fact, from, to, _view, sourceView) => {
           const { schema, table, column } = columnRef(fact);
           const target = `ALTER TABLE ${rel(schema, table)} ALTER COLUMN ${qid(column)}`;
           const fromSeq = identitySequenceId(from);
@@ -343,14 +383,23 @@ export const tableRules: Record<string, KindRules> = {
             });
           }
           // a parameter-only change (START/INCREMENT/CACHE/MIN/MAX/CYCLE) is an
-          // in-place ALTER COLUMN SET — no sequence rebuild
-          specs.push(
-            ...identityOptionAlterSpecs(
-              target,
-              identityOptions(from),
-              identityOptions(to),
-            ),
-          );
+          // in-place ALTER COLUMN SET — no sequence rebuild.
+          // A concurrent `type` delta on the same column owns these bounds: they
+          // must run AFTER the type change (the backing sequence is retyped with
+          // the column), and `type.alter` folds them in there. Emitting them here
+          // too would run them first — while the sequence still has the old type.
+          const sourceType = sourceView.get(fact.id)?.payload["type"];
+          const retyped =
+            sourceType !== undefined && sourceType !== p(fact, "type");
+          if (!retyped) {
+            specs.push(
+              ...identityOptionAlterSpecs(
+                target,
+                identityOptions(from),
+                identityOptions(to),
+              ),
+            );
+          }
           return specs;
         },
       },

--- a/packages/pg-delta/src/plan/rules/tables.ts
+++ b/packages/pg-delta/src/plan/rules/tables.ts
@@ -12,6 +12,7 @@ import {
   identityOptionsClause,
   identitySequenceId,
   identitySequenceNameClause,
+  isNarrowingIdentityTypeChange,
   p,
   reloptionsAlterSpecs,
   renameRule,
@@ -241,15 +242,21 @@ export const tableRules: Record<string, KindRules> = {
         // the change is sandwiched DROP DEFAULT → TYPE … USING → SET DEFAULT.
         // Identity and generated columns take neither bookend (they can't hold a
         // default and PostgreSQL rejects the statements outright) — see below.
-        alter: (fact, _from, to, view, sourceView) => {
+        alter: (fact, from, to, view, sourceView) => {
           const { schema, table, column } = columnRef(fact);
           const target = `ALTER TABLE ${rel(schema, table)} ALTER COLUMN ${qid(column)}`;
-          // `fact` is the DESIRED-side column; the statements below run BEFORE
-          // the type change, so anything conditional on the column's shape must
-          // read the SOURCE side (identity may be added/dropped in the same
-          // plan, by a delta the graph orders independently).
+          // `fact` is the DESIRED-side column. Identity add/drop deltas land on
+          // this same fact and the differ emits a fact's attributes
+          // ALPHABETICALLY (`identity` < `type`), which the topo tie-break
+          // preserves — so by the time these statements run the column's
+          // identity state is already the DESIRED one. Gate identity-sensitive
+          // statements on `desiredIdentity`, not the source.
           const sourceColumn = sourceView.get(fact.id) ?? fact;
           const sourceIdentity = sourceColumn.payload["identity"] ?? null;
+          const desiredIdentity = fact.payload["identity"] ?? null;
+          // `generated` stays SOURCE-side: a generatedExpr change routes through
+          // a column replace, so whenever `type.alter` runs at all the source
+          // and desired generated-ness are necessarily the same.
           const sourceGenerated = sourceColumn.payload["generatedExpr"] != null;
           // Foreign tables have no local storage, so PostgreSQL rejects the
           // USING cast clause ("<rel> is not a table", 42809) — it would force a
@@ -283,30 +290,42 @@ export const tableRules: Record<string, KindRules> = {
           // but PostgreSQL REJECTS it on an identity column ("… is an identity
           // column") or a generated column ("… is a generated column") whether
           // or not a default exists — and neither kind can carry one anyway.
-          if (sourceIdentity == null && !sourceGenerated) {
+          // The identity side reads DESIRED (see above): a plain column that
+          // gains identity in this same plan is ALREADY an identity column here,
+          // and an identity column that loses it is already plain (so the no-op
+          // is emitted, harmlessly, after DROP IDENTITY).
+          if (desiredIdentity == null && !sourceGenerated) {
             specs.push({ sql: `${target} DROP DEFAULT` });
           }
-          specs.push(typeSpec);
           // An identity column's implicit sequence is typed after the column, so
-          // widening moves the column type AND the identity bounds. Both deltas
-          // land on the SAME fact with no edge between them and the differ emits
-          // attributes alphabetically (`identity` < `type`), so `SET MAXVALUE`
-          // would run while the sequence still has the old type ("MAXVALUE … is
-          // out of range for sequence data type integer"). Fold the bounds in
-          // AFTER the type change instead — `identity.alter` skips them when a
-          // `type` delta is present. Correct in both directions: PostgreSQL
-          // re-derives an at-type-max bound from the new type, and the explicit
-          // SET then converges the exact desired values.
-          const desiredIdentity = fact.payload["identity"] ?? null;
-          if (sourceIdentity != null && desiredIdentity != null) {
-            specs.push(
-              ...identityOptionAlterSpecs(
-                target,
-                identityOptions(sourceIdentity),
-                identityOptions(desiredIdentity),
-              ),
-            );
-          }
+          // retyping moves the column type AND the identity bounds. Both deltas
+          // land on the SAME fact with no edge between them, so `identity.alter`
+          // skips the bounds when a `type` delta is present and `type.alter`
+          // positions that ONE chained-SET statement (never split — see
+          // identityOptionAlterSpecs) relative to the TYPE by direction:
+          //   - WIDENING (or an unrecognised type pair): AFTER. The desired
+          //     bounds may exceed the old type's range, so setting them first
+          //     fails; PostgreSQL re-derives an at-type-max bound from the new
+          //     type and the explicit SET then converges the exact values.
+          //   - NARROWING: BEFORE. An explicit bound that overflows the new type
+          //     makes the retype itself fail ("MAXVALUE (5000000000) is out of
+          //     range for sequence data type integer"). Setting the bounds first
+          //     is always valid here because the desired values fit the desired
+          //     (narrower) type, which is a subset of the old type's range.
+          // Any RESTART rides along with the statement wherever it lands — the
+          // restart target is the desired START, inside the desired range.
+          const boundSpecs =
+            sourceIdentity != null && desiredIdentity != null
+              ? identityOptionAlterSpecs(
+                  target,
+                  identityOptions(sourceIdentity),
+                  identityOptions(desiredIdentity),
+                )
+              : [];
+          const narrowing = isNarrowingIdentityTypeChange(str(from), str(to));
+          if (narrowing) specs.push(...boundSpecs);
+          specs.push(typeSpec);
+          if (!narrowing) specs.push(...boundSpecs);
           const desiredDefault = view
             .childrenOf(fact.id)
             .find((c) => c.id.kind === "default");


### PR DESCRIPTION
Fixes the two cutover blockers (P1a, P1b) from the old-engine differential review, plus a third defect the RED scenario surfaced, plus two more defects found by the Codex review round (both confirmed empirically and fixed with the same RED → GREEN discipline). Repro for the first three: widening an `integer GENERATED ALWAYS AS IDENTITY` (or `GENERATED ALWAYS AS (…) STORED`) column to `bigint` produced a plan that could not apply, in either direction.

## The five defects (all in the `column.type` alter rule)

1. **Unconditional `DROP DEFAULT` (P1a).** The `DROP DEFAULT → TYPE … USING → SET DEFAULT` sandwich assumed the leading statement is a no-op on default-less columns, but PostgreSQL rejects it outright on identity ("… is an identity column") and generated ("… is a generated column") columns. Now gated on the column being neither — see defect 4 for which side of the diff the gate reads.
2. **Identity bounds ordered before the type widening (P1b).** `type` and `identity` are attributes of the same column fact; the differ emits attribute deltas alphabetically (`identity` < `type`), no graph edge connects two consumers of the same fact, and the topo tie-break falls back to emission index — so `SET MAXVALUE 9223372036854775807` ran while the backing sequence was still `integer`-typed. Fixed by folding `identityOptionAlterSpecs(…)` into `type.alter` when both deltas fire on one fact (`identity.alter` skips them in that case) — see defect 5 for where the folded statement lands relative to the `TYPE`.
3. **`USING` cast on generated columns (found during RED).** PostgreSQL also rejects `ALTER COLUMN … TYPE … USING` on a generated column, and these do **not** route through replace: the generation expression renders identically for `integer` and `bigint`, so there is no `generatedExpr` delta — only `type`. The `USING` clause is now omitted for source-generated columns; `rewriteRisk` is retained (unlike the foreign-table case, the recompute still rewrites the table).

### Review round 1 (Codex) — both findings confirmed on postgres:17-alpine and fixed

4. **The `DROP DEFAULT` gate read the wrong diff side.** The first cut gated on the *source* column, reasoning the bookend runs before the type change. But identity add/drop deltas land on the same fact and order **before** the type action (alphabetical emission + emission-index tie-break), so a plain column gaining identity while retyping hit `DROP DEFAULT` on an already-identity column. The gate now reads the **desired** identity state — the column's actual state by the time the statement runs. (`generatedExpr` stays source-side: generated-ness changes route through a column replace, so source == desired whenever `type.alter` runs.) Unit tests pin all four source/desired quadrants; corpus scenario `identity-operations--add-identity-with-type-change` covers the transition end-to-end, seeded.
5. **Identity bounds after the `TYPE` breaks narrowing.** Bounds-after is required when widening (the desired bounds may not fit the old type yet) but fails when narrowing with an explicit out-of-range bound: retyping `bigint … (MAXVALUE 5000000000)` to `integer` fails with `MAXVALUE (5000000000) is out of range for sequence data type integer`. The single chained-SET options statement (never split — chained SETs validate final state by design) is now positioned by direction via `isNarrowingIdentityTypeChange` (`IDENTITY_TYPE_MAX` + BigInt compare; unmapped types keep the widening/after default): **before** the `TYPE` when narrowing — always valid, since desired values fit the desired narrower type, a subset of the old range — and after it otherwise. Corpus scenario `identity-operations--widen-identity-explicit-bounds` covers it; the reverse direction is exactly the narrowing failure.

## RED → GREEN

RED round 1 (commit a80ba0f, corpus scenario `identity-operations--widen-identity-column`): `0 pass / 2 fail`

```
forward:  apply failed at action 0: MAXVALUE (9223372036854775807) is out of range for sequence data type integer
reverse:  apply failed at action 1: column "id" of relation "counters" is an identity column
```

RED round 2 (commit 617abef, the two new corpus scenarios, against the round-1 GREEN code):

```
add-identity-with-type-change forward:   apply failed at action 1: column "id" of relation "counters" is an identity column
                                         (plan: 0 ADD … AS IDENTITY · 1 DROP DEFAULT · 2 TYPE bigint USING)
widen-identity-explicit-bounds reverse:  apply failed at action 0: MAXVALUE (5000000000) is out of range for sequence data type integer
                                         (plan: 0 TYPE integer USING · 1 SET MAXVALUE 2147483647)
```

Plus RED unit cases in `src/plan/identity-options.test.ts` each round (round 2 rewrites the round-1 "gate reads the source side" test, which pinned the behavior defect 4 reverses).

GREEN (after 9659e3d): focused scenarios pass in both directions · full unit suite **966 pass / 0 fail** · **full corpus on postgres:17-alpine 646 pass / 0 fail** · format-and-lint + check-types clean (knip's repo-level pg-topo unused-files finding is pre-existing, reproduced on the clean base tree).

## Out of scope, recorded

- A desired identity bound pinned exactly at the source type's max (e.g. `bigint … (MAXVALUE 2147483647)` diffed against an `integer` identity) produces **no** `identity` delta, yet PostgreSQL re-derives the bound on retype — an invisible-drift gap needing a synthesized delta at extract/diff time. Recorded in the correctness ledger (`docs/roadmap/pg-delta-next-follow-ups.md`, "Old-engine differential review" section, landing in #381).
- Two adjacent pre-existing ordering gaps surfaced by the review round are recorded under **"PR #379 review triage"** in `docs/roadmap/pg-delta-next-follow-ups.md` (in this PR): adding identity to a **nullable** plain column (`identity` < `notNull` emission order puts `ADD … AS IDENTITY` before `SET NOT NULL`), and a plain→identity add whose **inline** bounds exceed the not-yet-retyped column type. Both predate this PR's changes; the ledger entries explain why they're deferred and what a fix needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

