### PR TITLE
fix(pg-delta): surface pg_parameter_acl as an unmodeled kind

### DIFF
--- a/.changeset/parameter-acl-unmodeled-probe.md
+++ b/.changeset/parameter-acl-unmodeled-probe.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+`extract()` now detects `pg_parameter_acl` (PG 15+, backs `GRANT SET ON PARAMETER` / `GRANT ALTER SYSTEM ON PARAMETER`) and surfaces it as an `unmodeled_kind` diagnostic instead of silently missing it. The probe is version-gated and stays a clean no-op on PG 14.

--- a/packages/pg-delta/COVERAGE.md
+++ b/packages/pg-delta/COVERAGE.md
@@ -29,7 +29,7 @@ Most families are fully modeled end-to-end. The cases worth calling out — so
 | Foreign tables | yes (columns, options, local CHECK) | yes | inherit/partition-of foreign tables out of scope |
 | Security labels | yes (`SECURITY LABEL`) | yes | needs a provider; CI uses the `dummy_seclabel` image. See the dedicated scope note below for which targets are supported / diagnosed / out of scope |
 | Extension members | observed via `memberOfExtension` edges | projected out by default | sub-entity member families use the extract-time anti-join (tier-4-deferrals.md) |
-| Not modeled | — | — | casts, operators (class/family), text-search, statistics, transforms, user languages: **detected + reported** as `unmodeled_kind`, never silently dropped |
+| Not modeled | — | — | casts, operators (class/family), text-search, statistics, transforms, user languages, parameter ACLs: **detected + reported** as `unmodeled_kind`, never silently dropped |
 
 Ownership is modeled as an `owner` EDGE (object --owner--> role), not a payload
 field: it diffs as an edge link/unlink that the planner renders as `ALTER …
@@ -119,6 +119,10 @@ are excluded — only genuine user state is reported. So the exclusions below ar
   first-class facts, casts, transforms, statistics objects** — out of v1 scope;
   none are modeled, all are detected. Extension-provided variants are filtered
   at extract time (see below).
+- **Parameter ACLs** (`pg_parameter_acl`, PG 15+ — backs `GRANT SET ON
+  PARAMETER` / `GRANT ALTER SYSTEM ON PARAMETER`) — out of v1 scope; not
+  modeled, detected. The probe is version-gated (`minVersion: 15` in
+  `unmodeled.ts`'s `PROBES`) since the catalog does not exist on PG 14.
 - **Large objects** — out of v1 scope; not modeled and (as data state rather
   than schema DDL) not part of the unmodeled-kind schema check.
 - **Sequence `last_value`** — runtime state, not desired schema state

--- a/packages/pg-delta/src/extract/unmodeled.ts
+++ b/packages/pg-delta/src/extract/unmodeled.ts
@@ -31,6 +31,11 @@ import type { Diagnostic } from "../core/diagnostic.ts";
  * - `name`   : SQL expression producing a human-readable name per object
  * - `from`   : FROM/JOIN clause exposing `oid` and `name`
  * - `where`  : optional extra predicate (e.g. procedural-languages-only)
+ * - `minVersion`: optional PG major version the probe's catalog first exists
+ *   in (e.g. 15 for `pg_parameter_acl`). Probes below this version are
+ *   dropped from the union query entirely — referencing a nonexistent
+ *   catalog in `FROM` fails at parse time regardless of any `WHERE` guard,
+ *   so gating must happen before the SQL is built, not inside it.
  */
 interface UnmodeledProbe {
   kind: string;
@@ -39,6 +44,7 @@ interface UnmodeledProbe {
   name: string;
   from: string;
   where?: string;
+  minVersion?: number;
 }
 
 /**
@@ -140,6 +146,14 @@ const PROBES: readonly UnmodeledProbe[] = [
     name: "format_type(tr.trftype, NULL) || ' / ' || (SELECT ll.lanname FROM pg_language ll WHERE ll.oid = tr.trflang)",
     from: "pg_transform tr",
   },
+  {
+    kind: "parameter ACL",
+    classid: "pg_parameter_acl",
+    oid: "pa.oid",
+    name: "pa.parname",
+    from: "pg_parameter_acl pa",
+    minVersion: 15,
+  },
 ];
 
 function probeSql(p: UnmodeledProbe): string {
@@ -173,7 +187,14 @@ interface ProbeRow {
 export async function detectUnmodeledKinds(
   client: PoolClient,
 ): Promise<Diagnostic[]> {
-  const sql = PROBES.map(probeSql).join("\nUNION ALL\n");
+  const { rows: verRows } = await client.query<{ major: number }>(
+    `SELECT (current_setting('server_version_num')::int / 10000) AS major`,
+  );
+  const major = verRows[0]?.major ?? 0;
+  const activeProbes = PROBES.filter(
+    (p) => p.minVersion === undefined || major >= p.minVersion,
+  );
+  const sql = activeProbes.map(probeSql).join("\nUNION ALL\n");
   const { rows } = await client.query<ProbeRow>(sql);
   const diagnostics: Diagnostic[] = [];
   for (const row of rows) {

--- a/packages/pg-delta/tests/unmodeled-parameter-acl.test.ts
+++ b/packages/pg-delta/tests/unmodeled-parameter-acl.test.ts
@@ -29,9 +29,7 @@ describe.skipIf(PG_MAJOR < 15)(
       try {
         await db.pool.query(`CREATE ROLE ${roleName}`);
         try {
-          await db.pool.query(
-            `GRANT SET ON PARAMETER work_mem TO ${roleName}`,
-          );
+          await db.pool.query(`GRANT SET ON PARAMETER work_mem TO ${roleName}`);
 
           const result: ExtractResult = await extract(db.pool);
           const d = result.diagnostics.find(

--- a/packages/pg-delta/tests/unmodeled-parameter-acl.test.ts
+++ b/packages/pg-delta/tests/unmodeled-parameter-acl.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `pg_parameter_acl` (PostgreSQL 15+) backs `GRANT SET ON PARAMETER` /
+ * `GRANT ALTER SYSTEM ON PARAMETER`. It is not modeled as a fact by the v1
+ * engine (see COVERAGE.md), so — per the completeness floor in
+ * `src/extract/unmodeled.ts` — a user-created parameter ACL MUST surface as an
+ * `unmodeled_kind` diagnostic, never be silently dropped.
+ *
+ * `pg_parameter_acl` is a SHARED (cluster-wide) catalog, and the test cluster
+ * is a shared singleton across test files — this test revokes the grant and
+ * drops its role in a `finally` so the ACL never leaks into another test's
+ * extraction.
+ */
+import { describe, expect, test } from "bun:test";
+import { extract, type ExtractResult } from "../src/extract/extract.ts";
+import { createTestDb } from "./containers.ts";
+
+const PG_MAJOR = Number(
+  /postgres:(\d+)/.exec(
+    process.env["PGDELTA_TEST_IMAGE"] ?? "postgres:17-alpine",
+  )?.[1] ?? "17",
+);
+
+describe.skipIf(PG_MAJOR < 15)(
+  "extract: unmodeled pg_parameter_acl detection",
+  () => {
+    test("a user parameter ACL grant is reported, not silently dropped", async () => {
+      const db = await createTestDb("param_acl");
+      const roleName = `param_acl_role_${db.name}`;
+      try {
+        await db.pool.query(`CREATE ROLE ${roleName}`);
+        try {
+          await db.pool.query(
+            `GRANT SET ON PARAMETER work_mem TO ${roleName}`,
+          );
+
+          const result: ExtractResult = await extract(db.pool);
+          const d = result.diagnostics.find(
+            (diag) =>
+              diag.code === "unmodeled_kind" &&
+              diag.context?.["kind"] === "parameter ACL",
+          );
+
+          expect(d).toBeDefined();
+          expect(d?.severity).toBe("warning");
+          expect(
+            ((d?.context?.["samples"] ?? []) as string[]).join(" "),
+          ).toContain("work_mem");
+        } finally {
+          await db.pool.query(
+            `REVOKE SET ON PARAMETER work_mem FROM ${roleName}`,
+          );
+          await db.pool.query(`DROP ROLE ${roleName}`);
+        }
+      } finally {
+        await db.drop();
+      }
+    }, 120_000);
+  },
+);


### PR DESCRIPTION
`pg_parameter_acl` (PostgreSQL 15+, backing `GRANT SET / ALTER SYSTEM ON PARAMETER`) was neither modeled as a fact nor covered by `unmodeled.ts`'s `PROBES` list, so a database using parameter ACLs was **silently invisible** to `extract()` — no fact, no diagnostic. That violates the completeness module's own contract: every present-but-unmodeled catalog kind must at least surface an `unmodeled_kind` warning (P2b from the old-engine differential review, triaged in `docs/roadmap/pg-delta-next-follow-ups.md` ("Old-engine differential review" section, landing in #381)).

## Fix

- New `PROBES` entry (`kind: "parameter ACL"`, `pg_parameter_acl` / `parname`), following the existing declarative probe shape. Modeling the grant as a real fact stays deliberately out of scope (add-when-needed doctrine).
- New optional `minVersion` field on probes: a `FROM` reference to a nonexistent catalog fails at parse time regardless of `WHERE` guards, so `detectUnmodeledKinds` now filters probes by server major (via `server_version_num`) before building the UNION ALL. The probe is a clean no-op on PG 14.
- `COVERAGE.md` documents the detected-but-unmodeled exclusion (PG 15+ gating noted).

## RED → GREEN

RED (commit 94216946, postgres:17-alpine):

```
error: expect(received).toBeDefined()
Received: undefined
(fail) extract: unmodeled pg_parameter_acl detection > a user parameter ACL grant is reported, not silently dropped
```

GREEN: focused test 1 pass on PG 17 · same file on PG 14 → clean self-skip (`0 pass, 1 skip`) with `unmodeled-kinds.test.ts` passing 5/5 on PG 14 (probe correctly excluded, extraction unaffected) · full unit suite 958 pass / 0 fail · **full corpus on postgres:17-alpine 640 pass / 0 fail** · format-and-lint + check-types clean · knip matches the pre-existing baseline only.

Test hygiene: `pg_parameter_acl` is a shared (cluster-wide) catalog and the test cluster is a shared singleton, so the test revokes the grant and drops its uniquely-named role in `finally`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

