### PR TITLE
feat(pg-delta): add partitionOf policy predicate for partition-churn exclusion

### DIFF
--- a/.changeset/spicy-panthers-repeat.md
+++ b/.changeset/spicy-panthers-repeat.md
@@ -1,0 +1,11 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Add a `partitionOf` predicate to the Policy DSL: matches declarative partition
+children (`pg_class.relispartition`), optionally pinned to a parent table by
+schema/name glob. `{ partitionOf: {} }` is the drop-in replacement for the old
+filter DSL's `table/is_partition: true`; the pinned form
+(`{ partitionOf: { schema: "realtime", name: "messages" } }`) is preferred —
+it states whose partitions are operational churn instead of hiding every
+partition, and the projection audit classifies it as a named-object selector.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -730,3 +730,47 @@ re-flags one, link here instead of re-fixing.
   `ADD … AS IDENTITY` plus a post-retype chained `SET`, i.e. teach
   `identity.alter` about a concurrent widening; deferred until a real schema
   needs it.
+
+## PR #383 review triage (Codex) — `partitionOf` policy predicate
+
+Codex reviewed #383 while the PR was still mis-based against `main`, so the
+diff it saw was the entire delta-next rewrite, not the PR's six files. All
+four findings target pre-existing engine code the PR never touches — none is
+a defect in what the PR adds — so per the automated-review scope rule they
+are recorded here instead of fixed there. If a re-review re-flags one, link
+to this section.
+
+- **P1 — `CONCURRENTLY` splice in `src/plan/rules/indexes.ts` "violates the
+  no-regex-transform rule".** Pre-existing behavior of the opt-in
+  `concurrentIndexes` serialize param. The splice is an anchored prefix
+  rewrite inserting an execution modifier that `pg_get_indexdef` can never
+  emit (CONCURRENTLY is an execution choice, not catalog state) — it never
+  changes what the index *is*, only how it is built, and partitioned parents
+  are already exempted. Arguably still a doctrinal wart: a cleaner shape
+  would render the statement from structured state. Revisit only if the
+  splice ever misfires on a real `def`; not a #383 concern.
+
+- **P2 — `pg_publication_rel` dependencies resolve to the parent publication,
+  not the `publicationRel` member (`src/extract/dependencies.ts`, `pubrel`
+  CTE).** Plausible: a PG15+ member column list / row filter depending on a
+  function or type that is replaced would not rebuild the member, and a
+  planned function drop could fail at apply. Pre-existing extraction
+  behavior; needs a repro (corpus scenario with a row-filtered publication
+  member whose function is replaced) before a fix. Same family as the
+  member-grain work in #370.
+
+- **P1 — `databaseScratch` emptiness guard counts only `pg_class` rows
+  (`src/frontends/load-sql-files.ts`).** Plausible: a scratch shadow
+  pre-populated with only non-relation objects (enum, function, empty user
+  schema, …) passes the guard and contaminates the loaded desired state. The
+  guard should sweep every managed catalog outside the allowed seeded
+  schemas. Pre-existing frontend hardening; needs its own RED test.
+
+- **P2 — composite retype guard rejects a plan that adds the FIRST column of
+  the retyped composite (`src/plan/rules/types.ts`).** Plausible
+  over-rejection: the guard reads desired-side columns, but PostgreSQL only
+  forbids `ALTER TYPE … ALTER ATTRIBUTE` while a column already exists —
+  distinguishing source-side users from newly-added columns (and ordering
+  those creates after the retype) would admit a valid migration. Pre-existing
+  planner conservatism: it fails loud, never corrupts. Fix when a real schema
+  hits it.

--- a/packages/pg-delta/MIGRATION.md
+++ b/packages/pg-delta/MIGRATION.md
@@ -77,6 +77,7 @@ paths, no function escape hatches.
 | `{ "*/schema": ["auth", …] }` | `{ match: { schema: ["auth", …] }, action: "exclude" }` |
 | `{ "schema/name": [...] }` | `{ match: { all: [{ kind: "schema" }, { name: [...] }] }, action: "exclude" }` |
 | `{ "*/owner": [...] }` | `{ match: { owner: [...] }, action: "exclude" }` |
+| `{ "table/is_partition": true }` | `{ match: { partitionOf: {} }, action: "exclude" }` — prefer pinning the parent: `{ partitionOf: { schema: "realtime", name: "messages" } }` |
 | `{ objectType: "extension", operation: "create" }` | `{ match: { all: [{ kind: "extension" }, { verb: "add" }] }, action: "include" }` |
 | `or` / `and` / `not` | `any` / `all` / `not` |
 | allow-list evaluation | ordered rules, first-match-wins, no-match = include |

--- a/packages/pg-delta/src/extract/relations.ts
+++ b/packages/pg-delta/src/extract/relations.ts
@@ -77,6 +77,11 @@ export async function extractTables(ctx: ExtractContext): Promise<void> {
             row["partition_key"] == null
               ? null
               : (row["partition_key"] as string),
+          // partitionBound + parentTable are policy-API surface, not just hash
+          // substance: the `partitionOf` predicate (src/policy/policy.ts)
+          // matches on these exact payload field names. Renaming either
+          // silently un-matches every partitionOf rule — no validatePolicy
+          // error fires.
           partitionBound:
             row["partition_bound"] == null
               ? null

--- a/packages/pg-delta/src/policy/policy.test.ts
+++ b/packages/pg-delta/src/policy/policy.test.ts
@@ -1273,3 +1273,173 @@ describe("factMatches — edgeTo predicate", () => {
     );
   });
 });
+
+describe("factMatches — partitionOf predicate", () => {
+  // The Realtime shape: a partitioned parent (partitionKey, no bound), a
+  // declarative partition child (partitionBound + parentTable), a legacy
+  // INHERITS child (parentTable but NO bound), and a plain table.
+  const schemaRealtime: StableId = { kind: "schema", name: "realtime" };
+  const parentId: StableId = {
+    kind: "table",
+    schema: "realtime",
+    name: "messages",
+  };
+  const childId: StableId = {
+    kind: "table",
+    schema: "realtime",
+    name: "messages_2026_08_05",
+  };
+  const inheritsChildId: StableId = {
+    kind: "table",
+    schema: "realtime",
+    name: "messages_audit",
+  };
+  const plainId: StableId = {
+    kind: "table",
+    schema: "realtime",
+    name: "schema_migrations",
+  };
+
+  const fb = makeFactBase([
+    { id: schemaRealtime, payload: {} },
+    {
+      id: parentId,
+      parent: schemaRealtime,
+      payload: {
+        partitionKey: "RANGE (inserted_at)",
+        partitionBound: null,
+        parentTable: null,
+      },
+    },
+    {
+      id: childId,
+      parent: schemaRealtime,
+      payload: {
+        partitionKey: null,
+        partitionBound: "FOR VALUES FROM ('2026-08-05') TO ('2026-08-06')",
+        parentTable: { schema: "realtime", name: "messages" },
+      },
+    },
+    {
+      id: inheritsChildId,
+      parent: schemaRealtime,
+      payload: {
+        partitionKey: null,
+        partitionBound: null,
+        parentTable: { schema: "realtime", name: "messages" },
+      },
+    },
+    {
+      id: plainId,
+      parent: schemaRealtime,
+      payload: { partitionKey: null, partitionBound: null, parentTable: null },
+    },
+  ]);
+
+  test("bare {} matches any declarative partition child", () => {
+    expect(factMatches({ partitionOf: {} }, fb.get(childId)!, fb)).toBe(true);
+  });
+
+  test("does not match the partitioned parent", () => {
+    expect(factMatches({ partitionOf: {} }, fb.get(parentId)!, fb)).toBe(false);
+  });
+
+  test("does not match a plain table", () => {
+    expect(factMatches({ partitionOf: {} }, fb.get(plainId)!, fb)).toBe(false);
+  });
+
+  test("does not match a legacy INHERITS child (no partition bound)", () => {
+    expect(
+      factMatches({ partitionOf: {} }, fb.get(inheritsChildId)!, fb),
+    ).toBe(false);
+    expect(
+      factMatches(
+        { partitionOf: { schema: "realtime", name: "messages" } },
+        fb.get(inheritsChildId)!,
+        fb,
+      ),
+    ).toBe(false);
+  });
+
+  test("does not match a fact without a partitionBound payload field", () => {
+    expect(factMatches({ partitionOf: {} }, fb.get(schemaRealtime)!, fb)).toBe(
+      false,
+    );
+  });
+
+  test("parent pinning by schema and name", () => {
+    expect(
+      factMatches(
+        { partitionOf: { schema: "realtime", name: "messages" } },
+        fb.get(childId)!,
+        fb,
+      ),
+    ).toBe(true);
+    expect(
+      factMatches(
+        { partitionOf: { schema: "public", name: "messages" } },
+        fb.get(childId)!,
+        fb,
+      ),
+    ).toBe(false);
+    expect(
+      factMatches(
+        { partitionOf: { name: "events" } },
+        fb.get(childId)!,
+        fb,
+      ),
+    ).toBe(false);
+  });
+
+  test("parent name accepts globs and arrays", () => {
+    expect(
+      factMatches({ partitionOf: { name: "mess*" } }, fb.get(childId)!, fb),
+    ).toBe(true);
+    expect(
+      factMatches(
+        { partitionOf: { name: ["events", "messages"] } },
+        fb.get(childId)!,
+        fb,
+      ),
+    ).toBe(true);
+    expect(
+      factMatches(
+        { partitionOf: { name: ["events", "logs"] } },
+        fb.get(childId)!,
+        fb,
+      ),
+    ).toBe(false);
+  });
+
+  test("composes with not for keep-partitions-only style rules", () => {
+    expect(
+      factMatches({ not: { partitionOf: {} } }, fb.get(childId)!, fb),
+    ).toBe(false);
+    expect(
+      factMatches({ not: { partitionOf: {} } }, fb.get(parentId)!, fb),
+    ).toBe(true);
+  });
+
+  test("filterDeltas excludes partition-child deltas, keeps the parent's", () => {
+    const source = makeFactBase([]);
+    const addParent: Delta = { verb: "add", fact: fb.get(parentId)! };
+    const addChild: Delta = { verb: "add", fact: fb.get(childId)! };
+    const policy: Policy = {
+      id: "realtime-test",
+      filter: [
+        {
+          match: { partitionOf: { schema: "realtime", name: "messages" } },
+          action: "exclude",
+        },
+      ],
+    };
+    const { kept, filtered } = filterDeltas(
+      [addParent, addChild],
+      policy,
+      source,
+      fb,
+    );
+    expect(kept).toEqual([addParent]);
+    expect(filtered).toEqual([addChild]);
+  });
+});

--- a/packages/pg-delta/src/policy/policy.test.ts
+++ b/packages/pg-delta/src/policy/policy.test.ts
@@ -1349,9 +1349,9 @@ describe("factMatches — partitionOf predicate", () => {
   });
 
   test("does not match a legacy INHERITS child (no partition bound)", () => {
-    expect(
-      factMatches({ partitionOf: {} }, fb.get(inheritsChildId)!, fb),
-    ).toBe(false);
+    expect(factMatches({ partitionOf: {} }, fb.get(inheritsChildId)!, fb)).toBe(
+      false,
+    );
     expect(
       factMatches(
         { partitionOf: { schema: "realtime", name: "messages" } },
@@ -1383,11 +1383,7 @@ describe("factMatches — partitionOf predicate", () => {
       ),
     ).toBe(false);
     expect(
-      factMatches(
-        { partitionOf: { name: "events" } },
-        fb.get(childId)!,
-        fb,
-      ),
+      factMatches({ partitionOf: { name: "events" } }, fb.get(childId)!, fb),
     ).toBe(false);
   });
 

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -48,6 +48,17 @@
  * SYSTEM_SCHEMAS}), and for provenance filtering of operationally-managed
  * objects (edgeTo {edgeKind: "managedBy"}).
  *
+ * ### `{ partitionOf: { schema?: string | string[]; name?: string | string[] } }`
+ * Matches a declarative partition child: a fact whose payload carries a
+ * non-null `partitionBound` (exactly `pg_class.relispartition` — the extractor
+ * sets it from `pg_get_expr(relpartbound)`), optionally pinned to a parent
+ * whose `payload.parentTable` schema/name match the given globs. Needed for:
+ * excluding operational partition churn from a managed view (Realtime's daily
+ * `realtime.messages` partitions — the old DSL's `table/is_partition`, #346).
+ * Prefer the parent-pinned form: "is a partition" alone cannot tell service
+ * churn from a user-declared `PARTITION OF` (the pg_partman CLI-1591 lesson).
+ * A legacy INHERITS child has `parentTable` but no bound, so it does NOT match.
+ *
  * `validatePolicy` rejects an `idField` naming an unknown identity field, so a
  * typo fails loudly instead of silently never matching (review #7).
  */
@@ -180,6 +191,26 @@ export type EdgeToPredicate = {
   };
 };
 
+/**
+ * Matches a declarative partition child: a fact whose payload has a non-null
+ * `partitionBound` (⇔ `pg_class.relispartition`), optionally pinned to a
+ * parent whose `payload.parentTable` matches the given schema/name globs.
+ *
+ * All sub-fields are optional; `{ partitionOf: {} }` matches ANY partition
+ * (the old filter DSL's `table/is_partition: true`). Prefer pinning the parent
+ * (`{ partitionOf: { schema: "realtime", name: "messages" } }`): it states
+ * WHOSE partitions are operational churn instead of hiding every partition,
+ * and the projection audit classifies the pinned form as a named-object
+ * selector. A legacy INHERITS child (parentTable without a bound) never
+ * matches.
+ */
+export type PartitionOfPredicate = {
+  partitionOf: {
+    schema?: string | string[];
+    name?: string | string[];
+  };
+};
+
 export type Predicate =
   | KindPredicate
   | SchemaPredicate
@@ -193,7 +224,8 @@ export type Predicate =
   | OwnerPredicate
   | IdFieldPredicate
   | TargetPredicate
-  | EdgeToPredicate;
+  | EdgeToPredicate
+  | PartitionOfPredicate;
 
 // ---------------------------------------------------------------------------
 // Rules
@@ -497,6 +529,33 @@ export function factMatches(
       if (!patterns.some((p) => globMatch(p, targetNameVal))) return false;
     }
 
+    return true;
+  }
+
+  // partitionOf — a declarative partition child (payload.partitionBound is
+  // non-null exactly when pg_class.relispartition), optionally pinned to a
+  // parent whose payload.parentTable schema/name match the given globs.
+  if ("partitionOf" in predicate) {
+    if (typeof fact.payload["partitionBound"] !== "string") return false;
+    const { schema: schemaFilter, name: nameFilter } = predicate.partitionOf;
+    if (schemaFilter === undefined && nameFilter === undefined) return true;
+    const parentRaw = fact.payload["parentTable"];
+    if (parentRaw === null || typeof parentRaw !== "object") return false;
+    const parentObj = parentRaw as Record<string, unknown>;
+    if (schemaFilter !== undefined) {
+      const parentSchema = parentObj["schema"];
+      if (typeof parentSchema !== "string") return false;
+      const patterns = Array.isArray(schemaFilter)
+        ? schemaFilter
+        : [schemaFilter];
+      if (!patterns.some((p) => globMatch(p, parentSchema))) return false;
+    }
+    if (nameFilter !== undefined) {
+      const parentName = parentObj["name"];
+      if (typeof parentName !== "string") return false;
+      const patterns = Array.isArray(nameFilter) ? nameFilter : [nameFilter];
+      if (!patterns.some((p) => globMatch(p, parentName))) return false;
+    }
     return true;
   }
 
@@ -886,6 +945,16 @@ function isNamedObjectPredicate(predicate: Predicate): boolean {
       selectors.every((value) => stringValues(value).every(noWildcard))
     );
   }
+  if ("partitionOf" in predicate) {
+    const selectors = [
+      predicate.partitionOf.name,
+      predicate.partitionOf.schema,
+    ].filter((value): value is string | string[] => value !== undefined);
+    return (
+      selectors.length > 0 &&
+      selectors.every((value) => stringValues(value).every(noWildcard))
+    );
+  }
   return false;
 }
 
@@ -911,6 +980,11 @@ function containsWildcardMatcher(predicate: Predicate): boolean {
     );
   if ("target" in predicate) {
     return [predicate.target.name, predicate.target.schema]
+      .filter((value): value is string | string[] => value !== undefined)
+      .some((value) => stringValues(value).some((part) => !noWildcard(part)));
+  }
+  if ("partitionOf" in predicate) {
+    return [predicate.partitionOf.name, predicate.partitionOf.schema]
       .filter((value): value is string | string[] => value !== undefined)
       .some((value) => stringValues(value).some((part) => !noWildcard(part)));
   }

--- a/packages/pg-delta/src/policy/projection-audit.test.ts
+++ b/packages/pg-delta/src/policy/projection-audit.test.ts
@@ -118,6 +118,75 @@ describe("attributed projection audit", () => {
     expect(audit.summary.suspicious).toBe(0);
   });
 
+  test("partitionOf exclusion pinned to a concrete parent is acknowledged", () => {
+    const realtimeSchema = schema("realtime");
+    const partitionChild = table("realtime", "messages_2026_08_05");
+    const source = buildFactBase([fact(realtimeSchema)], []);
+    const desired = buildFactBase(
+      [
+        fact(realtimeSchema),
+        fact(
+          partitionChild,
+          {
+            partitionBound: "FOR VALUES FROM ('2026-08-05') TO ('2026-08-06')",
+            parentTable: { schema: "realtime", name: "messages" },
+          },
+          realtimeSchema,
+        ),
+      ],
+      [],
+    );
+    const policy: Policy = {
+      id: "realtime",
+      filter: [
+        {
+          match: { partitionOf: { schema: "realtime", name: "messages" } },
+          action: "exclude",
+        },
+      ],
+    };
+
+    const audit = auditManagedViewProjection(source, desired, { policy });
+    expect(audit.entries).toHaveLength(1);
+    expect(audit.entries[0]).toMatchObject({
+      subject: { kind: "fact", id: partitionChild },
+      classification: "acknowledged",
+    });
+    expect(audit.summary.suspicious).toBe(0);
+  });
+
+  test("bare partitionOf exclusion is a broad class selector: suspicious", () => {
+    const realtimeSchema = schema("realtime");
+    const partitionChild = table("realtime", "messages_2026_08_05");
+    const source = buildFactBase([fact(realtimeSchema)], []);
+    const desired = buildFactBase(
+      [
+        fact(realtimeSchema),
+        fact(
+          partitionChild,
+          {
+            partitionBound: "FOR VALUES FROM ('2026-08-05') TO ('2026-08-06')",
+            parentTable: { schema: "realtime", name: "messages" },
+          },
+          realtimeSchema,
+        ),
+      ],
+      [],
+    );
+    const policy: Policy = {
+      id: "realtime",
+      filter: [{ match: { partitionOf: {} }, action: "exclude" }],
+    };
+
+    const audit = auditManagedViewProjection(source, desired, { policy });
+    expect(audit.entries).toHaveLength(1);
+    expect(audit.entries[0]).toMatchObject({
+      subject: { kind: "fact", id: partitionChild },
+      classification: "suspicious",
+    });
+    expect(audit.summary.suspicious).toBe(1);
+  });
+
   test("identical source and desired produce an empty audit", () => {
     const publicSchema = schema("public");
     const fb = buildFactBase([fact(publicSchema)], []);

--- a/packages/pg-delta/tests/policy-filter-integration.test.ts
+++ b/packages/pg-delta/tests/policy-filter-integration.test.ts
@@ -10,11 +10,15 @@
  *   1. a schema-exclude policy projects a whole schema out of the plan and the
  *      kept view round-trips to zero drift (catalog-export-filter realtime use);
  *   2. security-label changes are excludable by kind and by provider — which
- *      requires a real label provider (seclabelCluster), so it is not corpus.
+ *      requires a real label provider (seclabelCluster), so it is not corpus;
+ *   3. a partitionOf-exclude policy leaves differing partition sets unmanaged
+ *      on BOTH sides while the rest converges (the Realtime tenant-migration
+ *      use — the old filter DSL's `table/is_partition`, #346).
  *
  * Intentional v2 deltas (recorded in the ledger, no test): filter-wildcard's
- * `is_partition` boolean and `requires` regex have no Policy v2 predicate, and
- * the CLI `--filter` AND-combine is an old-API shape.
+ * `requires` regex has no Policy v2 predicate, and the CLI `--filter`
+ * AND-combine is an old-API shape. (Its `is_partition` boolean is superseded
+ * by the `partitionOf` predicate, pinned in this file.)
  */
 import { describe, expect, test } from "bun:test";
 import { apply } from "../src/apply/apply.ts";
@@ -81,6 +85,89 @@ describe("policy filter: schema projection roundtrip", () => {
       expect(report.status).toBe("applied");
       const after = await extract(main.pool);
       expect(plan(after.factBase, d.factBase, { policy }).actions).toEqual([]);
+    } finally {
+      await Promise.all([main.drop(), desired.drop()]);
+    }
+  }, 60_000);
+});
+
+describe("policy filter: partitionOf projection roundtrip", () => {
+  test("differing partition sets stay unmanaged on both sides; the rest converges", async () => {
+    const cluster = await sharedCluster();
+    const main = await cluster.createDb("polf_part_main");
+    const desired = await cluster.createDb("polf_part_dst");
+    try {
+      // The Realtime tenant shape: both sides share the partitioned parent, but
+      // carry DIFFERENT operationally-created partition sets (daily churn the
+      // Realtime service owns). The desired side also adds a plain table that
+      // the tenant migration SHOULD manage.
+      await main.pool.query(`
+        CREATE SCHEMA realtime;
+        CREATE TABLE realtime.messages (
+          id bigint NOT NULL,
+          inserted_at timestamptz NOT NULL,
+          PRIMARY KEY (id, inserted_at)
+        ) PARTITION BY RANGE (inserted_at);
+        CREATE TABLE realtime.messages_2026_08_01
+          PARTITION OF realtime.messages
+          FOR VALUES FROM ('2026-08-01') TO ('2026-08-02');
+      `);
+      await desired.pool.query(`
+        CREATE SCHEMA realtime;
+        CREATE TABLE realtime.messages (
+          id bigint NOT NULL,
+          inserted_at timestamptz NOT NULL,
+          PRIMARY KEY (id, inserted_at)
+        ) PARTITION BY RANGE (inserted_at);
+        CREATE TABLE realtime.messages_2026_08_05
+          PARTITION OF realtime.messages
+          FOR VALUES FROM ('2026-08-05') TO ('2026-08-06');
+        CREATE TABLE realtime.messages_2026_08_06
+          PARTITION OF realtime.messages
+          FOR VALUES FROM ('2026-08-06') TO ('2026-08-07');
+        CREATE TABLE realtime.subscription (id bigint PRIMARY KEY);
+      `);
+      const policy: Policy = {
+        id: "realtime-tenant",
+        filter: [
+          {
+            match: { partitionOf: { schema: "realtime", name: "messages" } },
+            action: "exclude",
+            audit: { reasonCode: "realtime.messages-partition-churn" },
+          },
+        ],
+      };
+
+      const [s, d] = await Promise.all([
+        extract(main.pool),
+        extract(desired.pool),
+      ]);
+      const thePlan = plan(s.factBase, d.factBase, { policy });
+
+      // no partition child is created or dropped in either direction …
+      expect(thePlan.actions.some((a) => /messages_20/.test(a.sql))).toBe(
+        false,
+      );
+      // … while the plain table IS planned.
+      expect(thePlan.actions.some((a) => /subscription/.test(a.sql))).toBe(
+        true,
+      );
+
+      const report = await apply(thePlan, main.pool, {
+        fingerprintGate: false,
+      });
+      expect(report.status).toBe("applied");
+
+      // roundtrip: re-plan under the same policy → zero drift even though the
+      // two sides still hold different partition sets.
+      const after = await extract(main.pool);
+      expect(plan(after.factBase, d.factBase, { policy }).actions).toEqual([]);
+
+      // the churn partition on main was never dropped.
+      const rows = await main.pool.query(
+        `SELECT relname FROM pg_class WHERE relname = 'messages_2026_08_01'`,
+      );
+      expect(rows.rows).toHaveLength(1);
     } finally {
       await Promise.all([main.drop(), desired.drop()]);
     }


### PR DESCRIPTION
## Summary

The old filter DSL's `table/is_partition` boolean (used by Realtime's tenant migrations) has no Policy v2 equivalent — it was an intentional, ledger-recorded drop in the rewrite. This PR adds a `partitionOf` predicate to the Policy DSL so that use case has a first-class replacement:

```jsonc
{ "partitionOf": {} }                                        // any declarative partition (old is_partition semantics)
{ "partitionOf": { "schema": "realtime", "name": "messages" } } // preferred: pinned to a parent
```

- Matches declarative partition children: `payload.partitionBound` is non-null exactly when `pg_class.relispartition`. Legacy `INHERITS` children (parentTable without a bound) never match.
- The parent-pinned form states **whose** partitions are operational churn instead of hiding every partition (the pg_partman CLI-1591 lesson: `relispartition` alone can't tell service churn from a user-declared `PARTITION OF`), and the projection audit classifies it as a named-object selector (acknowledged); the bare form stays suspicious unless annotated.
- Pure serializable data — works in custom `--profile ./profile.json` files out of the box, at both fact-scope and delta level.
- MIGRATION.md gains the v1 → v2 cookbook row for `table/is_partition`.

RED → GREEN: the first commit adds the failing regression (10 failures — `factMatches` falls through its exhaustive arm, and the audit classifies the pinned rule as suspicious); the second makes it pass. End-to-end, `tests/policy-filter-integration.test.ts` now pins the Realtime shape: two databases with **different** partition sets under `realtime.messages` plan zero partition churn while the rest converges, and the roundtrip re-plan is empty.

## Linked issue

Refs #346 (old-DSL `table/is_partition` parity for the Realtime tenant filter; the underlying cycle bug is superseded by the rewrite).

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8yHw5nQhvYH1wFHnX4oK1