### PR TITLE
fix(pg-delta): omit assumed seed facts with managed dependencies

### DIFF
--- a/.changeset/assumed-seed-managed-dependency.md
+++ b/.changeset/assumed-seed-managed-dependency.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Prevent assumed-schema shadow seeding from replaying reference-only objects before their managed dependencies exist.

--- a/packages/pg-delta/src/frontends/seed-assumed-schemas.test.ts
+++ b/packages/pg-delta/src/frontends/seed-assumed-schemas.test.ts
@@ -541,4 +541,60 @@ describe("deriveAssumedSchemaSeed", () => {
     expect(seed.facts).toBe(1);
     expect(seed.schemas).toEqual([]);
   });
+
+  test("an assumed SHELL keeps its inherited managed dependency (publication members)", () => {
+    // #370: an assumed publication is seeded EMPTY — membership is a separate
+    // MANAGED `publicationRel` child fact the seed never creates. But extract
+    // collapses `pg_publication_rel` catalog rows onto the PUBLICATION id
+    // (src/extract/dependencies.ts's `pubrel` CTE), so the publication fact
+    // INHERITS a `depends` edge to each managed member table. That edge is not a
+    // replay requirement for `CREATE PUBLICATION` with no `FOR TABLE`, so the
+    // managed-dependency rule must not omit the publication (which would silently
+    // empty the seed and break a membership-only declarative dir).
+    const pubOnlyPolicy: Policy = {
+      id: "test-pub-only-members",
+      filter: [
+        {
+          match: { all: [{ kind: "publication" }, { name: "platform_pub" }] },
+          action: "exclude",
+        },
+      ],
+      assumedPublications: ["platform_pub"],
+    };
+    const platformPub: StableId = { kind: "publication", name: "platform_pub" };
+    const userTable: StableId = { kind: "table", schema: "public", name: "t" };
+    const pubRel: StableId = {
+      kind: "publicationRel",
+      publication: "platform_pub",
+      schema: "public",
+      table: "t",
+    };
+    const target = buildFactBase(
+      [
+        f(schemaPublic),
+        f(platformPub, {
+          allTables: false,
+          viaRoot: false,
+          publish: ["insert", "update", "delete", "truncate"],
+        }),
+        { id: userTable, parent: schemaPublic, payload: { persistence: "p" } },
+        {
+          id: pubRel,
+          parent: platformPub,
+          payload: { columns: null, where: null },
+        },
+      ],
+      [{ from: platformPub, to: userTable, kind: "depends" }],
+    );
+    const seed = deriveAssumedSchemaSeed(target, {
+      policy: pubOnlyPolicy,
+      assumedSchemas: [],
+      assumedRoles: [],
+      assumedPublications: ["platform_pub"],
+    });
+    expect(seed.sql).toContain('CREATE PUBLICATION "platform_pub"');
+    // seeded as a bare shell — membership is managed, never seeded.
+    expect(seed.sql).not.toMatch(/ADD TABLE|FOR TABLE/i);
+    expect(seed.facts).toBe(1);
+  });
 });

--- a/packages/pg-delta/src/frontends/seed-assumed-schemas.test.ts
+++ b/packages/pg-delta/src/frontends/seed-assumed-schemas.test.ts
@@ -304,6 +304,170 @@ describe("deriveAssumedSchemaSeed", () => {
     expect(seed.sql).toContain('CREATE SCHEMA "platform"');
   });
 
+  // A reference-only overlay can DEPEND on a MANAGED fact (one that only comes
+  // into existence when the declarative files load, AFTER the seed replays).
+  // Field case: a policy on an assumed platform table whose expression calls a
+  // user function in a managed schema — the seed used to include it and Postgres
+  // failed the whole seed with `schema "app" does not exist`. Such a candidate
+  // must be omitted WHOLE (never rewritten), together with everything that
+  // depends on it and every fact it structurally contains.
+  const appHelperFn: StableId = {
+    kind: "function",
+    schema: "app",
+    name: "helper",
+    args: [],
+  };
+  const appHelperDef =
+    `CREATE OR REPLACE FUNCTION app.helper()\n` +
+    ` RETURNS integer\n` +
+    ` LANGUAGE sql\n` +
+    `AS $function$SELECT 1$function$`;
+
+  test("a candidate depending on a MANAGED fact is omitted, transitively", () => {
+    const crossLayerFn: StableId = {
+      kind: "function",
+      schema: "platform",
+      name: "cross_layer",
+      args: [],
+    };
+    const downstreamFn: StableId = {
+      kind: "function",
+      schema: "platform",
+      name: "downstream",
+      args: [],
+    };
+    const crossLayerDef =
+      `CREATE OR REPLACE FUNCTION platform.cross_layer()\n` +
+      ` RETURNS integer\n` +
+      ` LANGUAGE sql\n` +
+      `AS $function$SELECT app.helper()$function$`;
+    const downstreamDef =
+      `CREATE OR REPLACE FUNCTION platform.downstream()\n` +
+      ` RETURNS integer\n` +
+      ` LANGUAGE sql\n` +
+      `AS $function$SELECT platform.cross_layer()$function$`;
+    const target = buildFactBase(
+      [
+        f(schemaPlatform),
+        f(schemaApp),
+        f(appHelperFn, routinePayload(appHelperDef, [])),
+        f(crossLayerFn, routinePayload(crossLayerDef, [])),
+        f(downstreamFn, routinePayload(downstreamDef, [])),
+        f(tidyFn, routinePayload(tidyDef, ["search_path"])),
+      ],
+      [
+        { from: crossLayerFn, to: appHelperFn, kind: "depends" },
+        { from: downstreamFn, to: crossLayerFn, kind: "depends" },
+      ],
+    );
+    const seed = deriveAssumedSchemaSeed(target, {
+      policy: platformPolicy,
+      assumedSchemas: ["platform"],
+      assumedRoles: [],
+    });
+    // the assumed schema and the self-contained platform routine still seed.
+    expect(seed.sql).toContain('CREATE SCHEMA "platform"');
+    expect(seed.sql).toContain("platform.tidy()");
+    // the managed-dependency overlay AND its dependent are absent.
+    expect(seed.sql).not.toContain("cross_layer");
+    expect(seed.sql).not.toContain("downstream");
+    // the managed schema and its objects are never seeded.
+    expect(seed.sql).not.toContain('"app"');
+    expect(seed.sql).not.toContain("app.helper");
+    expect(seed.schemas).toEqual(["platform"]);
+    expect(seed.facts).toBe(2);
+  });
+
+  test("a candidate omitted for a MANAGED dependency does not orphan its CHILD facts", () => {
+    // Same structural interplay as the susetGucs case: containment is `Fact.parent`,
+    // not a `depends` edge, so omitting the container without its descendants
+    // would leave orphaned children and buildFactBase would hard-throw
+    // "references missing parent".
+    const overlayView: StableId = {
+      kind: "view",
+      schema: "platform",
+      name: "overlay",
+    };
+    const overlayIdColumn: StableId = {
+      kind: "column",
+      schema: "platform",
+      table: "overlay",
+      name: "id",
+    };
+    const target = buildFactBase(
+      [
+        f(schemaPlatform),
+        f(schemaApp),
+        f(appHelperFn, routinePayload(appHelperDef, [])),
+        f(tidyFn, routinePayload(tidyDef, ["search_path"])),
+        {
+          id: overlayView,
+          parent: schemaPlatform,
+          payload: { def: " SELECT app.helper() AS id;" },
+        },
+        {
+          id: overlayIdColumn,
+          parent: overlayView,
+          payload: { type: "integer", notNull: false },
+        },
+      ],
+      [{ from: overlayView, to: appHelperFn, kind: "depends" }],
+    );
+    const seed = deriveAssumedSchemaSeed(target, {
+      policy: platformPolicy,
+      assumedSchemas: ["platform"],
+      assumedRoles: [],
+    });
+    expect(seed.sql).toContain('CREATE SCHEMA "platform"');
+    expect(seed.sql).toContain("platform.tidy()");
+    expect(seed.sql).not.toContain("overlay");
+    expect(seed.sql).not.toContain("app.helper");
+    expect(seed.facts).toBe(2);
+  });
+
+  test("a candidate depending on another REFERENCE-ONLY non-candidate is still seeded", () => {
+    // Extension members are reference-only but excluded from the candidate set
+    // (CREATE EXTENSION owns their lifecycle). They are ambient in the shadow —
+    // an assumed-schema fact depending on one must NOT be omitted.
+    const ext: StableId = { kind: "extension", name: "someext" };
+    const memberFn: StableId = {
+      kind: "function",
+      schema: "platform",
+      name: "member_fn",
+      args: [],
+    };
+    const userOfMember: StableId = {
+      kind: "function",
+      schema: "platform",
+      name: "uses_member",
+      args: [],
+    };
+    const usesMemberDef =
+      `CREATE OR REPLACE FUNCTION platform.uses_member()\n` +
+      ` RETURNS integer\n` +
+      ` LANGUAGE sql\n` +
+      `AS $function$SELECT platform.member_fn()$function$`;
+    const target = buildFactBase(
+      [
+        f(schemaPlatform),
+        f(ext),
+        f(memberFn, routinePayload("CREATE FUNCTION platform.member_fn()", [])),
+        f(userOfMember, routinePayload(usesMemberDef, [])),
+      ],
+      [
+        { from: memberFn, to: ext, kind: "memberOfExtension" },
+        { from: userOfMember, to: memberFn, kind: "depends" },
+      ],
+    );
+    const seed = deriveAssumedSchemaSeed(target, {
+      policy: platformPolicy,
+      assumedSchemas: ["platform"],
+      assumedRoles: [],
+    });
+    expect(seed.sql).toContain('CREATE SCHEMA "platform"');
+    expect(seed.sql).toContain("platform.uses_member()");
+  });
+
   test("without susetGucs: routine def retained verbatim (byte-identical), ADP still omitted", () => {
     const seed = deriveAssumedSchemaSeed(platformTarget(), {
       policy: platformPolicy,

--- a/packages/pg-delta/src/frontends/seed-assumed-schemas.ts
+++ b/packages/pg-delta/src/frontends/seed-assumed-schemas.ts
@@ -24,6 +24,20 @@
  * profile, so the seeded objects come back reference-only and cancel against the
  * target's reference-only copies in `plan()` — nothing leaks into the diff.
  *
+ * The seed is a REPLAYABLE SUBSET of the reference-only facts, not all of them.
+ * It replays FIRST, into an empty shadow; the MANAGED objects only come into
+ * existence afterwards, when the declarative files load. So a reference-only
+ * overlay that DEPENDS on managed state (the field case: a policy on an assumed
+ * `storage.objects` whose expression calls a user function in a managed `app`
+ * schema) simply cannot replay during the seed phase — PostgreSQL fails the
+ * whole seed with `schema "app" does not exist`. Such a candidate is OMITTED
+ * WHOLE, together with everything that depends on it and everything it
+ * structurally contains. Omitting it is safe and symmetric: generic diffing
+ * skips a fact that is reference-only on EITHER side, so a shadow that lacks it
+ * plans no create and no drop. No SQL is parsed, inspected semantically, or
+ * rewritten to make such a fact replayable — the fact is dropped from the seed
+ * set or it is replayed verbatim, never anything in between.
+ *
  * Baseline is deliberately NOT applied here (Codex #323 finding 3). The seed is
  * the SUPERSET question — "what platform objects must exist for the user SQL to
  * elaborate in the shadow" — whereas the diff is the SUBSET question — "what do
@@ -52,8 +66,12 @@
  * load fails LOUDLY at file:line with a precise missing-object error — acceptable
  * (user code essentially never calls these internal platform RPCs, and a clear
  * error beats rewritten SQL). `susetGucs` absent ⇒ nothing is skipped for this
- * reason (byte-identical behavior). Any fact that DEPENDS on a skipped routine is
- * transitively skipped too (it could not replay against a missing dependency).
+ * reason (byte-identical behavior).
+ *
+ * All omission reasons (managed dependency, suset-GUC routine, ADP, extension
+ * member) feed ONE exclusion closure, so a fact that depends on — or is
+ * structurally contained by — an omitted fact is omitted too, whatever the
+ * original reason was.
  */
 import { buildFactBase, type Fact, type FactBase } from "../core/fact.ts";
 import { encodeId, type StableId } from "../core/stable-id.ts";
@@ -164,18 +182,78 @@ export function deriveAssumedSchemaSeed(
   // ROLE <r>` needs membership in <r>, which a non-superuser applier lacks, and
   // an ADP entry has no possible dependents (see the module doc). Applies to ALL
   // roles — even an applier-owned ADP is unnecessary for elaboration.
-  const keptFacts = view
+  const candidateFacts = view
     .facts()
     .filter(
       (f) => seedIds.has(encodeId(f.id)) && f.id.kind !== "defaultPrivilege",
     );
-  const keptIds = new Set(keptFacts.map((f) => encodeId(f.id)));
+  const candidateIds = new Set(candidateFacts.map((f) => encodeId(f.id)));
 
-  // Skip whole routines that carry a superuser-only SET header clause (they can't
-  // be CREATEd by a non-superuser), decided from structured `_configGucs` — never
-  // by editing the `def` SQL text. Then cascade exclusion to a fixpoint over TWO
-  // relations:
-  //   - `depends` edges: any kept fact DEPENDING on a skipped one (it can't
+  // Candidates the seed materializes as a bare SHELL, because at least one of
+  // their subsidiary facts is NOT a candidate (managed membership). Extract
+  // collapses a subsidiary catalog row onto its owning object's id — e.g.
+  // `pg_publication_rel` resolves to the PUBLICATION id
+  // (src/extract/dependencies.ts's `pubrel` CTE) — so such a container INHERITS
+  // its members' `depends` edges even though membership lives in a separate child
+  // fact (`publicationRel`) the seed never creates. A shell's inherited edge is
+  // therefore NOT a replay requirement: `CREATE PUBLICATION supabase_realtime`
+  // with no `FOR TABLE` needs none of its members (#370 seeds it EMPTY on
+  // purpose). Computed by walking each NON-candidate view fact up to its
+  // candidate ancestors.
+  const shellIds = new Set<string>();
+  for (const fct of view.facts()) {
+    if (candidateIds.has(encodeId(fct.id))) continue;
+    let ancestor = fct.parent;
+    while (ancestor !== undefined) {
+      const key = encodeId(ancestor);
+      if (candidateIds.has(key)) shellIds.add(key);
+      ancestor = view.get(ancestor)?.parent;
+    }
+  }
+
+  // INITIAL exclusions — the reasons a candidate cannot be replayed at seed time
+  // at all. They all feed the SAME closure below, so a future reason needs no new
+  // cascade logic.
+  const excludedIds = new Set<string>();
+
+  // (1) MANAGED dependency: the candidate `depends` on a fact that is in the
+  //     managed view but is neither a seed candidate nor reference-only, i.e. an
+  //     object the declarative files create LATER. The seed replays into an empty
+  //     shadow, so that object does not exist yet and the statement fails (field
+  //     case: `schema "app" does not exist`). Two target classes stay allowed:
+  //       - a reference-only NON-candidate (extension member, ADP) — ambient in
+  //         the co-located shadow (or with no replay meaning), which is the
+  //         existing contract the plan's requirement guard already exempts via
+  //         `assumedSchemas`;
+  //       - anything a SHELL candidate inherited from a non-seeded subsidiary
+  //         (see `shellIds`) — the shell's own DDL does not reference it.
+  for (const e of view.edges) {
+    if (e.kind !== "depends") continue;
+    const from = encodeId(e.from);
+    if (!candidateIds.has(from) || excludedIds.has(from)) continue;
+    if (shellIds.has(from)) continue;
+    const to = encodeId(e.to);
+    if (candidateIds.has(to) || view.referenceOnly.has(to)) continue;
+    excludedIds.add(from);
+  }
+
+  // (2) whole routines that carry a superuser-only SET header clause (they can't
+  //     be CREATEd by a non-superuser), decided from structured `_configGucs` —
+  //     never by editing the `def` SQL text.
+  const suset = opts.susetGucs;
+  if (suset !== undefined && suset.size > 0) {
+    for (const fct of candidateFacts) {
+      if (
+        (fct.id.kind === "function" || fct.id.kind === "procedure") &&
+        configGucsOf(fct).some((g) => suset.has(g))
+      ) {
+        excludedIds.add(encodeId(fct.id));
+      }
+    }
+  }
+
+  // Cascade every initial exclusion to a fixpoint over TWO relations:
+  //   - `depends` edges: any candidate DEPENDING on an excluded one (it can't
   //     replay against a missing dependency);
   //   - structural containment (`Fact.parent`): a container fact's CHILD facts
   //     (e.g. a view's columns) are not linked by a `depends` edge at all — they
@@ -187,64 +265,73 @@ export function deriveAssumedSchemaSeed(
   // COLUMN-level id (src/extract/dependencies.ts's `resolved` CTE,
   // `objsubid > 0`), so a `depends` edge can point AT a column. A column
   // excluded structurally (because its parent view was excluded) can therefore
-  // be the very fact another kept fact `depends` on, which the edge pass must
+  // be the very fact another candidate `depends` on, which the edge pass must
   // then pick up — hence a combined fixpoint, not one pass of each.
-  const excluded = new Set<string>();
-  const suset = opts.susetGucs;
-  if (suset && suset.size > 0) {
-    for (const fct of keptFacts) {
-      if (
-        (fct.id.kind === "function" || fct.id.kind === "procedure") &&
-        configGucsOf(fct).some((g) => suset.has(g))
-      ) {
-        excluded.add(encodeId(fct.id));
+  if (excludedIds.size > 0) {
+    const parentOf = new Map<string, string>();
+    for (const fct of candidateFacts) {
+      if (fct.parent !== undefined) {
+        parentOf.set(encodeId(fct.id), encodeId(fct.parent));
       }
     }
-    if (excluded.size > 0) {
-      const parentOf = new Map<string, string>();
-      for (const fct of keptFacts) {
-        if (fct.parent !== undefined) {
-          parentOf.set(encodeId(fct.id), encodeId(fct.parent));
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const e of view.edges) {
+        if (e.kind !== "depends") continue;
+        const from = encodeId(e.from);
+        if (
+          candidateIds.has(from) &&
+          !excludedIds.has(from) &&
+          excludedIds.has(encodeId(e.to))
+        ) {
+          excludedIds.add(from);
+          changed = true;
         }
       }
-      let changed = true;
-      while (changed) {
-        changed = false;
-        for (const e of view.edges) {
-          if (e.kind !== "depends") continue;
-          const from = encodeId(e.from);
-          if (
-            keptIds.has(from) &&
-            !excluded.has(from) &&
-            excluded.has(encodeId(e.to))
-          ) {
-            excluded.add(from);
+      for (const fct of candidateFacts) {
+        const encoded = encodeId(fct.id);
+        if (excludedIds.has(encoded)) continue;
+        let ancestor = parentOf.get(encoded);
+        while (ancestor !== undefined) {
+          if (excludedIds.has(ancestor)) {
+            excludedIds.add(encoded);
             changed = true;
+            break;
           }
-        }
-        for (const fct of keptFacts) {
-          const encoded = encodeId(fct.id);
-          if (excluded.has(encoded)) continue;
-          let ancestor = parentOf.get(encoded);
-          while (ancestor !== undefined) {
-            if (excluded.has(ancestor)) {
-              excluded.add(encoded);
-              changed = true;
-              break;
-            }
-            ancestor = parentOf.get(ancestor);
-          }
+          ancestor = parentOf.get(ancestor);
         }
       }
     }
   }
 
   const seedFacts =
-    excluded.size > 0
-      ? keptFacts.filter((f) => !excluded.has(encodeId(f.id)))
-      : keptFacts;
+    excludedIds.size > 0
+      ? candidateFacts.filter((f) => !excludedIds.has(encodeId(f.id)))
+      : candidateFacts;
   if (seedFacts.length === 0) return EMPTY;
   const finalIds = new Set(seedFacts.map((f) => encodeId(f.id)));
+
+  // Defensive invariant: the edge filter below narrows `view.edges` to intra-seed
+  // edges, which would SILENTLY discard the evidence of an unsatisfied dependency
+  // and let PostgreSQL discover it at replay time instead. Nothing in the final
+  // seed set may still depend on a MANAGED fact outside it — the closure above
+  // exists precisely to guarantee that, so a violation is an engine bug, not user
+  // input. (Reference-only targets outside the seed remain allowed: they are
+  // ambient in the co-located shadow.)
+  for (const e of view.edges) {
+    if (e.kind !== "depends") continue;
+    const from = encodeId(e.from);
+    if (!finalIds.has(from) || shellIds.has(from)) continue;
+    const to = encodeId(e.to);
+    if (finalIds.has(to) || view.referenceOnly.has(to)) continue;
+    if (view.getByEncoded(to) === undefined) continue;
+    throw new Error(
+      `deriveAssumedSchemaSeed: seed fact ${from} still depends on managed fact ` +
+        `${to}, which the seed does not create; the exclusion closure is incomplete`,
+    );
+  }
+
   const seedEdges = [...view.edges].filter(
     (e) => finalIds.has(encodeId(e.from)) && finalIds.has(encodeId(e.to)),
   );

--- a/packages/pg-delta/tests/schema-frontends.test.ts
+++ b/packages/pg-delta/tests/schema-frontends.test.ts
@@ -19,7 +19,11 @@ import {
   type ManagementScope,
   type SqlFile,
 } from "../src/frontends/index.ts";
-import { rawProfile } from "../src/integrations/index.ts";
+import {
+  rawProfile,
+  type IntegrationProfile,
+} from "../src/integrations/index.ts";
+import type { Policy } from "../src/policy/policy.ts";
 import { sharedCluster } from "./containers.ts";
 
 const SCHEMA_SQL = `
@@ -234,6 +238,109 @@ describe("public schema frontends", () => {
       }
     } finally {
       await Promise.all([source.drop(), target.drop()]);
+    }
+  }, 120_000);
+
+  test("assumed-schema seeding omits a reference-only overlay with a managed dependency", async () => {
+    // A reference-only object can DEPEND on a MANAGED one: here a policy on the
+    // assumed `platform.objects` whose expression calls a user function and casts
+    // to a user domain, both in the managed `app` schema. `app` only exists AFTER
+    // the declarative files load, so replaying that policy during the seed phase
+    // failed the whole seed with `schema "app" does not exist`. The policy must be
+    // omitted WHOLE from the seed (never rewritten) while the useful assumed table
+    // is still seeded — and because a reference-only fact is skipped by the diff on
+    // both sides, its absence produces no spurious create/drop.
+    const platformPolicy: Policy = {
+      id: "test-platform-seed",
+      filter: [
+        {
+          match: { any: [{ schema: "platform" }, { name: "platform" }] },
+          action: "exclude",
+        },
+      ],
+      assumedSchemas: ["platform"],
+    };
+    const platformProfile: IntegrationProfile = {
+      id: "test-platform-seed",
+      handlers: [],
+      policy: platformPolicy,
+    };
+    const appSql = `
+      CREATE SCHEMA app;
+      CREATE DOMAIN app.valid_name AS text CHECK (length(value) > 0);
+      CREATE FUNCTION app.is_handle_maintainer(h text) RETURNS boolean
+        LANGUAGE sql IMMUTABLE AS $$ SELECT h IS NOT NULL $$;
+      CREATE TABLE app.links (
+        id integer PRIMARY KEY,
+        object_id integer REFERENCES platform.objects(id)
+      );
+    `;
+    const platformSql = `
+      CREATE SCHEMA platform;
+      CREATE TABLE platform.objects (id integer PRIMARY KEY, name text NOT NULL);
+      ALTER TABLE platform.objects ENABLE ROW LEVEL SECURITY;
+    `;
+    // The cross-layer overlay: reference-only (schema platform) but depending on
+    // BOTH managed app objects. Applied last — even the target can only create it
+    // once both layers exist, which is exactly why the seed cannot replay it.
+    const crossLayerPolicySql = `
+      CREATE POLICY cross_layer ON platform.objects
+        USING (app.is_handle_maintainer(name) AND (name::app.valid_name) IS NOT NULL);
+    `;
+
+    const cluster = await sharedCluster();
+    const target = await cluster.createDb("frontend_seed_managed_dep");
+    try {
+      // the platform layer must exist before the app layer's FK to it, and both
+      // before the policy that spans them.
+      await target.pool.query(platformSql);
+      await target.pool.query(appSql);
+      await target.pool.query(crossLayerPolicySql);
+
+      const shadow = await provisionCoLocatedShadow(target.uri, {
+        uniqueSuffix: `seedmd_${Date.now().toString(36)}`,
+      });
+      const shadowPool = new pg.Pool({ connectionString: shadow.url, max: 5 });
+      try {
+        // declarative files declare ONLY the managed app layer; the assumed
+        // platform layer arrives via the seed.
+        const files: SqlFile[] = [{ name: "app.sql", sql: appSql }];
+        const planned = await planSchemaFiles(target.pool, shadowPool, files, {
+          profile: platformProfile,
+          scope: "database",
+          seedAssumedSchemas: true,
+        });
+
+        // the useful assumed table WAS seeded (the app FK could not load otherwise).
+        expect(
+          await shadowPool.query(
+            `SELECT to_regclass('platform.objects') IS NOT NULL AS present`,
+          ),
+        ).toMatchObject({ rows: [{ present: true }] });
+        // the cross-layer policy was NOT part of the seed.
+        expect(
+          await shadowPool.query<{ n: number }>(
+            `SELECT count(*)::int AS n FROM pg_policies WHERE schemaname = 'platform'`,
+          ),
+        ).toMatchObject({ rows: [{ n: 0 }] });
+        // the declarative app layer loaded.
+        expect(
+          await shadowPool.query(
+            `SELECT to_regclass('app.links') IS NOT NULL AS present`,
+          ),
+        ).toMatchObject({ rows: [{ present: true }] });
+        // reference-only on both sides ⇒ no create/drop for the omitted policy,
+        // and the managed state matches ⇒ an empty plan.
+        expect(
+          planned.plan.actions.filter((a) => /cross_layer/i.test(a.sql)),
+        ).toEqual([]);
+        expect(planned.plan.actions.map((a) => a.sql)).toEqual([]);
+      } finally {
+        await shadowPool.end();
+        await shadow.cleanup();
+      }
+    } finally {
+      await target.drop();
     }
   }, 120_000);
 


### PR DESCRIPTION
## Problem

The assumed-schema shadow seed (`deriveAssumedSchemaSeed`) replays into an **empty** co-located shadow **before** the declarative files load. A reference-only (assumed) seed candidate can carry a `depends` edge to a **managed** fact — one that only exists after that load — and the seed included it anyway, so PostgreSQL failed the whole seed at replay.

Field case: a policy on `storage.objects` (assumed schema) whose expression calls `app.valid_name` / `app.is_handle_maintainer(...)` where `app` is managed → `schema "app" does not exist`. The intra-seed edge filter silently deleted the evidence of the unsatisfied dependency, so the failure only surfaced inside Postgres.

## Fix (generic — no special-casing, no SQL parsing/rewriting)

- **New initial exclusion:** a seed candidate with a `depends` edge to a view-present fact that is neither a candidate nor reference-only (= managed) is excluded from the seed.
- **Shared exclusion closure:** the fixpoint cascade (depends edges + structural `Fact.parent` containment) previously ran only for suset-GUC exclusions; it now runs for all initial exclusion reasons.
- **Defensive invariant:** before the `seedEdges` filter, assert no final seed fact still depends on a managed non-seeded fact — an incomplete closure now fails loudly with both encoded ids instead of surfacing as a Postgres replay error.
- **Shell carve-out (design note):** an assumed publication seeded empty (#370, e.g. `supabase_realtime`) inherits `depends` edges to its managed member tables via the `pubrel` CTE in `src/extract/dependencies.ts`, yet replays fine empty. A candidate with ≥1 non-candidate descendant is treated as a *shell* and exempt from the new rule and the invariant (pinned by a RED-verified unit test — without the carve-out the publication seed goes empty and shadow load wedges). Residual gap: a shell with an *intrinsic* managed dependency still fails at replay — pre-fix behavior for that narrow shape, tracked as a follow-up (attribute the pubrel edge to the `publicationRel` child fact at extract time).

Omitting these facts is safe: they are reference-only on both sides, and generic diffing skips a fact reference-only on either side, so their absence cancels in the plan.

## RED → GREEN

`a3b46c7e` is tests-only and checkoutable-failing. RED excerpts against the pre-fix code:

Unit (`src/frontends/seed-assumed-schemas.test.ts`):
```
(fail) a candidate depending on a MANAGED fact is omitted, transitively
expect(received).not.toContain("cross_layer")
Received: ...CREATE OR REPLACE FUNCTION platform.cross_layer()...AS $function$SELECT app.helper()$function$;...
(fail) a candidate omitted for a MANAGED dependency does not orphan its CHILD facts
expect(received).not.toContain("overlay")
Received: ...CREATE VIEW "platform"."overlay" AS  SELECT app.helper() AS id;...
```

Integration (`tests/schema-frontends.test.ts`, stock `postgres:17-alpine`):
```
SchemaFrontendError: Failed to seed the co-located shadow with the target's
assumed-schema objects: schema "app" does not exist
```

## Validation

- Unit: 14/14 in the seed test file (was 11 pass / 2 fail RED); full pg-delta unit suite 981/981.
- Integration: `schema-frontends.test.ts` 11/11; adjacent seed/publication/load files 23/23 (`postgres:17-alpine`).
- **Full corpus: 646/646 pass** on `postgres:17-alpine` (base of the stacked flow gets no test CI, so this is the gate).
- `format-and-lint:fix` / `build` / `check-types` clean; `knip` clean for pg-delta (pg-topo's 2-unused-files report is pre-existing, verified identical with this change stashed).

Changeset included (`@supabase/pg-delta` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)