### PR TITLE
feat(pg-delta): allow preloaded platform baselines in isolated shadows

### DIFF
--- a/.changeset/lenient-data-statements-preloaded-shadow.md
+++ b/.changeset/lenient-data-statements-preloaded-shadow.md
@@ -1,0 +1,14 @@
+---
+"@supabase/pg-delta": minor
+---
+
+The shadow loader's post-load DML observation no longer fails a load, and a pre-provisioned isolated shadow is now supported.
+
+`loadSqlFiles` used to throw `ShadowLoadError` as soon as ANY managed non-extension table held rows after loading the declarative files. That blocked callers whose dedicated shadow is pre-provisioned by a platform — the Supabase CLI boots auth / storage / realtime against its isolated shadow, and those services write their own migration bookkeeping rows (`auth.schema_migrations`, `storage.migrations`, `_realtime.tenants`, …) BEFORE any declarative SQL is loaded. Those rows are not the user's DML and there is nothing the user can do about them.
+
+Two changes:
+
+- **Pre-existing rows are exempt.** New loader option `allowPreExistingRows` (default: `true` in `"isolatedCluster"` mode, `false` otherwise; `planSchemaFiles` forwards it and lets the loader default it). When enabled the loader snapshots WHICH managed non-extension tables are already populated before the load and exempts exactly those from the post-load observation — silently, with no diagnostic. The exempted set is returned as `LoadResult.preExistingPopulatedTables`. Exemption is by qualified table name and never compares row contents (the loader deliberately does not diff data), so a table that was already populated stays exempt even if a declarative file inserts into it.
+- **Rows the load DID introduce are a warning, not a failure.** A non-exempt populated table now appends a `data_statement` diagnostic with severity `warning` to `LoadResult.diagnostics` and the load proceeds: pg-delta only ever diffs schema, so incidental data in the shadow cannot corrupt a plan, and refusing to read the schema back would block every directory that carries some. Pass `--strict-data-statements` (loader option `strictDataStatements: true`, `planSchemaFiles` option of the same name) to restore the previous fatal `ShadowLoadError` for CI.
+
+Extension-owned relations (`pg_depend` deptype `'e'`) remain out of scope, exactly as before.

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -278,11 +278,20 @@ re-implemented inside an imperative diff.
     cluster (throwaway instance/container); a same-cluster scratch database
     is only safe for database-local schemas, and the loader enforces the
     distinction.
-  - **Data statements are rejected, parser-free.** DML would succeed in the
+  - **Data statements are detected by effect, parser-free — and, by
+    default, warned on rather than rejected.** DML would succeed in the
     shadow and then silently vanish from the schema-only plan. After
-    loading, the loader checks for observable data — any user table with
-    rows fails the run ("declarative files must not contain data
-    statements"). Detection by effect, not by parsing.
+    loading, the loader checks for observable data: any managed
+    non-extension table with rows, never by parsing SQL. In an
+    isolated-cluster shadow (the default there), tables that already held
+    rows *before* the load are exempt via `allowPreExistingRows` — a
+    name-based exemption; row contents are never compared, so an INSERT
+    into an already-populated table stays invisible — and surface silently
+    as `LoadResult.preExistingPopulatedTables`. Any other populated table
+    appends a `data_statement` warning diagnostic to
+    `LoadResult.diagnostics` and the run proceeds with the schema-only
+    plan. `strictDataStatements` (CLI: `--strict-data-statements`) restores
+    the fatal failure and is recommended for CI.
 - **Snapshots**: the serialized fact base round-trips losslessly and is the
   contract for offline diffing, fixtures, and caching. A flat fact relation
   serializes, filters, and streams trivially — properties a nested document
@@ -875,7 +884,7 @@ gate in checkable form — is recorded in [the build log](../build-log.md).
 | 4 | Generic diff: rollup-guided descent emitting fact and edge deltas | §3.3 | Fixture diffs; `diff(A, A) = ∅` generatively |
 | 5 | The planner: rule table, atomic actions, one-graph sort, compaction | §3.4–3.6 | Corpus green under proof; differential vs old engine (state-equivalent plans, divergences triaged); generative soak; zero cycles |
 | 6 | Execution + plan artifact v1: ordered deltas, rollup-hash fingerprints, safety report (proven / observed / vetted tiers) | §3.7–3.8 | End-to-end proof on the corpus, including segmented non-transactional actions |
-| 7 | Frontends: shadow-DB SQL loader (fail-safe ordering, body validation, cluster isolation, DML rejection); snapshot frontend | §3.2 | Declarative scenarios in the corpus; loader rejection tests |
+| 7 | Frontends: shadow-DB SQL loader (fail-safe ordering, body validation, cluster isolation, DML detection); snapshot frontend | §3.2 | Declarative scenarios in the corpus; loader detection/exemption tests |
 | 8 | Policy layer: DSL v2 over facts/deltas; Supabase integration as a data package with platform baseline | §3.9 | Policy scenarios; baseline-subtraction proof against a real platform image |
 | 9 | Renames (leaf + structural-rollup matching, policy-gated); declarative export; drift detection surfaced; public API and CLI finalized | §4.1, §4.2, §4.5 | Rename corpus; export round-trip `load(export(fb)) ≡ fb`; API review |
 | 10 | **Cutover at the parity bar**: full corpus green; differential clean-or-explained; generative soak quota met; extractor ring green on all supported PG versions. Old library enters maintenance; consumer migration guide ships | — | The parity bar itself |

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -551,6 +551,7 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
       "restrict-to-applier": { type: "boolean" },
       "strict-coverage": { type: "boolean" },
       "strict-function-bodies": { type: "boolean" },
+      "strict-data-statements": { type: "boolean" },
       "no-reorder": { type: "boolean" },
       "unsafe-show-secrets": { type: "boolean" },
       "isolated-shadow": { type: "boolean" },
@@ -569,7 +570,7 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
       throw new UsageError(
         `${err.message}\nUsage: pgdelta schema apply --dir <dir> --target <pg-url> [--shadow <pg-url>] ` +
           `[--renames auto|prompt|off] [--force] [--accept-rename <from>=<to>] ... ` +
-          `[--profile ${PROFILE_IDS}] [--restrict-to-applier] [--strict-coverage] [--strict-function-bodies] [--no-reorder] [--unsafe-show-secrets] [--isolated-shadow] [--scope database|cluster] [--skip-cluster-ddl] [--keep-shadow] [--allow-data-loss] ` +
+          `[--profile ${PROFILE_IDS}] [--restrict-to-applier] [--strict-coverage] [--strict-function-bodies] [--strict-data-statements] [--no-reorder] [--unsafe-show-secrets] [--isolated-shadow] [--scope database|cluster] [--skip-cluster-ddl] [--keep-shadow] [--allow-data-loss] ` +
           `[--trusted-local-host <hostname>]... [--allow-remote-shadow]\n` +
           `  [--dry-run] (print the portable apply script to stdout; apply nothing; see pgdelta --help for execution requirements) [--verbose] (stream per-statement progress to stderr) [--out-plan <plan.json>] (write the plan artifact)\n` +
           `  --shadow omitted: a co-located shadow database is created on the target's cluster (database scope only) and dropped after.`,
@@ -838,6 +839,7 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
         restrictToApplier: flags["restrict-to-applier"],
       },
       strictFunctionBodies: flags["strict-function-bodies"] === true,
+      strictDataStatements: flags["strict-data-statements"] === true,
       reorder: !flags["no-reorder"],
       onWarning: (message) => {
         if (message.startsWith("the directory records no default owner")) {

--- a/packages/pg-delta/src/cli/main.ts
+++ b/packages/pg-delta/src/cli/main.ts
@@ -79,7 +79,7 @@ Commands:
                  [--group-patterns <json>] [--flat-schemas <csv>] [--no-group-partitions]
   schema apply   --dir <dir> [--shadow <pg-url>] --target <pg-url>
                  [--renames auto|prompt|off] [--force] [--allow-data-loss]
-                 [--scope database|cluster] [--isolated-shadow]
+                 [--scope database|cluster] [--isolated-shadow] [--strict-data-statements]
                  [--trusted-local-host <hostname>]... [--allow-remote-shadow]
                  [--accept-rename <from>=<to>] ... [--no-reorder]
                  [--dry-run] [--verbose] [--out-plan <plan.json>]
@@ -137,6 +137,13 @@ Notes:
     raw files at file granularity. Reorder is on by default — it splits files
     into one-statement units and topologically pre-sorts them so authoring
     order within a file no longer matters.
+  --strict-data-statements (schema apply): fail (instead of warn) when
+    declarative files leave rows in managed user tables. By default a
+    populated table observed after loading is either exempt (pre-existing
+    rows in --isolated-shadow mode, reported on the result) or downgraded to
+    a "data_statement" warning diagnostic, and the load proceeds with a
+    schema-only plan; this flag restores the fatal error (recommended for
+    CI).
   schema apply: the applied statements are planner-rendered atomic DDL, not
     the authored declarative SQL (the planner re-derives them from the
     catalog diff between the shadow and target states). --verbose shows every
@@ -193,7 +200,7 @@ Subcommands:
                  [--group-patterns <json>] [--flat-schemas <csv>] [--no-group-partitions]
   schema apply   --dir <dir> [--shadow <pg-url>] --target <pg-url>
                  [--renames auto|prompt|off] [--force] [--allow-data-loss]
-                 [--scope database|cluster] [--isolated-shadow]
+                 [--scope database|cluster] [--isolated-shadow] [--strict-data-statements]
                  [--trusted-local-host <hostname>]... [--allow-remote-shadow]
                  [--accept-rename <from>=<to>] ... [--no-reorder]
                  [--dry-run] [--verbose] [--out-plan <plan.json>]

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -6,7 +6,7 @@
  * - body validation: routines re-validated with checks ON after loading
  * - shared-object isolation: pg_roles + pg_auth_members snapshot before/after;
  *   leakage fails in "databaseScratch" mode (skipped in "isolatedCluster" mode)
- * - DML rejection: any user table containing rows fails, by observation
+ * - DML detection: any user table containing rows is reported, by observation
  *
  * ## Loader modes
  *
@@ -17,7 +17,9 @@
  * would pollute the shared catalog — this is called a "leak". The loader
  * snapshots pg_roles and pg_auth_members before loading and after; if the
  * sets differ, it throws a ShadowLoadError. Use this mode for typical CI /
- * tooling usage where one cluster hosts many test databases.
+ * tooling usage where one cluster hosts many test databases. The shadow must
+ * also be EMPTY before the load, and no managed table may hold pre-existing
+ * rows (`allowPreExistingRows` defaults to false here).
  *
  * ### "isolatedCluster"
  * The shadow database has its own dedicated PostgreSQL cluster (e.g. from
@@ -26,6 +28,26 @@
  * snapshot check is SKIPPED entirely; files that CREATE ROLE or GRANT role
  * memberships will load successfully. Use this mode when your SQL files
  * intentionally manage cluster-level state.
+ *
+ * A dedicated shadow is also allowed to be PRE-PROVISIONED: the Supabase CLI
+ * boots its platform services (auth, storage, realtime, …) against the shadow
+ * before any declarative SQL is loaded, so their migration bookkeeping tables
+ * already hold rows. `allowPreExistingRows` therefore defaults to TRUE in this
+ * mode: the loader snapshots WHICH managed tables are populated BEFORE the load
+ * and exempts exactly those from the post-load DML observation, silently (no
+ * diagnostic). Documented limitation: the snapshot keys on the qualified table
+ * NAME, never on row contents — the loader deliberately never compares data — so
+ * a table that was already populated stays exempt even if a declarative file
+ * inserts into it, and a drop+recreate of the same name remains exempt too.
+ *
+ * ## DML observation severity
+ * A managed non-extension table that holds rows the load cannot account for is a
+ * `data_statement` WARNING on {@link LoadResult.diagnostics} by default and the
+ * load PROCEEDS: Postgres accepted the rows, and pg-delta only ever diffs
+ * schema, so refusing to read the schema back would block every directory that
+ * carries incidental data. Set `strictDataStatements: true` (CLI
+ * `--strict-data-statements`) to restore the fatal `ShadowLoadError` for CI.
+ * Extension-owned relations (pg_depend deptype 'e') are always out of scope.
  */
 import type { Pool, PoolClient, QueryResult } from "pg";
 import type { Diagnostic } from "../core/diagnostic.ts";
@@ -444,6 +466,11 @@ export interface LoadResult {
   pgVersion: string;
   diagnostics: Diagnostic[];
   rounds: number;
+  /** Managed non-extension tables that already held rows BEFORE the load, as
+   *  `"schema"."table"`, and are therefore exempt from the post-load DML
+   *  observation. Empty unless `allowPreExistingRows` is in effect (it defaults
+   *  to true in `"isolatedCluster"` mode). */
+  preExistingPopulatedTables: string[];
 }
 
 export class ShadowLoadError extends Error {
@@ -552,6 +579,39 @@ async function restoreScratchClusterState(
   return diags;
 }
 
+/**
+ * Qualified (`"schema"."table"`) names of the managed non-extension tables that
+ * currently hold at least one row. This is the ONE query behind both the pre-load
+ * exemption snapshot and the post-load DML observation, so the exemption is exact
+ * string-set subtraction (identical scope, identical escaping).
+ *
+ * "Managed user table" must mean the SAME thing the diff path manages, so reuse
+ * the extraction scope predicate (USER_SCHEMA_FILTER drops pg_catalog /
+ * information_schema / pg_toast / pg_temp) and exclude extension-owned relations
+ * (pg_depend deptype 'e'). Otherwise a declarative file that installs an
+ * extension whose CREATE EXTENSION seeds internal config rows — or a platform
+ * object — is wrongly read as if the user wrote DML (P2).
+ */
+async function listPopulatedManagedTables(
+  db: Pick<PoolClient, "query">,
+): Promise<string[]> {
+  const tables = await db.query(`
+    SELECT n.nspname AS schema, c.relname AS name
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'r'
+      AND ${USER_SCHEMA_FILTER}
+      AND ${notExtensionMember("pg_class", "c.oid")}`);
+  const populated: string[] = [];
+  for (const row of tables.rows as { schema: string; name: string }[]) {
+    const qualified = `"${row.schema.replaceAll('"', '""')}"."${row.name.replaceAll('"', '""')}"`;
+    const r = await db.query(
+      `SELECT EXISTS (SELECT 1 FROM ${qualified} LIMIT 1) AS has`,
+    );
+    if ((r.rows[0] as { has: boolean }).has) populated.push(qualified);
+  }
+  return populated;
+}
+
 export async function loadSqlFiles(
   files: SqlFile[],
   shadow: Pool,
@@ -592,6 +652,29 @@ export async function loadSqlFiles(
      *  a routine in a seeded schema that is NOT an unchanged seed always throws
      *  (Codex #329), and an unchanged seeded routine always warns. */
     strictFunctionBodies?: boolean;
+    /** Tolerate rows that already existed in the shadow BEFORE this load
+     *  (default: `true` in `"isolatedCluster"` mode, `false` otherwise). A
+     *  dedicated shadow may be pre-provisioned by a platform — the Supabase CLI
+     *  boots auth / storage / realtime against it, and those services write their
+     *  own migration bookkeeping rows — long before declarative SQL is loaded.
+     *  When enabled the loader snapshots which managed non-extension tables are
+     *  populated before the load and exempts exactly those from the post-load DML
+     *  observation, silently; the exempted set is returned as
+     *  {@link LoadResult.preExistingPopulatedTables}. Exemption is by qualified
+     *  table NAME (no data comparison, ever), so a pre-populated table stays
+     *  exempt even if a declarative file inserts into it — an accepted limitation
+     *  of observing rather than parsing. */
+    allowPreExistingRows?: boolean;
+    /** Escalate the post-load DML observation back to a fatal error (default
+     *  `false`). By default a managed non-extension table holding rows the load
+     *  cannot account for is a loud `data_statement` WARNING and the load
+     *  proceeds: pg-delta only diffs schema, so incidental data cannot corrupt a
+     *  plan, and refusing to read the schema back would block every directory
+     *  that carries some. Set to `true` (CLI `--strict-data-statements`) to
+     *  restore the `ShadowLoadError` refusal for CI. Pre-existing rows exempted
+     *  by `allowPreExistingRows` are never escalated — they are not observed at
+     *  all. */
+    strictDataStatements?: boolean;
   } = {},
 ): Promise<LoadResult> {
   // Rounds scale with dependency DEPTH, not file count: each round resolves
@@ -614,6 +697,14 @@ export async function loadSqlFiles(
   const seededSchemas = options.seededSchemas ?? [];
   const seededRoutines = options.seededRoutines;
   const strictFunctionBodies = options.strictFunctionBodies ?? false;
+  const strictDataStatements = options.strictDataStatements ?? false;
+  // A dedicated (isolatedCluster) shadow may legitimately arrive pre-provisioned
+  // with a platform baseline whose services already wrote bookkeeping rows — the
+  // Supabase CLI declarative seam. A co-located scratch database never can (the
+  // emptiness guard below already forbids it), so default the tolerance to the
+  // mode and let an explicit option override either way.
+  const allowPreExistingRows =
+    options.allowPreExistingRows ?? mode === "isolatedCluster";
   // isolatedCluster shadows may already carry a platform baseline (e.g. the
   // Supabase CLI declarative seam). The empty guard is for co-located scratch
   // databases only — requiring emptiness there prevents accidental loads into
@@ -632,6 +723,16 @@ export async function loadSqlFiles(
       throw new ShadowLoadError("shadow database is not empty", []);
     }
   }
+
+  // Snapshot which managed tables ALREADY hold rows, before a single file runs
+  // (mirrors the rolesBefore / membershipsBefore snapshots below). Those tables
+  // are fully exempt from the post-load DML observation: their rows pre-date the
+  // declarative files, so attributing them to the user's SQL would be wrong.
+  // Exemption is exact string-set subtraction against the identical query.
+  const preExistingPopulatedTables = allowPreExistingRows
+    ? await listPopulatedManagedTables(shadow)
+    : [];
+  const preExistingPopulatedSet = new Set(preExistingPopulatedTables);
 
   // reject files that manage their own transaction (review finding 6): an
   // explicit COMMIT/BEGIN/SAVEPOINT/… would break the per-file atomic wrapper
@@ -703,6 +804,8 @@ export async function loadSqlFiles(
   // body-validation warnings for SEEDED-schema routines (populated below,
   // outside the try/finally so the final result can merge them in).
   let seededBodyWarnings: Diagnostic[] = [];
+  // non-fatal `data_statement` observations (same lifetime rationale).
+  let dataStatementWarnings: Diagnostic[] = [];
   // the most recent round's per-file failures, retained so a budget-exhaustion
   // error can report WHY each still-pending file failed (review P1 #2).
   let lastFailures: Array<{ file: SqlFile; message: string }> = [];
@@ -1047,36 +1150,30 @@ export async function loadSqlFiles(
     }
     seededBodyWarnings = bodyWarnings;
 
-    // DML rejection by observation: any MANAGED USER table with rows fails.
-    // "User table" must mean the SAME thing the diff path manages, so reuse the
-    // extraction scope predicate (USER_SCHEMA_FILTER drops pg_catalog /
-    // information_schema / pg_toast / pg_temp) and exclude extension-owned
-    // relations (pg_depend deptype 'e'). Otherwise a declarative file that
-    // installs an extension whose CREATE EXTENSION seeds internal config rows —
-    // or a platform object — is wrongly rejected as if the user wrote DML (P2).
-    const tables = await client.query(`
-      SELECT n.nspname AS schema, c.relname AS name
-      FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE c.relkind = 'r'
-        AND ${USER_SCHEMA_FILTER}
-        AND ${notExtensionMember("pg_class", "c.oid")}`);
-    const populated: string[] = [];
-    for (const row of tables.rows as { schema: string; name: string }[]) {
-      const qualified = `"${row.schema.replaceAll('"', '""')}"."${row.name.replaceAll('"', '""')}"`;
-      const r = await client.query(
-        `SELECT EXISTS (SELECT 1 FROM ${qualified} LIMIT 1) AS has`,
-      );
-      if ((r.rows[0] as { has: boolean }).has) populated.push(qualified);
-    }
+    // DML observation: report every MANAGED USER table that holds rows, minus the
+    // tables that already held rows before the load (see the pre-load snapshot).
+    // Tables exempted there are dropped SILENTLY — their rows are not the user's
+    // DML, so there is nothing to tell the caller about.
+    const populated = (await listPopulatedManagedTables(client)).filter(
+      (t) => !preExistingPopulatedSet.has(t),
+    );
     if (populated.length > 0) {
-      throw new ShadowLoadError(
-        `declarative files must not contain data statements — rows found in managed user table(s): ${populated.join(", ")}`,
-        populated.map((t) => ({
-          code: "data_statement",
-          severity: "error",
-          message: `managed user table ${t} contains rows after loading the declarative files`,
-        })),
-      );
+      // FATAL only under the strictDataStatements opt-in. By default this is a
+      // loud warning and the load proceeds: pg-delta diffs schema only, so rows
+      // in the shadow cannot corrupt the plan, and refusing to read the schema
+      // back would block every directory that carries incidental data.
+      const details: Diagnostic[] = populated.map((t) => ({
+        code: "data_statement",
+        severity: strictDataStatements ? "error" : "warning",
+        message: `managed user table ${t} contains rows after loading the declarative files`,
+      }));
+      if (strictDataStatements) {
+        throw new ShadowLoadError(
+          `declarative files must not contain data statements — rows found in managed user table(s): ${populated.join(", ")}`,
+          details,
+        );
+      }
+      dataStatementWarnings = details;
     }
   } catch (err) {
     // Best-effort containment of any cluster-level leak that committed before the
@@ -1133,8 +1230,13 @@ export async function loadSqlFiles(
   return {
     factBase,
     pgVersion: result.pgVersion,
-    diagnostics: [...result.diagnostics, ...seededBodyWarnings],
+    diagnostics: [
+      ...result.diagnostics,
+      ...seededBodyWarnings,
+      ...dataStatementWarnings,
+    ],
     rounds,
+    preExistingPopulatedTables,
   };
 }
 

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -234,6 +234,12 @@ export interface PlanSchemaFilesOptions {
   acceptRenames?: Array<{ from: StableId; to: StableId }>;
   resolveOptions?: Omit<ResolveProfileOptions, "redactSecrets">;
   strictFunctionBodies?: boolean;
+  /** Exempt managed tables that already held rows before the shadow load from the
+   *  DML observation. Left undefined the loader picks its own default (true for an
+   *  isolated shadow, which may be pre-provisioned by a platform). */
+  allowPreExistingRows?: boolean;
+  /** Make the shadow load's DML observation fatal again (default: warning). */
+  strictDataStatements?: boolean;
   /** Statement-reorder assist. Default: true. */
   reorder?: boolean;
   /** Soft warnings (reorder fallback, ADP caveat, …). */
@@ -557,6 +563,11 @@ export async function planSchemaFiles(
       extract: (p, o) => ctx.extract(p, { ...o, redactSecrets }),
       ...(seededSchemas.length > 0 ? { seededSchemas, seededRoutines } : {}),
       strictFunctionBodies: options.strictFunctionBodies === true,
+      strictDataStatements: options.strictDataStatements === true,
+      // undefined = let the loader default it from the mode
+      ...(options.allowPreExistingRows !== undefined
+        ? { allowPreExistingRows: options.allowPreExistingRows }
+        : {}),
       ...(options.isolatedShadow === true
         ? { mode: "isolatedCluster" as const }
         : {}),

--- a/packages/pg-delta/tests/load-sql-files-extension-rows.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-extension-rows.test.ts
@@ -86,6 +86,9 @@ describe("loadSqlFiles: extension-owned internal rows are not DML", () => {
         },
       ],
       shadow.pool,
+      // the DML gate is a warning by default; assert the fatal path still scopes
+      // the rejection to the USER table and never to partman.part_config.
+      { strictDataStatements: true },
     ).then(
       () => null,
       (e: unknown) => e,

--- a/packages/pg-delta/tests/load-sql-files.test.ts
+++ b/packages/pg-delta/tests/load-sql-files.test.ts
@@ -197,7 +197,7 @@ describe("loadSqlFiles (shadow frontend)", () => {
     }
   }, 60_000);
 
-  test("DML is rejected by observation, not parsing", async () => {
+  test("DML is rejected by observation, not parsing (under strictDataStatements)", async () => {
     const shadow = await createTestDb("shadow");
     try {
       const error = await captureError(
@@ -209,10 +209,74 @@ describe("loadSqlFiles (shadow frontend)", () => {
             },
           ],
           shadow.pool,
+          // the DML gate is a WARNING by default now; the fatal throw is gated
+          // on the strictDataStatements opt-in.
+          { strictDataStatements: true },
         ),
       );
       expect(error).toBeInstanceOf(ShadowLoadError);
       expect(String(error)).toMatch(/data statements/);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("DML in a managed user table is a warning by default, not a failure", async () => {
+    const shadow = await createTestDb("shadow_dml_warn");
+    try {
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "schema.sql",
+            sql: "CREATE TABLE public.example (id integer); INSERT INTO public.example VALUES (1);",
+          },
+        ],
+        shadow.pool,
+      );
+      // the load SUCCEEDS: Postgres accepted the rows, and refusing to read the
+      // schema back would block every directory that carries incidental data.
+      expect(
+        result.factBase.has({
+          kind: "table",
+          schema: "public",
+          name: "example",
+        }),
+      ).toBe(true);
+      const dml = result.diagnostics.filter((d) => d.code === "data_statement");
+      expect(dml).toHaveLength(1);
+      expect(dml[0]?.severity).toBe("warning");
+      expect(dml[0]?.message).toContain(`"public"."example"`);
+      expect(dml[0]?.message).toContain("contains rows");
+      // nothing was pre-existing in a fresh scratch shadow
+      expect(result.preExistingPopulatedTables).toEqual([]);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("strictDataStatements restores the fatal DML gate", async () => {
+    const shadow = await createTestDb("shadow_dml_strict");
+    try {
+      const error = await captureError(
+        loadSqlFiles(
+          [
+            {
+              name: "schema.sql",
+              sql: "CREATE TABLE public.example (id integer); INSERT INTO public.example VALUES (1);",
+            },
+          ],
+          shadow.pool,
+          { strictDataStatements: true },
+        ),
+      );
+      expect(error).toBeInstanceOf(ShadowLoadError);
+      expect(String(error)).toMatch(/data statements/);
+      const detail = (error as ShadowLoadError).details.find(
+        (d) => d.code === "data_statement",
+      );
+      expect(detail).toBeDefined();
+      expect(detail?.severity).toBe("error");
+      expect(detail?.message).toContain(`"public"."example"`);
     } finally {
       await shadow.drop();
     }
@@ -316,6 +380,115 @@ describe("loadSqlFiles (shadow frontend)", () => {
       await shadow.drop();
     }
   }, 60_000);
+
+  test("isolatedCluster mode: rows that pre-date the load are exempt from the DML check", async () => {
+    // The Supabase CLI hands pg-delta a dedicated shadow whose platform services
+    // (auth, storage, realtime, …) have ALREADY bootstrapped their own migration
+    // bookkeeping before any declarative SQL is loaded. Those rows are not user
+    // DML, so an isolatedCluster load snapshots which managed tables are already
+    // populated and exempts exactly those — silently, no diagnostic.
+    const [clusterA] = await isolatedClusterPair();
+    const shadow = await clusterA.createDb("shadow_preseeded");
+    try {
+      await shadow.pool.query(`
+        CREATE SCHEMA auth;
+        CREATE TABLE auth.schema_migrations (version text PRIMARY KEY);
+        INSERT INTO auth.schema_migrations VALUES ('20240101000000');
+      `);
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "app.sql",
+            sql: "CREATE TABLE public.widgets (id integer PRIMARY KEY);",
+          },
+        ],
+        shadow.pool,
+        { mode: "isolatedCluster" },
+      );
+      expect(
+        result.diagnostics.filter((d) => d.code === "data_statement"),
+      ).toEqual([]);
+      expect(result.preExistingPopulatedTables).toContain(
+        `"auth"."schema_migrations"`,
+      );
+      expect(
+        result.factBase.has({
+          kind: "table",
+          schema: "public",
+          name: "widgets",
+        }),
+      ).toBe(true);
+    } finally {
+      await shadow.drop();
+    }
+  }, 90_000);
+
+  test("isolatedCluster mode: a declarative INSERT into an already-populated table is tolerated (accepted name-based gap)", async () => {
+    // ACCEPTED / APPROVED LIMITATION: the exemption keys on the qualified table
+    // NAME captured before the load, never on the row contents — the loader
+    // deliberately never compares data. So once a table is exempt, rows a
+    // declarative file adds to THAT table are invisible to the check, and a
+    // drop+recreate of the same name stays exempt too. The alternative (row-level
+    // comparison) is explicitly out of scope.
+    const [clusterA] = await isolatedClusterPair();
+    const shadow = await clusterA.createDb("shadow_preseeded_dml");
+    try {
+      await shadow.pool.query(`
+        CREATE SCHEMA auth;
+        CREATE TABLE auth.schema_migrations (version text PRIMARY KEY);
+        INSERT INTO auth.schema_migrations VALUES ('20240101000000');
+      `);
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "dml.sql",
+            sql: "INSERT INTO auth.schema_migrations VALUES ('20250101000000');",
+          },
+        ],
+        shadow.pool,
+        { mode: "isolatedCluster" },
+      );
+      expect(
+        result.diagnostics.filter((d) => d.code === "data_statement"),
+      ).toEqual([]);
+      expect(result.preExistingPopulatedTables).toContain(
+        `"auth"."schema_migrations"`,
+      );
+    } finally {
+      await shadow.drop();
+    }
+  }, 90_000);
+
+  test("isolatedCluster mode: a table populated only BY the load still warns", async () => {
+    // The exemption covers pre-existing rows only: a managed table that was
+    // EMPTY before the load and has rows after it is still reported (warning),
+    // so genuine DML in declarative files stays visible even in a pre-seeded
+    // isolated shadow.
+    const [clusterA] = await isolatedClusterPair();
+    const shadow = await clusterA.createDb("shadow_preseeded_new");
+    try {
+      await shadow.pool.query(`
+        CREATE SCHEMA auth;
+        CREATE TABLE auth.schema_migrations (version text PRIMARY KEY);
+        INSERT INTO auth.schema_migrations VALUES ('20240101000000');
+      `);
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "app.sql",
+            sql: "CREATE TABLE public.widgets (id integer PRIMARY KEY); INSERT INTO public.widgets VALUES (1);",
+          },
+        ],
+        shadow.pool,
+        { mode: "isolatedCluster" },
+      );
+      const dml = result.diagnostics.filter((d) => d.code === "data_statement");
+      expect(dml).toHaveLength(1);
+      expect(dml[0]?.message).toContain(`"public"."widgets"`);
+    } finally {
+      await shadow.drop();
+    }
+  }, 90_000);
 
   test("isolatedCluster mode: same role-creating file FAILS in databaseScratch mode and leaks no role", async () => {
     const shadow = await createTestDb("shadow_scratch");

--- a/packages/pg-delta/tests/schema-frontends.test.ts
+++ b/packages/pg-delta/tests/schema-frontends.test.ts
@@ -20,7 +20,7 @@ import {
   type SqlFile,
 } from "../src/frontends/index.ts";
 import { rawProfile } from "../src/integrations/index.ts";
-import { sharedCluster } from "./containers.ts";
+import { isolatedClusterPair, sharedCluster } from "./containers.ts";
 
 const SCHEMA_SQL = `
   CREATE SCHEMA app;
@@ -151,6 +151,43 @@ describe("public schema frontends", () => {
       await cluster.dropRolesExcept(rolesBefore, { strict: true });
     }
   }, 90_000);
+
+  test("planSchemaFiles tolerates a pre-provisioned isolated shadow (Supabase CLI seam)", async () => {
+    // End-to-end shape of the Supabase CLI's declarative flow: the isolated
+    // shadow is pre-provisioned with the platform baseline (schemas + the
+    // services' own migration rows) BEFORE declarative SQL is loaded. The
+    // baseline exists on the target too, so with identical schema intent on both
+    // sides the plan must be EMPTY — the pre-existing rows must neither fail the
+    // load nor leak into the diff.
+    const [clusterA, clusterB] = await isolatedClusterPair();
+    const target = await clusterA.createDb("frontend_preseeded_target");
+    const shadow = await clusterB.createDb("frontend_preseeded_shadow");
+    try {
+      const BASELINE_DDL = `
+        CREATE SCHEMA auth;
+        CREATE TABLE auth.schema_migrations (version text PRIMARY KEY);
+      `;
+      await target.pool.query(BASELINE_DDL + SCHEMA_SQL);
+      await shadow.pool.query(
+        `${BASELINE_DDL} INSERT INTO auth.schema_migrations VALUES ('20240101000000');`,
+      );
+
+      // the declarative directory carries USER schema only; the baseline is
+      // pre-provisioned on both sides (exactly how the CLI drives this).
+      const files: SqlFile[] = [{ name: "app.sql", sql: SCHEMA_SQL }];
+      const planned = await planSchemaFiles(target.pool, shadow.pool, files, {
+        profile: rawProfile,
+        scope: "database",
+        isolatedShadow: true,
+      });
+      expect(planned.plan.actions).toEqual([]);
+      expect(
+        planned.loadDiagnostics.filter((d) => d.code === "data_statement"),
+      ).toEqual([]);
+    } finally {
+      await Promise.all([target.drop(), shadow.drop()]);
+    }
+  }, 120_000);
 
   test("planSchemaFiles permits a non-isolated database-scope sibling from the same lineage", async () => {
     const cluster = await sharedCluster();


### PR DESCRIPTION
## Problem

The Supabase CLI's next pg-delta seam provisions two isolated clusters (A: baseline + migrations, B: baseline + declarative SQL) and calls `planSchemaFiles(..., { isolatedShadow: true, seedAssumedSchemas: false })`. Cluster B is set up via `SetupShadowDatabase`, whose service migrations legitimately insert bootstrap rows into `auth.schema_migrations`, `storage.migrations`, `realtime.schema_migrations`, `_realtime.{schema_migrations,extensions,tenants}`, `supabase_functions.migrations` **before** any declarative SQL loads.

`loadSqlFiles`'s post-load DML observation rejected ANY managed non-extension table containing rows, so planning failed with:

```
declarative files must not contain data statements — rows found in managed user table(s): "_realtime"."extensions", "_realtime"."tenants", "auth"."schema_migrations", ...
```

It was the only loader check that was mode-blind: `isolatedCluster` already tolerates pre-existing schema **objects** (emptiness guard skipped) but not pre-existing **rows** in them.

## Design (agreed policy)

1. **Table-level exemption for pre-existing rows.** New loader option `allowPreExistingRows` (default `true` when `mode === "isolatedCluster"`, `false` otherwise). The loader snapshots which managed non-extension tables are populated **before** the load (same query/escaping as the post-load observation) and exempts exactly those tables afterward — silently. The exempted set is exposed as `LoadResult.preExistingPopulatedTables`. Exemption is by qualified name only; the loader never diffs row contents, so a declarative `INSERT` into an already-populated baseline table is an accepted, documented gap.
2. **Warning by default, fatal under strict.** A non-exempt populated table now appends a `data_statement` diagnostic (`severity: "warning"`) to `LoadResult.diagnostics` and the load proceeds — pg-delta only diffs schema, so incidental data cannot corrupt a plan. New `strictDataStatements` option (loader + `planSchemaFiles` + `--strict-data-statements` CLI flag) restores the previous fatal `ShadowLoadError`.
3. **Extension-owned catalogs** (e.g. `cron.job`) remain exempt exactly as before; platform bootstrap rows stay entirely outside comparison semantics (no data diffing added).

## RED → GREEN

Commit 21c3c6f6 carries the regression tests only; against unmodified code the focused run failed as expected (`1005 pass, 5 fail`), every failure being:

```
ShadowLoadError: declarative files must not contain data statements — rows found in managed user table(s): "auth"."schema_migrations"
```

After the production change (0138aa9b): focused integration + full unit suite `1012 pass, 0 fail, 116 files`; supabase-image extension-rows file `2 pass`; `format-and-lint`, `check-types` clean. (`knip` exits 1 on pre-existing unused-export debt on this branch, untouched by this PR.)

New coverage: preloaded isolated shadow loads schema-only files cleanly and reports the exempt set; newly populated table warns by default and throws under strict; a table populated only *by* the load still warns even in a pre-seeded shadow; declarative INSERT into a pre-populated table is silent (pins the accepted gap); e2e `planSchemaFiles` over an isolated pair with baseline rows on both sides produces an **empty plan**.

Note: stacked PRs into `feat/pg-delta-next` get no test CI — the local runs above are the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)