### PR TITLE
fix(pg-delta): emit check_function_bodies preamble only for routine-touching plans

### DIFF
--- a/.changeset/conditional-check-function-bodies.md
+++ b/.changeset/conditional-check-function-bodies.md
@@ -6,9 +6,9 @@ Plans (and therefore rendered migration files) only carry
 `check_function_bodies = off` in their session preamble when the plan actually
 touches a routine-family object — a function, procedure, aggregate, extension,
 or extension intent, directly or through a satellite (comment / grant /
-security label) or a reference (e.g. a trigger's function). A migration that
-only touches tables, columns, indexes, or grants no longer starts with a
-`set local check_function_bodies = off;` it cannot need.
+security label). A migration that only touches tables, columns, indexes,
+grants, or triggers (`CREATE TRIGGER` never validates its function's body) no
+longer starts with a `set local check_function_bodies = off;` it cannot need.
 
 The predicate deliberately errs toward keeping the entry, and the omission is
 part of the cosmetic compaction contract: planning with `compact: false`

--- a/.changeset/conditional-check-function-bodies.md
+++ b/.changeset/conditional-check-function-bodies.md
@@ -1,0 +1,15 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Plans (and therefore rendered migration files) only carry
+`check_function_bodies = off` in their session preamble when the plan actually
+touches a routine-family object — a function, procedure, aggregate, extension,
+or extension intent, directly or through a satellite (comment / grant /
+security label) or a reference (e.g. a trigger's function). A migration that
+only touches tables, columns, indexes, or grants no longer starts with a
+`set local check_function_bodies = off;` it cannot need.
+
+The predicate deliberately errs toward keeping the entry, and the omission is
+part of the cosmetic compaction contract: planning with `compact: false`
+restores the unconditional preamble.

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -796,9 +796,9 @@ is imported as data and SQL; none of its *mechanisms* — and none of its
   `LANGUAGE SQL` bodies are opaque to Postgres's dependency tracking (only
   SQL-standard `BEGIN ATOMIC` bodies get edges), so the graph cannot order
   a routine after a table its body references. The strategy is layered:
-  plans run with `check_function_bodies = off` (the diff path already
-  emits this —
-  `create.ts:350`); PL/pgSQL
+  routine-touching plans run with `check_function_bodies = off` (a
+  preamble entry, omitted as a cosmetic compaction when no
+  routine-family object is involved — `src/plan/preamble.ts`); PL/pgSQL
   is late-bound at runtime, so missing edges rarely matter for it;
   SQL-language ordering gaps surface in the proof loop as a failed clone
   apply — before production, not in it; and the dev layer (§4.4) can lint

--- a/packages/pg-delta/MIGRATION.md
+++ b/packages/pg-delta/MIGRATION.md
@@ -61,7 +61,10 @@ you WILL see against old-engine output:
    of the new value). Mid-plan failure reporting tells you exactly
    which actions are applied/unapplied/in doubt.
 5. Plans never contain `SET check_function_bodies` statements — session
-   settings ride in `plan.preamble`.
+   settings ride in `plan.preamble`. The `check_function_bodies = off`
+   entry appears there only when the plan touches a routine-family
+   object (function / procedure / aggregate / extension); planning with
+   `compact: false` restores it unconditionally.
 
 Accepted differences (each is deliberate; none changes converged
 state): decomposed-then-compacted statement shapes (1), ACL

--- a/packages/pg-delta/corpus/function-ops--sql-body-cross-reference/b.sql
+++ b/packages/pg-delta/corpus/function-ops--sql-body-cross-reference/b.sql
@@ -3,8 +3,9 @@ CREATE SCHEMA test_schema;
 -- z_helper_parse is created first so the b.sql FIXTURE applies cleanly under the
 -- default check_function_bodies. The point of the scenario: a_wrapper's
 -- string-literal SQL body calls z_helper_parse but records NO pg_depend edge, so
--- the engine cannot topologically order the two functions and must rely on its
--- unconditional check_function_bodies=off plan preamble to converge (a->b/b->a).
+-- the engine cannot topologically order the two functions and must rely on the
+-- check_function_bodies=off plan preamble (always emitted for routine-touching
+-- plans like this one) to converge (a->b/b->a).
 CREATE OR REPLACE FUNCTION test_schema.z_helper_parse(input text)
  RETURNS text
  LANGUAGE sql

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -50,7 +50,7 @@ export type SubEntityKind = (typeof SUBENTITY_KINDS)[number];
  *  functions and procedures DIFFERENT DDL address syntax (COMMENT/GRANT/SECURITY
  *  LABEL ON FUNCTION vs ON PROCEDURE), so they are distinct id kinds — the
  *  renderer must never infer the address grammar from a payload field. */
-const ROUTINE_KINDS = ["function", "procedure", "aggregate"] as const;
+export const ROUTINE_KINDS = ["function", "procedure", "aggregate"] as const;
 export type RoutineKind = (typeof ROUTINE_KINDS)[number];
 
 export type StableId =

--- a/packages/pg-delta/src/frontends/render-plan-files.ts
+++ b/packages/pg-delta/src/frontends/render-plan-files.ts
@@ -95,7 +95,8 @@ export function renderPlanFiles(
     // migration. apply() keeps the pin on its own connection (no third-party
     // bookkeeping shares it). check_function_bodies is retained — function
     // bodies may legitimately need it and it does not affect name resolution of
-    // the runner's insert.
+    // the runner's insert. (The planner only puts it in the preamble when the
+    // plan touches a routine-family object — src/plan/preamble.ts.)
     //
     // Scope the remaining settings so a reused runner session (sequential
     // migration runners share a connection) does not silently inherit them —

--- a/packages/pg-delta/src/plan/plan.guard.test.ts
+++ b/packages/pg-delta/src/plan/plan.guard.test.ts
@@ -41,6 +41,10 @@ const KIND_LITERAL_BASELINE: Readonly<Record<string, number>> = {
   "phases/change-set.ts": 4,
   "phases/replacement-expansion.ts": 0,
   "plan.ts": 7,
+  // preamble.ts classifies actions into "routine-family or not" for the
+  // cosmetic check_function_bodies compaction; the routine kinds themselves
+  // come from core ROUTINE_KINDS, leaving only the two extension literals.
+  "preamble.ts": 2,
   "project.ts": 0,
   "renames.ts": 0,
   "render-sql.ts": 0,

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -15,6 +15,7 @@ import {
 import type { ManagementScope } from "../policy/view.ts";
 import { emitActions } from "./phases/action-emitter.ts";
 import { finalizeActions } from "./phases/action-graph.ts";
+import { needsCheckFunctionBodiesOff } from "./preamble.ts";
 import { buildChangeSet } from "./phases/change-set.ts";
 import { expandReplacements } from "./phases/replacement-expansion.ts";
 import type { LockClass } from "./locks.ts";
@@ -569,7 +570,15 @@ export function plan(
       // applier role's default search_path. Extraction canonicalizes to the
       // same path, so every emitted statement target is already qualified.
       { name: "search_path", value: "pg_catalog" },
-      { name: "check_function_bodies", value: "off" },
+      // check_function_bodies=off lets quoted routine bodies elaborate lazily
+      // (the planner records no body-dependency edges — rules/helpers.ts).
+      // Omitting it when no action touches a routine-family object is a
+      // cosmetic compaction pass (./preamble.ts); compact:false restores the
+      // unconditional preamble as the conservative opt-out.
+      ...(options?.compact === false ||
+      needsCheckFunctionBodiesOff(finalActions)
+        ? [{ name: "check_function_bodies", value: "off" }]
+        : []),
     ],
     deltas,
     filteredDeltas,

--- a/packages/pg-delta/src/plan/preamble.test.ts
+++ b/packages/pg-delta/src/plan/preamble.test.ts
@@ -107,6 +107,25 @@ describe("conditional check_function_bodies preamble", () => {
     ]);
   });
 
+  test("a trigger-only plan omits check_function_bodies (references never define bodies)", () => {
+    // the function pre-exists on both sides; only the trigger is added. Its
+    // create consumes the parent table — the function reference is a fact
+    // edge, never an action id — and CREATE TRIGGER does not validate the
+    // function's body, so the entry is deliberately omitted (Codex PR #386).
+    const trgFact: Fact = {
+      id: { kind: "trigger", schema: "app", table: "t", name: "trg" },
+      parent: tableId,
+      payload: {
+        def: `CREATE TRIGGER trg BEFORE INSERT ON app.t FOR EACH ROW EXECUTE FUNCTION app.f()`,
+        enabled: "O",
+      },
+    };
+    const both = [tableFact, colFact, fnFact];
+    const thePlan = plan(base(both), base([...both, trgFact]));
+    expect(thePlan.actions.length).toBeGreaterThan(0);
+    expect(preambleNames(thePlan)).toEqual(["search_path"]);
+  });
+
   test("an empty plan omits check_function_bodies", () => {
     const thePlan = plan(
       base([tableFact, colFact]),

--- a/packages/pg-delta/src/plan/preamble.test.ts
+++ b/packages/pg-delta/src/plan/preamble.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The preamble's `check_function_bodies = off` entry is governed by the
+ * cosmetic compaction contract (§3.6): a compacted plan (the default) carries
+ * it only when the plan touches a routine-family object — function, procedure,
+ * aggregate, extension, or extension intent, directly or through a satellite —
+ * and `compact: false` restores the unconditional preamble as the opt-out.
+ * The `search_path` pin is always present. Pure — no DB.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import type { StableId } from "../core/stable-id.ts";
+import { plan } from "./plan.ts";
+import { renderPlanSql } from "./render-sql.ts";
+
+const schemaId: StableId = { kind: "schema", name: "app" };
+const schemaFact: Fact = { id: schemaId, payload: { owner: "test" } };
+
+const tableId: StableId = { kind: "table", schema: "app", name: "t" };
+const tableFact: Fact = {
+  id: tableId,
+  parent: schemaId,
+  payload: { owner: "test", persistence: "p" },
+};
+const colFact: Fact = {
+  id: { kind: "column", schema: "app", table: "t", name: "n" },
+  parent: tableId,
+  payload: {
+    type: "integer",
+    notNull: false,
+    collation: null,
+    generatedExpr: null,
+  },
+};
+
+const fnId: StableId = { kind: "function", schema: "app", name: "f", args: [] };
+const fnFact: Fact = {
+  id: fnId,
+  parent: schemaId,
+  payload: {
+    def: `CREATE FUNCTION "app"."f"() RETURNS integer LANGUAGE sql AS $$SELECT 1$$`,
+  },
+};
+const fnCommentFact: Fact = {
+  id: { kind: "comment", target: fnId },
+  parent: fnId,
+  payload: { text: "a routine satellite" },
+};
+
+const base = (extra: Fact[]) => buildFactBase([schemaFact, ...extra], []);
+const preambleNames = (p: { preamble: { name: string }[] }) =>
+  p.preamble.map((s) => s.name);
+
+describe("conditional check_function_bodies preamble", () => {
+  test("a routine-free plan omits check_function_bodies (search_path retained)", () => {
+    const thePlan = plan(base([]), base([tableFact, colFact]));
+    expect(thePlan.actions.length).toBeGreaterThan(0);
+    expect(preambleNames(thePlan)).toEqual(["search_path"]);
+    expect(renderPlanSql(thePlan)).not.toContain("check_function_bodies");
+  });
+
+  test("compact: false restores the unconditional preamble (the opt-out)", () => {
+    const thePlan = plan(base([]), base([tableFact, colFact]), {
+      compact: false,
+    });
+    expect(preambleNames(thePlan)).toEqual([
+      "search_path",
+      "check_function_bodies",
+    ]);
+  });
+
+  test("creating a function keeps check_function_bodies = off", () => {
+    const thePlan = plan(base([]), base([fnFact]));
+    expect(preambleNames(thePlan)).toEqual([
+      "search_path",
+      "check_function_bodies",
+    ]);
+  });
+
+  test("dropping a function keeps check_function_bodies = off", () => {
+    const thePlan = plan(base([fnFact]), base([]));
+    expect(preambleNames(thePlan)).toEqual([
+      "search_path",
+      "check_function_bodies",
+    ]);
+  });
+
+  test("a satellite on a routine keeps check_function_bodies = off", () => {
+    // the function itself is identical on both sides — only its COMMENT is
+    // added, so the routine appears solely as a satellite target.
+    const thePlan = plan(base([fnFact]), base([fnFact, fnCommentFact]));
+    expect(thePlan.actions.length).toBeGreaterThan(0);
+    expect(preambleNames(thePlan)).toEqual([
+      "search_path",
+      "check_function_bodies",
+    ]);
+  });
+
+  test("creating an extension keeps check_function_bodies = off", () => {
+    const ext: Fact = {
+      id: { kind: "extension", name: "pgmq" },
+      payload: { schema: "pgmq", relocatable: false },
+    };
+    const thePlan = plan(base([]), base([ext]));
+    expect(preambleNames(thePlan)).toEqual([
+      "search_path",
+      "check_function_bodies",
+    ]);
+  });
+
+  test("an empty plan omits check_function_bodies", () => {
+    const thePlan = plan(base([tableFact, colFact]), base([tableFact, colFact]));
+    expect(thePlan.actions).toHaveLength(0);
+    expect(preambleNames(thePlan)).toEqual(["search_path"]);
+  });
+});

--- a/packages/pg-delta/src/plan/preamble.test.ts
+++ b/packages/pg-delta/src/plan/preamble.test.ts
@@ -108,7 +108,10 @@ describe("conditional check_function_bodies preamble", () => {
   });
 
   test("an empty plan omits check_function_bodies", () => {
-    const thePlan = plan(base([tableFact, colFact]), base([tableFact, colFact]));
+    const thePlan = plan(
+      base([tableFact, colFact]),
+      base([tableFact, colFact]),
+    );
     expect(thePlan.actions).toHaveLength(0);
     expect(preambleNames(thePlan)).toEqual(["search_path"]);
   });

--- a/packages/pg-delta/src/plan/preamble.ts
+++ b/packages/pg-delta/src/plan/preamble.ts
@@ -1,0 +1,63 @@
+/**
+ * Preamble compaction (§3.6): decide whether a plan needs
+ * `check_function_bodies = off` in its session preamble.
+ *
+ * The setting is load-bearing exactly when the plan defines quoted (plpgsql /
+ * string-literal SQL) routine bodies: the planner deliberately records no
+ * body-dependency edges for them (rules/helpers.ts `dependencyConsumes`), so a
+ * forward-referencing body only elaborates because validation is off. For a
+ * plan that touches no routine-family object the entry is pure noise, and
+ * omitting it is a cosmetic change under the compaction contract — proof
+ * results never differ, and `compact: false` restores the unconditional
+ * preamble as the conservative opt-out.
+ *
+ * The predicate errs toward keeping the entry ("rather have it than not"):
+ * it scans EVERY id an action mentions (produces / consumes / destroys /
+ * releases, satellites unwrapped to their target), so e.g. a CREATE TRIGGER
+ * that merely references a function still keeps the preamble. Kinds:
+ *   - function / procedure — the real cases (CREATE OR REPLACE with a body);
+ *   - aggregate — no body of its own, kept as routine-family insurance;
+ *   - extension / extensionIntent — extension scripts and intent replay run
+ *     arbitrary SQL (PostgreSQL forces check_function_bodies=off inside
+ *     CREATE EXTENSION scripts itself, so this is belt-and-braces).
+ */
+import {
+  ROUTINE_KINDS,
+  type FactKind,
+  type StableId,
+} from "../core/stable-id.ts";
+import type { Action } from "./plan.ts";
+
+const ROUTINE_FAMILY_KINDS: ReadonlySet<FactKind> = new Set<FactKind>([
+  ...ROUTINE_KINDS,
+  "extension",
+  "extensionIntent",
+]);
+
+/** A satellite id (comment / acl / securityLabel) addresses its target
+ *  object — unwrap to the base object the action actually touches. */
+function baseObjectKind(id: StableId): FactKind {
+  let current = id;
+  while ("target" in current) current = current.target;
+  return current.kind;
+}
+
+export function needsCheckFunctionBodiesOff(
+  actions: ReadonlyArray<
+    Pick<Action, "produces" | "consumes" | "destroys" | "releases">
+  >,
+): boolean {
+  for (const action of actions) {
+    for (const ids of [
+      action.produces,
+      action.consumes,
+      action.destroys,
+      action.releases,
+    ]) {
+      for (const id of ids) {
+        if (ROUTINE_FAMILY_KINDS.has(baseObjectKind(id))) return true;
+      }
+    }
+  }
+  return false;
+}

--- a/packages/pg-delta/src/plan/preamble.ts
+++ b/packages/pg-delta/src/plan/preamble.ts
@@ -13,8 +13,14 @@
  *
  * The predicate errs toward keeping the entry ("rather have it than not"):
  * it scans EVERY id an action mentions (produces / consumes / destroys /
- * releases, satellites unwrapped to their target), so e.g. a CREATE TRIGGER
- * that merely references a function still keeps the preamble. Kinds:
+ * releases, satellites unwrapped to their target). That is sufficient for
+ * every statement that can DEFINE a body — a routine create / replace /
+ * def-alter always carries its routine id in produces (and its depends
+ * targets in consumes, rules/routines.ts). A statement that merely
+ * REFERENCES a routine without its id in the action arrays (e.g. a table
+ * trigger, whose create consumes only its parent table — the function
+ * reference is a fact edge) does not keep the entry, deliberately:
+ * CREATE TRIGGER never validates the function's body. Kinds:
  *   - function / procedure — the real cases (CREATE OR REPLACE with a body);
  *   - aggregate — no body of its own, kept as routine-family insurance;
  *   - extension / extensionIntent — extension scripts and intent replay run

--- a/packages/pg-delta/src/plan/render-sql.ts
+++ b/packages/pg-delta/src/plan/render-sql.ts
@@ -3,7 +3,8 @@
  *
  * The output mirrors what `apply()` (src/apply/apply.ts) executes: the plan's
  * `preamble` session settings emitted as leading `SET`s (so forward-referencing
- * function bodies elaborate — `check_function_bodies = off` is always present),
+ * function bodies elaborate — `check_function_bodies = off` is present whenever
+ * the plan touches a routine-family object, see src/plan/preamble.ts),
  * then every action's SQL in `plan.actions` order (the dependency-sorted replay
  * order), each terminated with a single semicolon.
  *

--- a/packages/pg-delta/tests/compaction.test.ts
+++ b/packages/pg-delta/tests/compaction.test.ts
@@ -45,6 +45,17 @@ describe("compaction", () => {
         compact: false,
       });
 
+      // preamble compaction: RICH_SCHEMA has no routine-family object, so the
+      // compacted plan drops the check_function_bodies=off entry; compact:false
+      // keeps the unconditional preamble (the conservative opt-out). The proof
+      // below then demonstrates both plans converge identically without it.
+      expect(
+        compacted.preamble.some((s) => s.name === "check_function_bodies"),
+      ).toBe(false);
+      expect(
+        decomposed.preamble.some((s) => s.name === "check_function_bodies"),
+      ).toBe(true);
+
       // shape budget: the compacted plan folded the users columns
       expect(compacted.actions.length).toBeLessThan(decomposed.actions.length);
       const addColumns = compacted.actions.filter(


### PR DESCRIPTION
## Summary

Implements cosmetic preamble compaction for migration plans: the `check_function_bodies = off` session setting is now omitted from the plan preamble when the plan does not touch any routine-family objects (functions, procedures, aggregates, extensions, or extension intents). This reduces noise in generated migrations that only modify tables, columns, indexes, or grants.

The setting remains present when:
- The plan creates, drops, or modifies a function, procedure, or aggregate
- The plan creates or drops an extension (or replays an extension intent)
- The plan modifies a satellite (comment, grant, security label) on a routine
- Planning is invoked with `compact: false` (conservative opt-out)

A statement that merely *references* a routine without defining a body — e.g. `CREATE TRIGGER … EXECUTE FUNCTION` — deliberately does **not** keep the setting: trigger creation never validates the function's body, and only routine creates/replaces (which always carry their routine id in the action's `produces`) define bodies. This is pinned by a dedicated unit test (Codex review round 1).

This is a cosmetic change under the compaction contract: proof results never differ, validated by the proof gate in `tests/compaction.test.ts` and a full corpus run.

## Changes

- **New module `src/plan/preamble.ts`**: Exports `needsCheckFunctionBodiesOff()` predicate that scans all action ids (produces/consumes/destroys/releases) and returns true if any touch a routine-family object or extension. Unwraps satellite ids (comment/acl/securityLabel) to their target objects. Reuses core `ROUTINE_KINDS` (now exported from `stable-id.ts`).
- **New test file `src/plan/preamble.test.ts`**: RED-first regression suite covering omit/keep cases, the `compact: false` opt-out, and the trigger-only reference case.
- **Modified `src/plan/plan.ts`**: Conditionally includes `check_function_bodies = off` in the preamble based on `needsCheckFunctionBodiesOff(finalActions)` or `compact: false`.
- **Updated documentation and comments**: architecture docs, migration guide, render comments, and the `function-ops--sql-body-cross-reference` corpus scenario comment.
- **Updated integration test**: `tests/compaction.test.ts` now pins the preamble compaction under its cosmetic-by-contract proof gate.
- **Guard ratchet**: `plan.guard.test.ts` registers `preamble.ts` (2 kind literals).

## Linked issue

(No issue linked — this is a cosmetic improvement to the compaction contract.)

## Checklist

- [x] Tests added for the change (`src/plan/preamble.test.ts` + integration test update)
- [x] Changeset added (`.changeset/conditional-check-function-bodies.md`)
- [x] Code follows repository conventions (preamble.ts literal count updated in plan.guard.test.ts)

https://claude.ai/code/session_015none3B27xbnQyKPbFycD9