### PR TITLE
test(pg-delta): repair frontends preamble regression after conditional check_function_bodies

### DIFF
--- a/packages/pg-delta/tests/schema-frontends.test.ts
+++ b/packages/pg-delta/tests/schema-frontends.test.ts
@@ -224,7 +224,15 @@ describe("public schema frontends", () => {
     const source = await cluster.createDb("frontend_plan_src");
     const target = await cluster.createDb("frontend_plan_tgt");
     try {
-      await source.pool.query(SCHEMA_SQL);
+      // Include a routine so the plan carries the check_function_bodies
+      // preamble — the planner emits it only for routine-touching plans
+      // (src/plan/preamble.ts), and search_path is filtered from rendered
+      // files, so a table-only plan would render no settings at all.
+      await source.pool.query(`
+        ${SCHEMA_SQL}
+        CREATE FUNCTION app.item_count() RETURNS integer
+          LANGUAGE sql STABLE AS 'SELECT count(*)::integer FROM app.items';
+      `);
       const exported = await buildSchemaExport(source.pool, {
         profile: rawProfile,
         scope: "database",
@@ -253,10 +261,14 @@ describe("public schema frontends", () => {
         const rendered = renderPlanFiles(planned.plan, { allowDrops: true });
         expect(rendered.changes).toBe(true);
         expect(rendered.files.length).toBeGreaterThan(0);
+        // search_path is deliberately excluded from rendered files (dbmate
+        // appends an unqualified bookkeeping INSERT in the same transaction);
+        // the routine above guarantees check_function_bodies survives.
+        expect(
+          planned.plan.preamble.some((s) => s.name === "check_function_bodies"),
+        ).toBe(true);
         for (const file of rendered.files) {
-          if (planned.plan.preamble.length > 0) {
-            expect(file.contents).toContain("set ");
-          }
+          expect(file.contents).toContain("check_function_bodies = off;");
         }
 
         const report = await apply(planned.plan, target.pool, {


### PR DESCRIPTION
## Problem

#386 made the `check_function_bodies` preamble conditional on routine-touching plans, but the frontends integration regression `planSchemaFiles + renderPlanFiles preserve preamble and apply converges` (tests/schema-frontends.test.ts) still guarded its assertion on `plan.preamble.length > 0`. That guard now always fires (the preamble still carries `search_path`), while `renderPlanFiles` deliberately filters `search_path` out of rendered files (dbmate appends an unqualified bookkeeping INSERT in the same transaction) — so for the test's table-only plan the rendered file contains no `set ` at all and the test fails on `feat/pg-delta-next` @ e2c8c8c1. Stacked PRs get no test CI, so it slipped through; it surfaced while validating the #384 conflict resolution.

## Fix (test-only)

- Make the test's source schema routine-touching (adds `app.item_count()`), so the plan legitimately carries `check_function_bodies = off` and the render-path preamble coverage stays meaningful.
- Replace the now-vacuous length guard with explicit assertions: the plan preamble contains `check_function_bodies`, and every rendered file contains `check_function_bodies = off;`.

## RED → GREEN

RED on base (`e2c8c8c1`), unmodified test:

```
(fail) public schema frontends > planSchemaFiles + renderPlanFiles preserve preamble and apply converges
Expected to contain: "set "
```

GREEN with this change: `PGDELTA_TEST_POSTGRES_VERSIONS=17 bun run test --test-name-pattern "preserve preamble" tests/schema-frontends.test.ts` → 1 pass, 0 fail. Production behavior is untouched (it is correct); no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)