### PR TITLE
test(pg-delta): repair dbmate render test after conditional check_function_bodies

### DIFF
--- a/packages/pg-delta/tests/render-dbmate-searchpath.test.ts
+++ b/packages/pg-delta/tests/render-dbmate-searchpath.test.ts
@@ -29,10 +29,16 @@ describe("rendered migration files replay under a third-party runner (dbmate)", 
     empty = await createTestDb("dbmate_empty");
     populated = await createTestDb("dbmate_pop");
     target = await createTestDb("dbmate_target");
+    // Include a routine so the plan carries the check_function_bodies
+    // preamble — the planner emits it only for routine-touching plans
+    // (src/plan/preamble.ts); the assertions below need it present so the
+    // render path can prove it retains it while dropping search_path.
     await populated.pool.query(/* sql */ `
       CREATE SCHEMA app;
       CREATE TABLE public.widgets (id integer PRIMARY KEY, name text);
       CREATE TABLE app.gadgets (id integer PRIMARY KEY);
+      CREATE FUNCTION app.widget_count() RETURNS integer
+        LANGUAGE sql STABLE AS 'SELECT count(*)::integer FROM public.widgets';
     `);
   }, 120_000);
 


### PR DESCRIPTION
## Summary

PR #299 integration CI is red on all PG 14–18 matrix jobs with a single failing test:

```
(fail) rendered migration files replay under a third-party runner (dbmate)
       > rendered file + unqualified schema_migrations INSERT commit in one transaction

error: expect(received).toContainEqual(expected)
Expected to contain: { name: "check_function_bodies", value: "off" }
Received: [ { name: "search_path", value: "pg_catalog" } ]
  at tests/render-dbmate-searchpath.test.ts:54:24
```

#386 (e2c8c8c1) made the planner emit the `check_function_bodies` preamble only for routine-touching plans. #387 (bf5eb5fc) repaired the same regression in `schema-frontends.test.ts` but missed `render-dbmate-searchpath.test.ts`, whose table-only plan no longer carries the setting.

## Fix

Mirror the #387 repair: seed a routine (`app.widget_count()`) into the populated schema so the plan legitimately carries the `check_function_bodies` preamble, keeping the render-path assertions (setting retained in the rendered file, `search_path` dropped) meaningful.

Test-only change — no changeset needed.

## Validation

- `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/render-dbmate-searchpath.test.ts` — 1 pass
- `bun test src/` — 1012 pass, 0 fail
- `bun run format-and-lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)