### PR TITLE
fix(pg-delta): elide default-owner username in pg_cron job replay

### DIFF
--- a/.changeset/pg-cron-username-elision.md
+++ b/.changeset/pg-cron-username-elision.md
@@ -18,6 +18,10 @@ supabasePolicy.defaultOwner` and the CLI-1435 `supabase_read_only_user →
 postgres` alias. A job owned by the profile's default job owner replays with
 `NULL`; a job owned by a third role keeps the explicit literal (it genuinely
 requires a superuser executor) and now raises a new `intent-privileged`
-warning diagnostic at capture — warn and emit, never silently drop. Profiles
-with no declared default job owner (`raw`, custom profile files) keep today's
-explicit rendering.
+warning diagnostic at capture — warn and emit, never silently drop.
+
+A custom profile file (`--profile ./my-profile.json`) gets the same treatment:
+its `handlers: ["pg_cron"]` entry is built from the file's OWN
+`policy.defaultOwner`, so a profile that declares an owner/executor role also
+gets the elision. Only profiles with no declared default owner (`raw`, and
+profile files without `policy.defaultOwner`) keep the explicit rendering.

--- a/.changeset/pg-cron-username-elision.md
+++ b/.changeset/pg-cron-username-elision.md
@@ -1,0 +1,23 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Elide the default-owner username when replaying a pg_cron job, so a plan containing cron intent is applyable by a non-superuser executor.
+
+pg_cron requires SUPERUSER for any non-NULL `username` argument to
+`cron.schedule_in_database(...)` — even when it names the calling role itself
+(`ERROR: must be superuser to create a job for another role`). A bare `NULL`
+means `current_user` and needs no privilege. Because pg-delta always rendered
+an explicit username literal, every plan or export containing a pg_cron job
+was unapplyable as the `postgres` role a hosted Supabase project hands out.
+
+The pg_cron handler is now a factory, `makePgCronHandler({ defaultJobOwner,
+jobOwnerAliases })`, so the file carries no platform-specific role names; the
+Supabase profile constructs it with `defaultJobOwner:
+supabasePolicy.defaultOwner` and the CLI-1435 `supabase_read_only_user →
+postgres` alias. A job owned by the profile's default job owner replays with
+`NULL`; a job owned by a third role keeps the explicit literal (it genuinely
+requires a superuser executor) and now raises a new `intent-privileged`
+warning diagnostic at capture — warn and emit, never silently drop. Profiles
+with no declared default job owner (`raw`, custom profile files) keep today's
+explicit rendering.

--- a/docs/architecture/extension-intent.md
+++ b/docs/architecture/extension-intent.md
@@ -173,7 +173,12 @@ single codec).
 The handler is a **factory** — `makePgCronHandler({ defaultJobOwner,
 jobOwnerAliases })` — so `pg-cron.ts` names no platform roles; the Supabase
 profile (`src/integrations/supabase.ts`) supplies both, sourcing
-`defaultJobOwner` from `supabasePolicy.defaultOwner`.
+`defaultJobOwner` from `supabasePolicy.defaultOwner`. A **custom profile file**
+(`--profile ./p.json`) names handlers as strings, and the CLI resolves each name
+through a factory registry (`src/cli/profile.ts`) that passes the file's own
+declared `policy` — so `handlers: ["pg_cron"]` derives `defaultJobOwner` from
+that file's `policy.defaultOwner` too. `jobOwnerAliases` stays Supabase-only:
+it is platform history, not something a policy can express.
 
 - **Capture**: read `cron.job`. **Ownership normalization (CLI-1435)**: jobs
   created before the patch were owned by `supabase_read_only_user`; the
@@ -193,7 +198,8 @@ profile (`src/integrations/supabase.ts`) supplies both, sourcing
   `defaultJobOwner` is also declaring who executes the plan, so a job owned by
   that role renders `NULL` and stays applyable by the non-superuser `postgres`
   a hosted Supabase project hands out. Any other owner keeps the explicit
-  literal. With no `defaultJobOwner` (raw/custom profiles) nothing is elided.
+  literal. With no `defaultJobOwner` (the `raw` profile, or a profile file that
+  declares no `policy.defaultOwner`) nothing is elided.
 - **Change** (`schedule`/`command`/`active`/`database`): **`unschedule` +
   re-`schedule` by name** — fully static and deterministic; no apply-time
   `job_id` resolution. Run history isn't contracted, so recreate is lossless

--- a/docs/architecture/extension-intent.md
+++ b/docs/architecture/extension-intent.md
@@ -170,12 +170,30 @@ single codec).
              database:string, username:string, active:boolean } }
 ```
 
+The handler is a **factory** — `makePgCronHandler({ defaultJobOwner,
+jobOwnerAliases })` — so `pg-cron.ts` names no platform roles; the Supabase
+profile (`src/integrations/supabase.ts`) supplies both, sourcing
+`defaultJobOwner` from `supabasePolicy.defaultOwner`.
+
 - **Capture**: read `cron.job`. **Ownership normalization (CLI-1435)**: jobs
-  created before the patch were owned by `supabase_read_only_user`; normalize
-  `username` to `postgres` on capture so a rebuild doesn't reproduce the legacy
-  owner. Declared once, in the handler.
-- **Create**: `select cron.schedule('<jobname>','<schedule>','<command>')` (+
-  `schedule_in_database` when `database` differs).
+  created before the patch were owned by `supabase_read_only_user`; the
+  profile's `jobOwnerAliases` rewrites `username` to `postgres` on capture so a
+  rebuild doesn't reproduce the legacy owner. Declared once, in the profile.
+  A job owned by a role OTHER than `defaultJobOwner` also raises an
+  `intent-privileged` **warning** (warn + emit — its reconstruction genuinely
+  needs a superuser connection; see Create).
+- **Create**: `select cron.schedule_in_database('<jobname>','<schedule>',
+  '<command>','<database>',<username>,<active>)` — all captured fields replayed
+  (the 3-arg `cron.schedule` form always creates the job in the current
+  database, active, owned by the caller, so it cannot converge).
+  **Username elision**: pg_cron rejects a non-NULL `username` argument unless
+  the caller is SUPERUSER — *even when it names the calling role itself*
+  ("must be superuser to create a job for another role") — while a bare `NULL`
+  means `current_user` and needs no privilege. A profile declaring a
+  `defaultJobOwner` is also declaring who executes the plan, so a job owned by
+  that role renders `NULL` and stays applyable by the non-superuser `postgres`
+  a hosted Supabase project hands out. Any other owner keeps the explicit
+  literal. With no `defaultJobOwner` (raw/custom profiles) nothing is elided.
 - **Change** (`schedule`/`command`/`active`/`database`): **`unschedule` +
   re-`schedule` by name** — fully static and deterministic; no apply-time
   `job_id` resolution. Run history isn't contracted, so recreate is lossless
@@ -517,7 +535,7 @@ hazards in the same proof-verified safety report. No separate risk path.
 | CLI-1430 (intent matrix) | Authoritative column→intent spec the handlers consume; §3 is the v1 cut. |
 | CLI-1431 (declarative source format) | §4.4: the replay calls *are* the format, read by capture; typed block deferred to B+. |
 | CLI-1434 (vault) | §3.4: presence-only + blocking error. |
-| CLI-1435 (cron ownership) | §3.2: `username` normalization on capture. |
+| CLI-1435 (cron ownership) | §3.2: `username` normalization on capture (profile-supplied `jobOwnerAliases`) + `defaultJobOwner` elision on replay. |
 | CLI-1433 (pg_net templating) | Reserved `rewrite` hook (§4.1); full design deferred. |
 | CLI-1432 (cross-schema triggers) | Orthogonal — already handled by the Supabase policy (assessment §3). |
 

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -794,3 +794,16 @@ populated state `3530186683`, the `databaseScratch` emptiness guard, range
 CANONICAL, subscription `failover` `3537910587`); the ONE new fragment —
 subscription `password_required` — is recorded in the extract-completeness list
 above. Consolidated for the fidelity-hardening milestone as **Linear CLI-2134**.
+
+## PR #391 review triage — pg_cron username elision
+
+- **Deferred — export-resolved default owner is not threaded into pg_cron
+  rendering.** `buildSchemaExport` resolves a per-export owner (`defaultOwner`
+  option → profile default → `datdba`; `src/frontends/schema-export.ts:40-111`)
+  that can diverge from the handler's configured `defaultJobOwner`; a cron job
+  owned by that resolved role still renders an explicit username and needs a
+  superuser executor. Deferred because it requires threading export-time
+  context into intent rendering (rejected as disproportionate in this PR's
+  design); the capture-time `intent-privileged` warning already fires for
+  exactly this divergence, so the failure is pre-announced. Revisit if a real
+  profile hits it.

--- a/packages/pg-delta/src/cli/profile.test.ts
+++ b/packages/pg-delta/src/cli/profile.test.ts
@@ -5,8 +5,9 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildFactBase } from "../core/fact.ts";
+import { buildFactBase, type Fact } from "../core/fact.ts";
 import { serializeSnapshot } from "../core/snapshot.ts";
+import type { IntegrationProfile } from "../integrations/profile.ts";
 import { rawProfile } from "../integrations/profile.ts";
 import { supabaseProfile } from "../integrations/supabase.ts";
 import { UsageError } from "./flags.ts";
@@ -186,6 +187,91 @@ describe("parseProfileFile (custom file-based profiles)", () => {
       parseProfileFile(JSON.stringify({ id: "p", handlers: "nope" }), "p.json"),
     ).toThrow(/handlers/);
     expect(() => parseProfileFile("{not json", "p.json")).toThrow();
+  });
+});
+
+/**
+ * A custom profile file references handlers BY NAME, so a CONFIGURABLE handler
+ * has to be built from the same file's `policy` — otherwise `handlers:
+ * ["pg_cron"]` would silently get the unconfigured instance and lose username
+ * elision even though the file declares the executor via `policy.defaultOwner`.
+ */
+describe("parseProfileFile: pg_cron is configured from the file's own policy", () => {
+  const jobFact: Fact = {
+    id: {
+      kind: "extensionIntent",
+      ext: "pg_cron",
+      intentKind: "job",
+      key: "nightly",
+    },
+    payload: {
+      schedule: "0 0 * * *",
+      command: "select 1",
+      database: "postgres",
+      username: "postgres",
+      active: true,
+    },
+  };
+
+  /** Render the `job` intent's create SQL for a postgres-owned job. */
+  function cronCreateSql(profile: IntegrationProfile): string | undefined {
+    const handler = profile.handlers.find((h) => h.extension === "pg_cron");
+    return handler?.intentKinds?.["job"]?.create(jobFact, undefined as never)[0]
+      ?.sql;
+  }
+
+  test("policy.defaultOwner becomes the handler's defaultJobOwner (username elided to NULL)", () => {
+    const profile = parseProfileFile(
+      JSON.stringify({
+        id: "platform-middleware",
+        handlers: ["pg_cron"],
+        policy: { id: "pol", filter: [], defaultOwner: "postgres" },
+      }),
+      "profile.json",
+    );
+    expect(cronCreateSql(profile)).toMatchInlineSnapshot(
+      `"select cron.schedule_in_database('nightly', '0 0 * * *', 'select 1', 'postgres', NULL, true)"`,
+    );
+  });
+
+  test("no policy.defaultOwner → the explicit username literal is kept", () => {
+    const profile = parseProfileFile(
+      JSON.stringify({
+        id: "platform-middleware",
+        handlers: ["pg_cron"],
+        policy: { id: "pol", filter: [] },
+      }),
+      "profile.json",
+    );
+    expect(cronCreateSql(profile)).toMatchInlineSnapshot(
+      `"select cron.schedule_in_database('nightly', '0 0 * * *', 'select 1', 'postgres', 'postgres', true)"`,
+    );
+  });
+
+  test("no policy at all → the explicit username literal is kept", () => {
+    const profile = parseProfileFile(
+      JSON.stringify({ id: "mw", handlers: ["pg_cron"] }),
+      "profile.json",
+    );
+    expect(cronCreateSql(profile)).toMatchInlineSnapshot(
+      `"select cron.schedule_in_database('nightly', '0 0 * * *', 'select 1', 'postgres', 'postgres', true)"`,
+    );
+  });
+
+  test("pg_partman still resolves alongside a configured pg_cron", () => {
+    const profile = parseProfileFile(
+      JSON.stringify({
+        id: "mw",
+        handlers: ["pg_partman", "pg_cron"],
+        policy: { id: "pol", filter: [], defaultOwner: "postgres" },
+      }),
+      "profile.json",
+    );
+    expect(profile.handlers.map((h) => h.extension)).toEqual([
+      "pg_partman",
+      "pg_cron",
+    ]);
+    expect(profile.policy?.defaultOwner).toBe("postgres");
   });
 });
 

--- a/packages/pg-delta/src/cli/profile.test.ts
+++ b/packages/pg-delta/src/cli/profile.test.ts
@@ -258,6 +258,40 @@ describe("parseProfileFile: pg_cron is configured from the file's own policy", (
     );
   });
 
+  test("policy.extends inheriting defaultOwner from a parent still configures pg_cron elision (flattened, not raw)", () => {
+    const profile = parseProfileFile(
+      JSON.stringify({
+        id: "platform-middleware",
+        handlers: ["pg_cron"],
+        policy: {
+          id: "child",
+          filter: [],
+          extends: [{ id: "parent", filter: [], defaultOwner: "postgres" }],
+        },
+      }),
+      "profile.json",
+    );
+    expect(cronCreateSql(profile)).toMatchInlineSnapshot(
+      `"select cron.schedule_in_database('nightly', '0 0 * * *', 'select 1', 'postgres', NULL, true)"`,
+    );
+  });
+
+  test("a policy whose extends chain cycles surfaces as a UsageError mentioning the profile source", () => {
+    const badJson = JSON.stringify({
+      id: "mw",
+      handlers: ["pg_cron"],
+      policy: {
+        id: "child",
+        filter: [],
+        extends: [{ id: "child", filter: [] }],
+      },
+    });
+    expect(() => parseProfileFile(badJson, "profile.json")).toThrow(UsageError);
+    expect(() => parseProfileFile(badJson, "profile.json")).toThrow(
+      /profile profile\.json: invalid policy/,
+    );
+  });
+
   test("pg_partman still resolves alongside a configured pg_cron", () => {
     const profile = parseProfileFile(
       JSON.stringify({

--- a/packages/pg-delta/src/cli/profile.ts
+++ b/packages/pg-delta/src/cli/profile.ts
@@ -21,7 +21,7 @@ import {
   resolveProfile,
   supabaseProfile,
 } from "../integrations/index.ts";
-import type { Policy } from "../policy/policy.ts";
+import { flattenPolicy, type Policy } from "../policy/policy.ts";
 import { UsageError } from "./flags.ts";
 
 const PROFILES: Record<string, IntegrationProfile> = {
@@ -39,23 +39,27 @@ export const PROFILE_IDS = Object.keys(PROFILES).join(" | ");
  *
  * A factory (rather than a ready-made instance) is what lets a CONFIGURABLE
  * handler read the same file's `policy`: `pg_cron` derives its `defaultJobOwner`
- * from `policy.defaultOwner` — the role the profile already declares as the
- * owner/executor — so a profile file gets the same non-superuser-applyable
+ * from the policy's EFFECTIVE (flattened) `defaultOwner` — the role the profile
+ * already declares as the owner/executor, including one inherited through
+ * `Policy.extends` — so a profile file gets the same non-superuser-applyable
  * username elision the built-in Supabase profile gets. Platform-history knobs
  * (e.g. Supabase's `supabase_read_only_user` owner alias) are NOT derivable from
  * a policy and stay in `src/integrations/supabase.ts`.
+ *
+ * Takes the already-resolved default owner (not the raw `Policy`) so callers
+ * run `flattenPolicy` exactly ONCE per profile file, not once per handler.
  */
 const HANDLER_FACTORY_BY_NAME = new Map<
   string,
-  (policy: Policy | undefined) => ExtensionHandler
+  (resolvedDefaultOwner: string | undefined) => ExtensionHandler
 >([
   [pgPartmanHandler.extension, () => pgPartmanHandler],
   [
     "pg_cron",
-    (policy) =>
+    (resolvedDefaultOwner) =>
       makePgCronHandler(
-        policy?.defaultOwner !== undefined
-          ? { defaultJobOwner: policy.defaultOwner }
+        resolvedDefaultOwner !== undefined
+          ? { defaultJobOwner: resolvedDefaultOwner }
           : {},
       ),
   ],
@@ -117,6 +121,24 @@ export function parseProfileFile(
     rawPolicy !== undefined && rawPolicy !== null
       ? (rawPolicy as Policy)
       : undefined;
+  // Resolve the EFFECTIVE default owner through flattenPolicy exactly ONCE per
+  // profile file, not once per handler: `Policy.extends` composes inline
+  // nested policies, and `defaultOwner` inherits from the first parent that
+  // declares one when the policy itself doesn't (see flattenPolicy's
+  // scalar-inheritance contract) — reading `policy.defaultOwner` directly
+  // would miss that inherited value. The profile file's policy is an
+  // unvalidated blind cast, so flattenPolicy's cycle guard can throw; surface
+  // that as a UsageError instead of an unhandled Error.
+  let resolvedDefaultOwner: string | undefined;
+  if (policy !== undefined) {
+    try {
+      resolvedDefaultOwner = flattenPolicy(policy).defaultOwner;
+    } catch (err) {
+      throw new UsageError(
+        `profile ${source}: invalid policy — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
   const handlers: ExtensionHandler[] = [];
   for (const name of obj["handlers"]) {
     if (typeof name !== "string") {
@@ -130,7 +152,7 @@ export function parseProfileFile(
         `profile ${source}: unknown handler '${name}' — available: ${[...HANDLER_FACTORY_BY_NAME.keys()].join(", ")}`,
       );
     }
-    handlers.push(makeHandler(policy));
+    handlers.push(makeHandler(resolvedDefaultOwner));
   }
   const rawBaseline = obj["baseline"];
   if (

--- a/packages/pg-delta/src/cli/profile.ts
+++ b/packages/pg-delta/src/cli/profile.ts
@@ -13,7 +13,7 @@ import type { Pool } from "pg";
 import {
   type ExtensionHandler,
   type IntegrationProfile,
-  pgCronHandler,
+  makePgCronHandler,
   pgPartmanHandler,
   rawProfile,
   type ResolvedProfile,
@@ -32,11 +32,34 @@ const PROFILES: Record<string, IntegrationProfile> = {
 /** The `--profile` value shown in usage strings. */
 export const PROFILE_IDS = Object.keys(PROFILES).join(" | ");
 
-/** The bundled extension handlers a custom profile file may reference BY NAME
- *  (the handler's `extension` field). Extend this as new handlers ship. */
-const HANDLER_BY_NAME = new Map<string, ExtensionHandler>(
-  ([pgPartmanHandler, pgCronHandler] as const).map((h) => [h.extension, h]),
-);
+/**
+ * The bundled extension handlers a custom profile file may reference BY NAME
+ * (the handler's `extension` field), as FACTORIES taking the profile file's own
+ * declared policy. Extend this as new handlers ship.
+ *
+ * A factory (rather than a ready-made instance) is what lets a CONFIGURABLE
+ * handler read the same file's `policy`: `pg_cron` derives its `defaultJobOwner`
+ * from `policy.defaultOwner` — the role the profile already declares as the
+ * owner/executor — so a profile file gets the same non-superuser-applyable
+ * username elision the built-in Supabase profile gets. Platform-history knobs
+ * (e.g. Supabase's `supabase_read_only_user` owner alias) are NOT derivable from
+ * a policy and stay in `src/integrations/supabase.ts`.
+ */
+const HANDLER_FACTORY_BY_NAME = new Map<
+  string,
+  (policy: Policy | undefined) => ExtensionHandler
+>([
+  [pgPartmanHandler.extension, () => pgPartmanHandler],
+  [
+    "pg_cron",
+    (policy) =>
+      makePgCronHandler(
+        policy?.defaultOwner !== undefined
+          ? { defaultJobOwner: policy.defaultOwner }
+          : {},
+      ),
+  ],
+]);
 
 /** A `--profile` value is a path (load from disk) rather than a built-in id when
  *  it looks like a path: contains a `/` or ends in `.json`. */
@@ -47,11 +70,14 @@ export function isProfilePath(id: string): boolean {
 /**
  * Parse a custom profile file's JSON into an `IntegrationProfile`. The file
  * mirrors `IntegrationProfile` but references handlers BY NAME (resolved against
- * {@link HANDLER_BY_NAME}) so it stays plain, serializable data:
+ * {@link HANDLER_FACTORY_BY_NAME}) so it stays plain, serializable data:
  *
  *   { "id": "platform-middleware", "handlers": ["pg_partman", "pg_cron"],
  *     "policy"?: { ...a serializable Policy... },
  *     "baseline"?: "./middleware-base.json" }
+ *
+ * The declared `policy` also CONFIGURES the named handlers (a `pg_cron` handler
+ * takes its default job owner from `policy.defaultOwner`), so it is parsed first.
  *
  * `baseline` is a path to a `pgdelta snapshot` file; a relative path is resolved
  * against `opts.dir` (the profile file's own directory) so a committed profile +
@@ -84,6 +110,13 @@ export function parseProfileFile(
       `profile ${source}: "handlers" must be an array of handler names`,
     );
   }
+  // the policy is read BEFORE the handlers because a handler factory is
+  // configured from it (see HANDLER_FACTORY_BY_NAME).
+  const rawPolicy = obj["policy"];
+  const policy =
+    rawPolicy !== undefined && rawPolicy !== null
+      ? (rawPolicy as Policy)
+      : undefined;
   const handlers: ExtensionHandler[] = [];
   for (const name of obj["handlers"]) {
     if (typeof name !== "string") {
@@ -91,15 +124,14 @@ export function parseProfileFile(
         `profile ${source}: handler names must be strings (got ${typeof name})`,
       );
     }
-    const handler = HANDLER_BY_NAME.get(name);
-    if (handler === undefined) {
+    const makeHandler = HANDLER_FACTORY_BY_NAME.get(name);
+    if (makeHandler === undefined) {
       throw new UsageError(
-        `profile ${source}: unknown handler '${name}' — available: ${[...HANDLER_BY_NAME.keys()].join(", ")}`,
+        `profile ${source}: unknown handler '${name}' — available: ${[...HANDLER_FACTORY_BY_NAME.keys()].join(", ")}`,
       );
     }
-    handlers.push(handler);
+    handlers.push(makeHandler(policy));
   }
-  const policy = obj["policy"];
   const rawBaseline = obj["baseline"];
   if (
     rawBaseline !== undefined &&
@@ -120,9 +152,7 @@ export function parseProfileFile(
   return {
     id: obj["id"],
     handlers,
-    ...(policy !== undefined && policy !== null
-      ? { policy: policy as Policy }
-      : {}),
+    ...(policy !== undefined ? { policy } : {}),
     ...(baselinePath !== undefined ? { baselinePath } : {}),
   };
 }

--- a/packages/pg-delta/src/core/diagnostic.ts
+++ b/packages/pg-delta/src/core/diagnostic.ts
@@ -21,6 +21,15 @@ export interface Diagnostic {
  *  (`plan()`) agree on the string without a cross-layer import. */
 export const INTENT_UNKEYED = "intent-unkeyed";
 
+/** Diagnostic code for an extension-intent object whose reconstruction needs
+ *  privileges the profile's assumed executor does not have — today, a pg_cron
+ *  job owned by a role OTHER than the profile's default job owner (pg_cron
+ *  demands SUPERUSER for any non-NULL `username` argument, so the replay can
+ *  only be applied by a superuser connection). Warn + EMIT: the fact and its
+ *  statement are still produced, so a superuser executor can apply them; the
+ *  warning is the early signal that a plain connection will be rejected. */
+export const INTENT_PRIVILEGED = "intent-privileged";
+
 /** Diagnostic code for a `pg_user_mapping` row whose options a non-superuser
  *  extraction could not read (the `pg_user_mappings` fallback view NULLs
  *  `umoptions` for a row the caller isn't authorized on — see

--- a/packages/pg-delta/src/integrations/index.ts
+++ b/packages/pg-delta/src/integrations/index.ts
@@ -20,7 +20,12 @@ export type {
   ExtensionHandler,
   HandlerContext,
 } from "../extract/handler.ts";
-export { pgCronHandler, pgPartmanHandler } from "../policy/extensions/index.ts";
+export {
+  makePgCronHandler,
+  type PgCronHandlerConfig,
+  pgCronHandler,
+  pgPartmanHandler,
+} from "../policy/extensions/index.ts";
 export {
   type ApplierCapability,
   probeApplierCapability,

--- a/packages/pg-delta/src/integrations/supabase.ts
+++ b/packages/pg-delta/src/integrations/supabase.ts
@@ -9,14 +9,36 @@
  * the recipe.
  */
 import type { ExtensionHandler } from "../extract/handler.ts";
-import { pgCronHandler, pgPartmanHandler } from "../policy/extensions/index.ts";
+import {
+  makePgCronHandler,
+  pgPartmanHandler,
+} from "../policy/extensions/index.ts";
 import { supabasePolicy } from "../policy/supabase.ts";
 import type { IntegrationProfile } from "./profile.ts";
+
+/**
+ * The pg_cron handler bound to Supabase's role identities. The handler itself
+ * is platform-neutral; the two Supabase facts live here:
+ *
+ * - `defaultJobOwner` — `postgres` both owns ordinary cron jobs and executes
+ *   the plan, so its username is elided from the replay (pg_cron demands
+ *   SUPERUSER for a non-NULL username, and Cloud's `postgres` is not one).
+ *   Sourced from `supabasePolicy.defaultOwner`, the single place that already
+ *   names the profile's assumed executor for `ALTER … OWNER TO`.
+ * - `jobOwnerAliases` — CLI-1435: jobs scheduled before the ownership fix were
+ *   recorded under `supabase_read_only_user`.
+ */
+const supabasePgCronHandler = makePgCronHandler({
+  ...(supabasePolicy.defaultOwner !== undefined
+    ? { defaultJobOwner: supabasePolicy.defaultOwner }
+    : {}),
+  jobOwnerAliases: { supabase_read_only_user: "postgres" },
+});
 
 /** The stateful-extension handlers the Supabase integration composes. */
 export const SUPABASE_EXTENSION_HANDLERS: readonly ExtensionHandler[] = [
   pgPartmanHandler,
-  pgCronHandler,
+  supabasePgCronHandler,
 ];
 
 export const supabaseProfile: IntegrationProfile = {

--- a/packages/pg-delta/src/policy/extensions/index.ts
+++ b/packages/pg-delta/src/policy/extensions/index.ts
@@ -20,4 +20,8 @@ export type {
   HandlerContext,
 } from "../../extract/handler.ts";
 export { pgPartmanHandler } from "./pg-partman.ts";
-export { pgCronHandler } from "./pg-cron.ts";
+export {
+  makePgCronHandler,
+  type PgCronHandlerConfig,
+  pgCronHandler,
+} from "./pg-cron.ts";

--- a/packages/pg-delta/src/policy/extensions/pg-cron.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-cron.test.ts
@@ -139,6 +139,19 @@ describe("pgCronHandler.capture", () => {
     expect(result.diagnostics ?? []).toEqual([]);
   });
 
+  test("jobOwnerAliases lookup checks only OWN keys — a role literally named 'constructor' is not shadowed by Object.prototype", async () => {
+    const handler = makePgCronHandler({
+      jobOwnerAliases: { supabase_read_only_user: "postgres" },
+    });
+    const ctx = fakeCtx([baseJob({ username: "constructor" })]);
+    const current = buildFactBase([pgCronFact], []);
+
+    const result = await handler.capture(ctx, current);
+
+    expect(result.facts).toHaveLength(1);
+    expect(result.facts[0]?.payload["username"]).toBe("constructor");
+  });
+
   test("without jobOwnerAliases the captured username is left verbatim (the handler carries no platform strings)", async () => {
     const ctx = fakeCtx([baseJob({ username: "supabase_read_only_user" })]);
     const current = buildFactBase([pgCronFact], []);

--- a/packages/pg-delta/src/policy/extensions/pg-cron.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-cron.test.ts
@@ -2,18 +2,19 @@
  * Unit tests for the pg_cron handler (docs/architecture/extension-intent.md
  * §3.2). No database — a fake `HandlerContext` returns canned rows keyed off
  * the SQL the handler issues. Covers: intent-fact shape + depends-edge
- * guarding, `supabase_read_only_user` → `postgres` normalization (CLI-1435),
- * unnamed-job and duplicate-jobname diagnostics (never reaching the
- * FactBase), and the `intentKinds.job` create/drop SQL (including quote
- * doubling for jobname/command).
+ * guarding, `jobOwnerAliases` capture normalization (CLI-1435), unnamed-job
+ * and duplicate-jobname diagnostics (never reaching the FactBase), the
+ * `intentKinds.job` create/drop SQL (including quote doubling for
+ * jobname/command), and the `defaultJobOwner` username elision + its
+ * third-role `INTENT_PRIVILEGED` warning.
  */
 import { describe, expect, test } from "bun:test";
-import { INTENT_UNKEYED } from "../../core/diagnostic.ts";
+import { INTENT_PRIVILEGED, INTENT_UNKEYED } from "../../core/diagnostic.ts";
 import { buildFactBase, type Fact } from "../../core/fact.ts";
 import type { HandlerContext } from "../../extract/handler.ts";
 import type { Row } from "../../extract/scope.ts";
 import type { StableId } from "../../core/stable-id.ts";
-import { pgCronHandler } from "./pg-cron.ts";
+import { makePgCronHandler, pgCronHandler } from "./pg-cron.ts";
 
 const PG_CRON: StableId = { kind: "extension", name: "pg_cron" };
 const PUBLIC_SCHEMA: StableId = { kind: "schema", name: "public" };
@@ -122,14 +123,77 @@ describe("pgCronHandler.capture", () => {
     expect(result.edges).toEqual([]);
   });
 
-  test("supabase_read_only_user is normalized to postgres (CLI-1435)", async () => {
+  test("jobOwnerAliases rewrites a legacy owner on capture (CLI-1435)", async () => {
+    const handler = makePgCronHandler({
+      defaultJobOwner: "postgres",
+      jobOwnerAliases: { supabase_read_only_user: "postgres" },
+    });
+    const ctx = fakeCtx([baseJob({ username: "supabase_read_only_user" })]);
+    const current = buildFactBase([pgCronFact], []);
+
+    const result = await handler.capture(ctx, current);
+
+    expect(result.facts).toHaveLength(1);
+    expect(result.facts[0]?.payload["username"]).toBe("postgres");
+    // the alias resolves TO the default owner, so no privileged warning
+    expect(result.diagnostics ?? []).toEqual([]);
+  });
+
+  test("without jobOwnerAliases the captured username is left verbatim (the handler carries no platform strings)", async () => {
     const ctx = fakeCtx([baseJob({ username: "supabase_read_only_user" })]);
     const current = buildFactBase([pgCronFact], []);
 
     const result = await pgCronHandler.capture(ctx, current);
 
     expect(result.facts).toHaveLength(1);
-    expect(result.facts[0]?.payload["username"]).toBe("postgres");
+    expect(result.facts[0]?.payload["username"]).toBe(
+      "supabase_read_only_user",
+    );
+  });
+
+  test("a third-role-owned job emits an INTENT_PRIVILEGED warning AND still becomes a fact", async () => {
+    const handler = makePgCronHandler({ defaultJobOwner: "postgres" });
+    const ctx = fakeCtx([
+      baseJob({ jobname: "etl_nightly", username: "etl_runner" }),
+    ]);
+    const current = buildFactBase([pgCronFact], []);
+
+    const result = await handler.capture(ctx, current);
+
+    // warn + EMIT: the statement stays in the plan for a superuser executor
+    expect(result.facts).toHaveLength(1);
+    expect(result.facts[0]?.id).toEqual(jobIntentId("etl_nightly"));
+    expect(result.diagnostics).toHaveLength(1);
+    const diag = result.diagnostics?.[0];
+    expect(diag?.code).toBe(INTENT_PRIVILEGED);
+    expect(diag?.severity).toBe("warning");
+    expect(diag?.message).toContain("etl_nightly");
+    expect(diag?.message).toContain("etl_runner");
+    expect(diag?.message).toContain("superuser");
+    expect(diag?.context).toEqual({ ext: "pg_cron", intentKind: "job" });
+  });
+
+  test("no defaultJobOwner configured → no privileged warning (a raw executor is its own authority)", async () => {
+    const ctx = fakeCtx([
+      baseJob({ jobname: "etl_nightly", username: "etl_runner" }),
+    ]);
+    const current = buildFactBase([pgCronFact], []);
+
+    const result = await pgCronHandler.capture(ctx, current);
+
+    expect(result.facts).toHaveLength(1);
+    expect(result.diagnostics ?? []).toEqual([]);
+  });
+
+  test("a job owned by the default owner emits no privileged warning", async () => {
+    const handler = makePgCronHandler({ defaultJobOwner: "postgres" });
+    const ctx = fakeCtx([baseJob({ username: "postgres" })]);
+    const current = buildFactBase([pgCronFact], []);
+
+    const result = await handler.capture(ctx, current);
+
+    expect(result.facts).toHaveLength(1);
+    expect(result.diagnostics ?? []).toEqual([]);
   });
 
   test("unnamed job (null jobname) → no fact, one INTENT_UNKEYED diagnostic", async () => {
@@ -331,5 +395,67 @@ describe("pgCronHandler.intentKinds.job", () => {
     expect(action?.sql).toMatchInlineSnapshot(
       `"select cron.unschedule('bob''s job')"`,
     );
+  });
+});
+
+/**
+ * pg_cron requires SUPERUSER for ANY non-NULL `username` argument — even one
+ * naming the calling role. `NULL` means `current_user` and needs no privilege.
+ * A profile that declares a default job owner also declares who executes the
+ * plan, so a job owned by that role replays with an elided username and stays
+ * applyable by a plain (non-superuser) connection.
+ */
+describe("makePgCronHandler: defaultJobOwner username elision", () => {
+  const configuredRule = makePgCronHandler({ defaultJobOwner: "postgres" })
+    .intentKinds?.["job"];
+  const bareRule = pgCronHandler.intentKinds?.["job"];
+
+  const jobFact = (username: string, database = "postgres"): Fact => ({
+    id: jobIntentId("nightly"),
+    payload: {
+      schedule: "0 0 * * *",
+      command: "select 1",
+      database,
+      username,
+      active: true,
+    },
+  });
+
+  test("create: a job owned by the default owner renders a bare NULL username", () => {
+    const actions = configuredRule?.create(
+      jobFact("postgres"),
+      undefined as never,
+    );
+    expect(actions).toHaveLength(1);
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(
+      `"select cron.schedule_in_database('nightly', '0 0 * * *', 'select 1', 'postgres', NULL, true)"`,
+    );
+  });
+
+  test("create: a job owned by a THIRD role keeps the explicit username literal", () => {
+    const actions = configuredRule?.create(
+      jobFact("etl_runner", "analytics"),
+      undefined as never,
+    );
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(
+      `"select cron.schedule_in_database('nightly', '0 0 * * *', 'select 1', 'analytics', 'etl_runner', true)"`,
+    );
+  });
+
+  test("create: with NO defaultJobOwner configured nothing is elided (vanilla PG, superuser executor)", () => {
+    const actions = bareRule?.create(jobFact("postgres"), undefined as never);
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(
+      `"select cron.schedule_in_database('nightly', '0 0 * * *', 'select 1', 'postgres', 'postgres', true)"`,
+    );
+  });
+
+  test("payloadAttrs still carries username — elision is a RENDER decision, not a capture normalization", () => {
+    expect(configuredRule?.payloadAttrs).toEqual([
+      "schedule",
+      "command",
+      "database",
+      "username",
+      "active",
+    ]);
   });
 });

--- a/packages/pg-delta/src/policy/extensions/pg-cron.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-cron.ts
@@ -118,9 +118,15 @@ export function makePgCronHandler(
 ): ExtensionHandler {
   const { defaultJobOwner, jobOwnerAliases } = config;
 
-  /** Apply the profile's capture-time owner aliases (identity if none). */
+  /** Apply the profile's capture-time owner aliases (identity if none). Must
+   *  check `Object.hasOwn` — a role legally named `constructor` (or
+   *  `toString`, etc.) would otherwise resolve `jobOwnerAliases[username]` to
+   *  the inherited `Object.prototype` member instead of `undefined`, leaking
+   *  a function into the fact payload. */
   const normalizeOwner = (username: string): string =>
-    jobOwnerAliases?.[username] ?? username;
+    jobOwnerAliases !== undefined && Object.hasOwn(jobOwnerAliases, username)
+      ? (jobOwnerAliases[username] ?? username)
+      : username;
 
   return {
     extension: "pg_cron",

--- a/packages/pg-delta/src/policy/extensions/pg-cron.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-cron.ts
@@ -13,9 +13,19 @@
  * name, or two jobs sharing a name, cannot be keyed at all: both cases are
  * surfaced as an `INTENT_UNKEYED` diagnostic instead of a fact, and NEVER
  * reach the `FactBase` (which throws on a duplicate id).
+ *
+ * This file is PLATFORM-NEUTRAL: it holds no role names. The identity of the
+ * default job owner (and any legacy-owner aliases) is a property of the
+ * integration profile, so the handler is a FACTORY — see
+ * {@link makePgCronHandler} and its construction in
+ * `src/integrations/supabase.ts`.
  */
 import type { DependencyEdge, Fact, FactBase } from "../../core/fact.ts";
-import { INTENT_UNKEYED, type Diagnostic } from "../../core/diagnostic.ts";
+import {
+  INTENT_PRIVILEGED,
+  INTENT_UNKEYED,
+  type Diagnostic,
+} from "../../core/diagnostic.ts";
 import type {
   CaptureResult,
   ExtensionHandler,
@@ -27,11 +37,34 @@ import type { StableId } from "../../core/stable-id.ts";
 
 const PG_CRON: StableId = { kind: "extension", name: "pg_cron" };
 
-/** CLI-1435: jobs scheduled before the ownership fix were recorded under
- *  `supabase_read_only_user`. Normalize to `postgres` on capture so a
- *  rebuild (unschedule + reschedule) never reproduces the legacy owner. */
-const LEGACY_JOB_OWNER = "supabase_read_only_user";
-const NORMALIZED_JOB_OWNER = "postgres";
+/** Profile-supplied identity knobs for the pg_cron handler. Everything here is
+ *  platform-specific by nature, which is exactly why it is configuration and
+ *  not a constant in this file. */
+export interface PgCronHandlerConfig {
+  /**
+   * The role the profile assumes both OWNS ordinary cron jobs and EXECUTES the
+   * plan (on Supabase: `postgres`). Its presence enables two behaviors:
+   *
+   * - `create()` elides the username argument (renders `NULL`) for a job owned
+   *   by this role, so the replay is applyable by a non-superuser — see the
+   *   comment on the `job` intent's `create()`;
+   * - `capture()` warns (`INTENT_PRIVILEGED`) for a job owned by anyone else,
+   *   whose reconstruction genuinely requires a superuser connection.
+   *
+   * Omitted (e.g. the `raw` profile) → neither applies: the executor is its own
+   * authority and typically a superuser, so today's explicit rendering is
+   * correct.
+   */
+  defaultJobOwner?: string;
+  /**
+   * Capture-time rewrites of `cron.job.username`, `<legacy> → <current>`. Used
+   * by the Supabase profile for CLI-1435: jobs scheduled before the ownership
+   * fix were recorded under `supabase_read_only_user`, so they are normalized
+   * to `postgres` on capture and a rebuild (unschedule + reschedule) never
+   * reproduces the legacy owner.
+   */
+  jobOwnerAliases?: Record<string, string>;
+}
 
 /** Resolve whether pg_cron is installed (any schema — often `pg_catalog` on
  *  Supabase). Returns true/false; the handler always queries `cron.job`
@@ -71,165 +104,234 @@ function commandPreview(command: string): string {
   return command.length > 60 ? `${command.slice(0, 60)}…` : command;
 }
 
-export const pgCronHandler: ExtensionHandler = {
-  extension: "pg_cron",
+/**
+ * Build a pg_cron handler bound to a profile's role identities.
+ *
+ * The pg_cron privilege rule the config exists to satisfy is a GENERIC truth
+ * (see `create()` below); only the identity of the default owner is
+ * platform-specific, so it is injected here rather than hardcoded. Constructed
+ * for Supabase in `src/integrations/supabase.ts`; {@link pgCronHandler} is the
+ * unconfigured instance.
+ */
+export function makePgCronHandler(
+  config: PgCronHandlerConfig = {},
+): ExtensionHandler {
+  const { defaultJobOwner, jobOwnerAliases } = config;
 
-  async capture(
-    ctx: HandlerContext,
-    current: FactBase,
-  ): Promise<CaptureResult> {
-    const installed = await detect(ctx);
-    if (!installed) return { facts: [], edges: [] };
+  /** Apply the profile's capture-time owner aliases (identity if none). */
+  const normalizeOwner = (username: string): string =>
+    jobOwnerAliases?.[username] ?? username;
 
-    const rows = (await ctx.query(
-      `SELECT jobid, jobname, schedule, command, database, username, active
+  return {
+    extension: "pg_cron",
+
+    async capture(
+      ctx: HandlerContext,
+      current: FactBase,
+    ): Promise<CaptureResult> {
+      const installed = await detect(ctx);
+      if (!installed) return { facts: [], edges: [] };
+
+      const rows = (await ctx.query(
+        `SELECT jobid, jobname, schedule, command, database, username, active
          FROM cron.job`,
-    )) as unknown as CronJobRow[];
+      )) as unknown as CronJobRow[];
 
-    const diagnostics: Diagnostic[] = [];
-    // group named rows by jobname to detect duplicates before ever building a
-    // fact — the FactBase throws on a duplicate id, so a collision must be
-    // caught here.
-    const byName = new Map<string, CronJobRow[]>();
+      const diagnostics: Diagnostic[] = [];
+      // group named rows by jobname to detect duplicates before ever building a
+      // fact — the FactBase throws on a duplicate id, so a collision must be
+      // caught here.
+      const byName = new Map<string, CronJobRow[]>();
 
-    for (const row of rows) {
-      const jobname = row.jobname;
-      if (jobname === null || jobname === "") {
-        diagnostics.push({
-          code: INTENT_UNKEYED,
-          severity: "warning",
-          message:
-            `pg_cron job ${row.jobid} (command: ${commandPreview(row.command)}) ` +
-            `has no jobname and cannot be managed declaratively; name it via ` +
-            `cron.schedule('<name>', …)`,
-          context: { ext: "pg_cron", intentKind: "job" },
-        });
-        continue;
-      }
-      const group = byName.get(jobname) ?? [];
-      group.push(row);
-      byName.set(jobname, group);
-    }
-
-    const facts: Fact[] = [];
-    const edges: DependencyEdge[] = [];
-    const dependsOnExtension = current.has(PG_CRON);
-
-    for (const [jobname, group] of byName) {
-      if (group.length > 1) {
-        diagnostics.push({
-          code: INTENT_UNKEYED,
-          severity: "warning",
-          message:
-            `pg_cron jobname '${jobname}' is used by ${group.length} jobs ` +
-            `(jobids ${group.map((r) => r.jobid).join(", ")}) and cannot be ` +
-            `managed declaratively; jobnames must be unique to be keyed`,
-          context: { ext: "pg_cron", intentKind: "job" },
-        });
-        continue;
+      for (const row of rows) {
+        const jobname = row.jobname;
+        if (jobname === null || jobname === "") {
+          diagnostics.push({
+            code: INTENT_UNKEYED,
+            severity: "warning",
+            message:
+              `pg_cron job ${row.jobid} (command: ${commandPreview(row.command)}) ` +
+              `has no jobname and cannot be managed declaratively; name it via ` +
+              `cron.schedule('<name>', …)`,
+            context: { ext: "pg_cron", intentKind: "job" },
+          });
+          continue;
+        }
+        const group = byName.get(jobname) ?? [];
+        group.push(row);
+        byName.set(jobname, group);
       }
 
-      const row = group[0] as CronJobRow;
-      const username =
-        row.username === LEGACY_JOB_OWNER ? NORMALIZED_JOB_OWNER : row.username;
-      const id = jobIntentId(jobname);
-      facts.push({
-        id,
-        payload: {
-          schedule: row.schedule,
-          command: row.command,
-          database: row.database,
-          username,
-          active: row.active,
-        },
-      });
-      if (dependsOnExtension) {
-        edges.push({ from: id, to: PG_CRON, kind: "depends" });
-      }
-    }
+      const facts: Fact[] = [];
+      const edges: DependencyEdge[] = [];
+      const dependsOnExtension = current.has(PG_CRON);
 
-    return { facts, edges, diagnostics };
-  },
+      for (const [jobname, group] of byName) {
+        if (group.length > 1) {
+          diagnostics.push({
+            code: INTENT_UNKEYED,
+            severity: "warning",
+            message:
+              `pg_cron jobname '${jobname}' is used by ${group.length} jobs ` +
+              `(jobids ${group.map((r) => r.jobid).join(", ")}) and cannot be ` +
+              `managed declaratively; jobnames must be unique to be keyed`,
+            context: { ext: "pg_cron", intentKind: "job" },
+          });
+          continue;
+        }
 
-  intentKinds: {
-    job: {
-      payloadAttrs: ["schedule", "command", "database", "username", "active"],
-      create(fact) {
-        const key = (fact.id as Extract<StableId, { kind: "extensionIntent" }>)
-          .key;
-        const p = fact.payload as {
-          schedule: string;
-          command: string;
-          database: string;
-          username: string;
-          active: boolean;
-        };
-        // Replay ALL captured fields deterministically via the 6-arg
-        // `cron.schedule_in_database(job_name, schedule, command, database,
-        // username, active)`. The 3-arg `cron.schedule` form would always
-        // (re)create the job in the CURRENT database, active, owned by the
-        // executing user — so a job that is inactive, targets another
-        // database, or has a non-current username would never converge. The
-        // 6-arg signature has been stable since pg_cron 1.4 (2021), which
-        // every supported PostgreSQL image and the supabase/postgres image
-        // ship, so this stays compatible across the pg_cron versions we
-        // target. String args keep `lit()` quoting; `active` is a bare
-        // boolean literal.
-        return [
-          {
-            sql:
-              `select cron.schedule_in_database(${lit(key)}, ${lit(p.schedule)}, ` +
-              `${lit(p.command)}, ${lit(p.database)}, ${lit(p.username)}, ${p.active})`,
+        const row = group[0] as CronJobRow;
+        const username = normalizeOwner(row.username);
+        // Warn + EMIT (never drop): pg_cron demands SUPERUSER for any non-NULL
+        // `username` argument, and a job owned by a role OTHER than the
+        // profile's assumed executor cannot have that argument elided. The
+        // statement stays in the export/plan so a superuser executor can apply
+        // it; this is the early signal for why a plain connection would be
+        // rejected. Covers `drop()` too — `cron.unschedule` of another role's
+        // job is equally privileged.
+        if (defaultJobOwner !== undefined && username !== defaultJobOwner) {
+          diagnostics.push({
+            code: INTENT_PRIVILEGED,
+            severity: "warning",
+            message:
+              `pg_cron job '${jobname}' is owned by role '${username}', not the ` +
+              `profile's default job owner '${defaultJobOwner}'; reconstructing ` +
+              `it requires a superuser connection`,
+            context: { ext: "pg_cron", intentKind: "job" },
+          });
+        }
+        const id = jobIntentId(jobname);
+        facts.push({
+          id,
+          payload: {
+            schedule: row.schedule,
+            command: row.command,
+            database: row.database,
+            username,
+            active: row.active,
           },
-        ];
-      },
-      drop(fact) {
-        const key = (fact.id as Extract<StableId, { kind: "extensionIntent" }>)
-          .key;
-        return {
-          sql: `select cron.unschedule(${lit(key)})`,
-          dataLoss: "none",
-        };
-      },
-    } satisfies IntentKindRule,
-  },
+        });
+        if (dependsOnExtension) {
+          edges.push({ from: id, to: PG_CRON, kind: "depends" });
+        }
+      }
 
-  // pg_cron's schedule* functions run ONLY in the cluster's `cron.database_name`
-  // (default `postgres`). A co-located shadow database `schema apply` creates is
-  // never that database, so a declarative dir containing cron intent could never
-  // load there. Detect it and fail early with a clear remediation instead of a
-  // mid-load "function cron.schedule_in_database does not exist" stuck error.
-  shadowPrecheck: {
-    matchesStatement(masked) {
-      // `cron.<fn>(` survives literal masking (unquoted schema + function name);
-      // this is the intent replay a cron export/schema always contains.
-      return /\bcron\s*\.\s*(schedule|schedule_in_database|unschedule|alter_job)\s*\(/i.test(
-        masked,
-      );
+      return { facts, edges, diagnostics };
     },
-    async capable(query) {
-      const rows = await query(
-        `SELECT current_setting('cron.database_name', true) AS db,
+
+    intentKinds: {
+      job: {
+        payloadAttrs: ["schedule", "command", "database", "username", "active"],
+        create(fact) {
+          const key = (
+            fact.id as Extract<StableId, { kind: "extensionIntent" }>
+          ).key;
+          const p = fact.payload as {
+            schedule: string;
+            command: string;
+            database: string;
+            username: string;
+            active: boolean;
+          };
+          // Replay ALL captured fields deterministically via the 6-arg
+          // `cron.schedule_in_database(job_name, schedule, command, database,
+          // username, active)`. The 3-arg `cron.schedule` form would always
+          // (re)create the job in the CURRENT database, active, owned by the
+          // executing user — so a job that is inactive, targets another
+          // database, or has a non-current username would never converge. The
+          // 6-arg signature has been stable since pg_cron 1.4 (2021), which
+          // every supported PostgreSQL image and the supabase/postgres image
+          // ship, so this stays compatible across the pg_cron versions we
+          // target. String args keep `lit()` quoting; `active` is a bare
+          // boolean literal.
+          //
+          // USERNAME ELISION. pg_cron rejects a non-NULL `username` argument
+          // unless the caller is SUPERUSER — even when it names the calling role
+          // itself ("must be superuser to create a job for another role"). A
+          // bare `NULL` means `current_user` and needs no privilege. When the
+          // profile declares a `defaultJobOwner` it is also declaring who
+          // executes the plan (the same assumption `policy.defaultOwner` already
+          // encodes for `ALTER … OWNER TO`), so a job owned by that role replays
+          // with `NULL` and stays applyable by a plain connection — the ordinary
+          // hosted-Supabase case, where `postgres` is NOT a superuser. A job
+          // owned by anyone else keeps the explicit literal (it genuinely needs a
+          // superuser executor) and got an `INTENT_PRIVILEGED` warning at
+          // capture. Convergence is unaffected: the executor IS the default
+          // owner, so the created row's username is that role and re-capture
+          // hashes identically. `database` and `active` stay explicit — only
+          // `username` has a safe, meaningful default.
+          const username =
+            defaultJobOwner !== undefined && p.username === defaultJobOwner
+              ? "NULL"
+              : lit(p.username);
+          return [
+            {
+              sql:
+                `select cron.schedule_in_database(${lit(key)}, ${lit(p.schedule)}, ` +
+                `${lit(p.command)}, ${lit(p.database)}, ${username}, ${p.active})`,
+            },
+          ];
+        },
+        drop(fact) {
+          const key = (
+            fact.id as Extract<StableId, { kind: "extensionIntent" }>
+          ).key;
+          return {
+            sql: `select cron.unschedule(${lit(key)})`,
+            dataLoss: "none",
+          };
+        },
+      } satisfies IntentKindRule,
+    },
+
+    // pg_cron's schedule* functions run ONLY in the cluster's `cron.database_name`
+    // (default `postgres`). A co-located shadow database `schema apply` creates is
+    // never that database, so a declarative dir containing cron intent could never
+    // load there. Detect it and fail early with a clear remediation instead of a
+    // mid-load "function cron.schedule_in_database does not exist" stuck error.
+    shadowPrecheck: {
+      matchesStatement(masked) {
+        // `cron.<fn>(` survives literal masking (unquoted schema + function name);
+        // this is the intent replay a cron export/schema always contains.
+        return /\bcron\s*\.\s*(schedule|schedule_in_database|unschedule|alter_job)\s*\(/i.test(
+          masked,
+        );
+      },
+      async capable(query) {
+        const rows = await query(
+          `SELECT current_setting('cron.database_name', true) AS db,
                 current_database() AS cur,
                 EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') AS avail`,
-      );
-      const row = rows[0] as
-        | { db: string | null; cur: string; avail: boolean }
-        | undefined;
-      if (row === undefined || !row.avail) {
-        return {
-          capable: false,
-          reason:
-            "pg_cron is not available in the shadow (not in shared_preload_libraries)",
-        };
-      }
-      if (row.db === null || row.db !== row.cur) {
-        return {
-          capable: false,
-          reason: `the shadow database "${row.cur}" is not the cron database (cron.database_name = ${row.db === null ? "unset" : `"${row.db}"`})`,
-        };
-      }
-      return { capable: true };
+        );
+        const row = rows[0] as
+          | { db: string | null; cur: string; avail: boolean }
+          | undefined;
+        if (row === undefined || !row.avail) {
+          return {
+            capable: false,
+            reason:
+              "pg_cron is not available in the shadow (not in shared_preload_libraries)",
+          };
+        }
+        if (row.db === null || row.db !== row.cur) {
+          return {
+            capable: false,
+            reason: `the shadow database "${row.cur}" is not the cron database (cron.database_name = ${row.db === null ? "unset" : `"${row.db}"`})`,
+          };
+        }
+        return { capable: true };
+      },
     },
-  },
-};
+  };
+}
+
+/**
+ * The UNCONFIGURED pg_cron handler: no default job owner, no owner aliases.
+ *
+ * Public API (`@supabase/pg-delta/integrations`) and the `--profile <file>`
+ * handler registry both expose it under this name, and it is the right default
+ * for a `raw`/custom profile — such an executor is its own authority (typically
+ * a superuser), so nothing is elided and no privilege warning is raised. The
+ * Supabase profile builds its own instance via {@link makePgCronHandler}.
+ */
+export const pgCronHandler: ExtensionHandler = makePgCronHandler();

--- a/packages/pg-delta/tests/extension-intent-cron-privileges.test.ts
+++ b/packages/pg-delta/tests/extension-intent-cron-privileges.test.ts
@@ -1,0 +1,203 @@
+/**
+ * pg_cron job replay must be applyable by the NON-SUPERUSER executor a real
+ * Supabase project hands out (`postgres`), not just by the platform-internal
+ * `supabase_admin`.
+ *
+ * pg_cron's `cron.schedule_in_database(..., username, ...)` requires SUPERUSER
+ * whenever the `username` argument is non-NULL — even when it names the calling
+ * role itself. Passing `NULL` means "current_user" and needs no privilege. So a
+ * plan that replays a `postgres`-owned job with an explicit `'postgres'`
+ * username literal is unapplyable on a hosted project:
+ *
+ *     ERROR: must be superuser to create a job for another role
+ *
+ * Every OTHER cron integration test (`extension-intent-cron.test.ts`) drives the
+ * shared cluster's `adminPool`, which connects as `supabase_admin` — a genuine
+ * superuser — so none of them can see this. This file therefore uses
+ * `startStandaloneSupabase()`, whose `postgres` role is deliberately reshaped
+ * into a NON-superuser member of `supabase_privileged_role`, exactly like
+ * Supabase Cloud, and executes the planned SQL over `postgresConnectionUri()`.
+ *
+ * pg_cron only works in the cluster's `cron.database_name` (default `postgres`),
+ * so everything here runs against that one database; extraction/planning still
+ * goes through the admin connection (that is the platform's own extraction
+ * identity) while APPLY is deliberately the non-superuser one.
+ *
+ * Gated behind `PGDELTA_NEXT_SUPABASE_TESTS` like every other Supabase-image
+ * test (pg_cron is absent from stock `postgres:*-alpine`).
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import pg from "pg";
+import { plan } from "../src/plan/plan.ts";
+import {
+  type IntegrationProfile,
+  resolveProfile,
+} from "../src/integrations/profile.ts";
+import { SUPABASE_EXTENSION_HANDLERS } from "../src/integrations/supabase.ts";
+import {
+  runSupabaseBareTests,
+  startStandaloneSupabase,
+  type StartedStandaloneSupabase,
+} from "./containers.ts";
+
+/** The pg_cron handler AS THE SUPABASE PROFILE COMPOSES IT — the elision is a
+ *  property of that composition (the profile declares the default job owner),
+ *  not of the bare, platform-neutral handler. Isolating it in a minimal profile
+ *  keeps the test about the cron mechanism, not the whole Supabase policy. */
+const supabaseCronHandler = SUPABASE_EXTENSION_HANDLERS.find(
+  (h) => h.extension === "pg_cron",
+);
+
+const cronProfile: IntegrationProfile = {
+  id: "test-cron-privileges",
+  handlers: supabaseCronHandler === undefined ? [] : [supabaseCronHandler],
+};
+
+describe.skipIf(!runSupabaseBareTests)(
+  "extension-intent: pg_cron job replay as a non-superuser executor",
+  () => {
+    let container: StartedStandaloneSupabase;
+    let adminPool: pg.Pool;
+    let userPool: pg.Pool;
+
+    beforeAll(async () => {
+      container = await startStandaloneSupabase();
+      adminPool = new pg.Pool({
+        connectionString: container.connectionUri(),
+        max: 1,
+      });
+      adminPool.on("error", () => {});
+      userPool = new pg.Pool({
+        connectionString: container.postgresConnectionUri(),
+        max: 1,
+      });
+      userPool.on("error", () => {});
+
+      await adminPool.query(`CREATE EXTENSION IF NOT EXISTS pg_cron`);
+      // the documented Supabase enablement step — `postgres` manages its own
+      // jobs through the `cron` schema.
+      await adminPool.query(`GRANT USAGE ON SCHEMA cron TO postgres`);
+    }, 300_000);
+
+    afterAll(async () => {
+      await adminPool?.end().catch(() => {});
+      await userPool?.end().catch(() => {});
+      await container?.stop().catch(() => {});
+    });
+
+    test("the profile's cron handler is present", () => {
+      expect(supabaseCronHandler).toBeDefined();
+    });
+
+    test("`postgres` is a NON-superuser (the whole point of this file)", async () => {
+      const { rows } = await userPool.query<{
+        rolsuper: boolean;
+        me: string;
+      }>(
+        `SELECT rolsuper, current_user AS me FROM pg_roles WHERE rolname = current_user`,
+      );
+      expect(rows[0]?.me).toBe("postgres");
+      expect(rows[0]?.rolsuper).toBe(false);
+    });
+
+    test("a postgres-owned job's planned replay applies as the non-superuser postgres role and converges", async () => {
+      const ctx = await resolveProfile(adminPool, cronProfile);
+
+      // SOURCE snapshot: no such job.
+      const sourceFb = (await ctx.extract(adminPool)).factBase;
+
+      // DESIRED snapshot: a job created BY `postgres` itself, so its
+      // `cron.job.username` is `postgres` — the ordinary hosted-project shape.
+      await userPool.query(
+        `SELECT cron.schedule('pgdelta_np_replay', '0 0 * * *', 'select 1')`,
+      );
+      const desiredFb = (await ctx.extract(adminPool)).factBase;
+
+      const thePlan = plan(sourceFb, desiredFb, {
+        ...ctx.planOptions,
+        renames: "off",
+      });
+
+      const scheduleAction = thePlan.actions.find((a) =>
+        /select cron\.schedule_in_database\('pgdelta_np_replay'/.test(a.sql),
+      );
+      expect(scheduleAction).toBeDefined();
+
+      // reset to SOURCE: `postgres` owns the job, so it can unschedule it.
+      await userPool.query(`SELECT cron.unschedule('pgdelta_np_replay')`);
+
+      // THE REGRESSION: execute the planned replay as the non-superuser
+      // `postgres` — exactly what `pgdelta apply`/the CLI loader does against a
+      // hosted project. With an explicit username literal pg_cron rejects this
+      // with "must be superuser to create a job for another role".
+      await userPool.query(scheduleAction?.sql as string);
+
+      // the job exists, owned by postgres…
+      const { rows } = await adminPool.query<{
+        username: string;
+        schedule: string;
+        active: boolean;
+      }>(
+        `SELECT username, schedule, active FROM cron.job WHERE jobname = 'pgdelta_np_replay'`,
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.username).toBe("postgres");
+      expect(rows[0]?.schedule).toBe("0 0 * * *");
+      expect(rows[0]?.active).toBe(true);
+
+      // …and re-planning against the same desired state is a no-op, so the
+      // elided username still converges on the captured fact.
+      const reappliedFb = (await ctx.extract(adminPool)).factBase;
+      const secondPlan = plan(reappliedFb, desiredFb, {
+        ...ctx.planOptions,
+        renames: "off",
+      });
+      expect(secondPlan.actions.length).toBe(0);
+
+      await userPool.query(`SELECT cron.unschedule('pgdelta_np_replay')`);
+    }, 300_000);
+
+    test("an INACTIVE postgres-owned job also replays as the non-superuser role", async () => {
+      const ctx = await resolveProfile(adminPool, cronProfile);
+
+      const sourceFb = (await ctx.extract(adminPool)).factBase;
+
+      // the shape pg-delta's own export produces for a paused job — the 6-arg
+      // form is unavoidable here (the 3-arg one always creates active jobs), so
+      // it must stay applyable by a non-superuser.
+      await userPool.query(
+        `SELECT cron.schedule_in_database('pgdelta_np_inactive', '0 0 * * *', 'select 1', current_database(), NULL, false)`,
+      );
+      const desiredFb = (await ctx.extract(adminPool)).factBase;
+
+      const thePlan = plan(sourceFb, desiredFb, {
+        ...ctx.planOptions,
+        renames: "off",
+      });
+      const scheduleAction = thePlan.actions.find((a) =>
+        /select cron\.schedule_in_database\('pgdelta_np_inactive'/.test(a.sql),
+      );
+      expect(scheduleAction).toBeDefined();
+
+      await adminPool.query(
+        `DELETE FROM cron.job WHERE jobname = 'pgdelta_np_inactive'`,
+      );
+
+      await userPool.query(scheduleAction?.sql as string);
+
+      const { rows } = await adminPool.query<{
+        username: string;
+        active: boolean;
+      }>(
+        `SELECT username, active FROM cron.job WHERE jobname = 'pgdelta_np_inactive'`,
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.username).toBe("postgres");
+      expect(rows[0]?.active).toBe(false);
+
+      await adminPool.query(
+        `DELETE FROM cron.job WHERE jobname = 'pgdelta_np_inactive'`,
+      );
+    }, 300_000);
+  },
+);

--- a/packages/pg-delta/tests/extension-intent-cron.test.ts
+++ b/packages/pg-delta/tests/extension-intent-cron.test.ts
@@ -382,9 +382,16 @@ describe.skipIf(!runSupabaseBareTests)(
     // `supabaseProfile` — the full managed view (supabase policy + baseline +
     // the bundled pgPartmanHandler) must NOT filter out a user cron job's intent
     // fact, and the replay must apply cleanly against a Supabase database. ──────
-    test("supabaseProfile bundles pgCronHandler", () => {
-      expect(SUPABASE_EXTENSION_HANDLERS).toContain(pgCronHandler);
-      expect(supabaseProfile.handlers).toContain(pgCronHandler);
+    // by EXTENSION NAME, not identity: the profile composes its own instance
+    // via `makePgCronHandler({ defaultJobOwner, jobOwnerAliases })`, so it is
+    // deliberately NOT the unconfigured `pgCronHandler` singleton.
+    test("supabaseProfile bundles a pg_cron handler", () => {
+      expect(SUPABASE_EXTENSION_HANDLERS.map((h) => h.extension)).toContain(
+        "pg_cron",
+      );
+      expect(supabaseProfile.handlers?.map((h) => h.extension)).toContain(
+        "pg_cron",
+      );
     });
 
     test("supabase context: a user cron job plans + applies as intent through supabaseProfile", async () => {


### PR DESCRIPTION
## Problem

pg-delta replays pg_cron jobs via the 6-arg `cron.schedule_in_database(name, schedule, command, database, username, active)` with an **explicit username literal**. pg_cron (verified on 1.6.4, the Supabase image) requires SUPERUSER for any non-NULL `username` argument — **even when it names the calling role itself**:

```
-- as non-superuser postgres (rolsuper = f):
select cron.schedule_in_database('probe', '0 0 * * *', 'select 1', 'postgres', 'postgres', false);
-- ERROR:  must be superuser to create a job for another role

select cron.schedule_in_database('probe', '0 0 * * *', 'select 1', 'postgres', NULL, false);
-- OK — row created with username = postgres, active = false
```

Since hosted Supabase hands users a non-superuser `postgres` role, every plan or export containing a pg_cron job was unapplyable by the role it targets. Surfaced by the Supabase CLI declarative-schema integration (shadow load as `postgres`).

## Fix

- **`makePgCronHandler({ defaultJobOwner, jobOwnerAliases })`** — the handler is now a platform-neutral factory; zero platform role strings remain in `pg-cron.ts`. The Supabase integration constructs it with `defaultJobOwner: supabasePolicy.defaultOwner` (single source of truth for the profile's assumed executor) and the CLI-1435 `supabase_read_only_user → postgres` owner alias.
- **Username elision**: a job owned by the profile's default job owner renders `NULL` as the username argument (`NULL` = `current_user`, no privilege needed). Jobs owned by a third role keep the explicit literal — they genuinely require a superuser executor — and now raise a new `intent-privileged` **warning** diagnostic at capture (warn + emit, never silently drop; non-blocking).
- **Custom profile files** (`--profile ./file.json`) derive `defaultJobOwner` from their own declared `policy.defaultOwner` via a name→factory handler map. Profiles with no declared default owner (`raw`, bare `pgCronHandler`) keep today's explicit rendering.

## RED → GREEN

RED (new integration test, pre-fix, non-superuser `postgres` via `startStandaloneSupabase()` — the existing cron tests run as `supabase_admin`, which is why this was never caught):

```
error: must be superuser to create a job for another role
   routine: "ScheduleCronJob"
2 pass / 2 fail
```

GREEN after the fix; the test also re-extracts and asserts the job row converges (username = postgres).

## Verification (PRs into feat/pg-delta-next get no test CI — local gates)

- New regression `tests/extension-intent-cron-privileges.test.ts`: **4 pass / 0 fail** (PGDELTA_NEXT_SUPABASE_TESTS=1)
- Existing cron suites (`extension-intent-cron`, `schema-apply-cron-guard`): **10 pass / 0 fail**
- Full unit suite `bun test src/`: **1024 pass / 0 fail**
- Full corpus, `postgres:17-alpine`: **648 pass / 0 fail**
- `bun run build` + `format-and-lint:fix` + `check-types` clean; knip's only failure is the pre-existing pg-topo "unused files" noise (byte-identical on a stashed tree)

Changeset: `patch` for `@supabase/pg-delta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)