### PR TITLE
fix(pg-delta): schedule expression-evaluating actions after all ready definitions

### DIFF
--- a/.changeset/tidy-donkeys-tap.md
+++ b/.changeset/tidy-donkeys-tap.md
@@ -2,4 +2,4 @@
 "@supabase/pg-delta": patch
 ---
 
-Plan ordering: actions that evaluate user expressions at apply time (column defaults, generated columns, CHECK validation, expression indexes, materialized-view population) are now scheduled after all ready definition actions, so opaque quoted routine bodies can resolve their helpers.
+Plan ordering: actions that evaluate user expressions at apply time (column defaults, generated columns, CHECK validation, expression indexes, materialized-view population) are now scheduled after all ready definition actions, so opaque quoted routine bodies can resolve their helpers. An action counts as evaluating whenever a routine is *reachable* from the expression's recorded dependencies — including indirectly, e.g. a materialized view that selects from a view which calls the routine.

--- a/.changeset/tidy-donkeys-tap.md
+++ b/.changeset/tidy-donkeys-tap.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Plan ordering: actions that evaluate user expressions at apply time (column defaults, generated columns, CHECK validation, expression indexes) are now scheduled after all ready definition actions, so opaque quoted routine bodies can resolve their helpers.

--- a/.changeset/tidy-donkeys-tap.md
+++ b/.changeset/tidy-donkeys-tap.md
@@ -2,4 +2,4 @@
 "@supabase/pg-delta": patch
 ---
 
-Plan ordering: actions that evaluate user expressions at apply time (column defaults, generated columns, CHECK validation, expression indexes) are now scheduled after all ready definition actions, so opaque quoted routine bodies can resolve their helpers.
+Plan ordering: actions that evaluate user expressions at apply time (column defaults, generated columns, CHECK validation, expression indexes, materialized-view population) are now scheduled after all ready definition actions, so opaque quoted routine bodies can resolve their helpers.

--- a/.changeset/tidy-donkeys-tap.md
+++ b/.changeset/tidy-donkeys-tap.md
@@ -2,4 +2,4 @@
 "@supabase/pg-delta": patch
 ---
 
-Plan ordering: actions that evaluate user expressions at apply time (column defaults, generated columns, CHECK validation, expression indexes, materialized-view population) are now scheduled after all ready definition actions, so opaque quoted routine bodies can resolve their helpers. An action counts as evaluating whenever a routine is *reachable* from the expression's recorded dependencies — including indirectly, e.g. a materialized view that selects from a view which calls the routine.
+Plan ordering: actions that evaluate user expressions at apply time (column defaults, generated columns, CHECK validation, expression indexes, materialized-view population) are now scheduled after all ready definition actions, so opaque quoted routine bodies can resolve their helpers. An action counts as evaluating whenever a routine is *reachable* from the expression's recorded structure — including indirectly, e.g. a materialized view that selects from a view which calls the routine, or a column whose domain type carries a CHECK that calls it.

--- a/packages/pg-delta/corpus/function-ops--quoted-body-check-validation/a.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-check-validation/a.sql
@@ -1,0 +1,6 @@
+CREATE SCHEMA app;
+
+CREATE TABLE app.events (
+  id bigint PRIMARY KEY,
+  code text NOT NULL
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-check-validation/b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-check-validation/b.sql
@@ -1,0 +1,32 @@
+-- A VALIDATED CHECK constraint SCANS the existing rows while it is added, so it
+-- RUNS app.is_valid_code() — whose quoted SQL body calls app.z_valid_codes(),
+-- an unrecorded hop.
+--
+-- The helper is deliberately BLOCKED behind a view (`RETURNS SETOF
+-- app.valid_codes` is a real pg_depend edge), so it cannot be created until the
+-- view is. Constraints (weight 10) tie-break ahead of views (12), so without an
+-- evaluator stratum the ADD CONSTRAINT overtakes both and the validation scan
+-- calls a routine that does not exist yet.
+CREATE SCHEMA app;
+
+CREATE TABLE app.events (
+  id bigint PRIMARY KEY,
+  code text NOT NULL
+);
+
+CREATE VIEW app.valid_codes AS SELECT 'ok'::text AS code;
+
+CREATE FUNCTION app.z_valid_codes()
+ RETURNS SETOF app.valid_codes
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT * FROM app.valid_codes$function$;
+
+CREATE FUNCTION app.is_valid_code(candidate text)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT EXISTS (SELECT 1 FROM app.z_valid_codes() vc WHERE vc.code = candidate)$function$;
+
+ALTER TABLE app.events
+  ADD CONSTRAINT events_code_valid CHECK (app.is_valid_code(code));

--- a/packages/pg-delta/corpus/function-ops--quoted-body-check-validation/seed-b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-check-validation/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.events (id, code) VALUES (1, 'ok');

--- a/packages/pg-delta/corpus/function-ops--quoted-body-check-validation/seed.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-check-validation/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.events (id, code) VALUES (1, 'ok');

--- a/packages/pg-delta/corpus/function-ops--quoted-body-default-evaluation/a.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-default-evaluation/a.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA app;
+
+CREATE TABLE app.downloads (
+  id bigint PRIMARY KEY
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-default-evaluation/b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-default-evaluation/b.sql
@@ -1,0 +1,38 @@
+-- Execution-time evaluation of an opaque routine chain.
+--
+-- `ADD COLUMN … DEFAULT app.api_request_client_info()` does not merely
+-- REFERENCE the routine: PostgreSQL RUNS it while applying the statement (to
+-- materialize attmissingval / rewrite the rows). The only pg_depend edge the
+-- catalog records is default → api_request_client_info; that routine's QUOTED
+-- SQL body calls api_request_header, which calls api_request_headers, and
+-- neither call is recorded anywhere. So the engine cannot learn the transitive
+-- chain — it must schedule the evaluating statement after every ready
+-- definition instead.
+--
+-- Mirrors dbdev's 20230405163940_download_metrics.sql. The definition order
+-- below only satisfies THIS fixture's own check_function_bodies; the engine
+-- derives its apply order from the catalog, not from this file.
+CREATE SCHEMA app;
+
+CREATE FUNCTION app.api_request_headers()
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT coalesce(current_setting('request.headers', true), '{}')::jsonb$function$;
+
+CREATE FUNCTION app.api_request_header(header_name text)
+ RETURNS text
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT app.api_request_headers() ->> header_name$function$;
+
+CREATE FUNCTION app.api_request_client_info()
+ RETURNS text
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT coalesce(app.api_request_header('user-agent'), 'unknown')$function$;
+
+CREATE TABLE app.downloads (
+  id bigint PRIMARY KEY,
+  client_info text DEFAULT app.api_request_client_info()
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-default-evaluation/seed-b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-default-evaluation/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.downloads (id) VALUES (1);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-default-evaluation/seed.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-default-evaluation/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.downloads (id) VALUES (1);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-domain-check-default/a.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-domain-check-default/a.sql
@@ -1,0 +1,31 @@
+-- The domain AND its CHECK already exist here; only the helper that the CHECK's
+-- wrapper opaquely calls, plus the column that uses the domain, are new in b.
+--
+-- Why the domain must PRE-EXIST: `CREATE DOMAIN` inlines its validated CHECKs
+-- (rules/types.ts, via alsoProduces), so a from-scratch domain create already
+-- produces the `constraint` fact and is classified an evaluator by its DIRECT
+-- routine edge. The gap only shows when the domain is untouched and the COLUMN
+-- is the evaluating action.
+--
+-- `app.wrapper` is PL/pgSQL on purpose: plpgsql bodies are not name-resolved at
+-- CREATE FUNCTION time, so this fixture loads cleanly under the default
+-- check_function_bodies even though `app.z_helper` does not exist yet — and
+-- pg_depend never records an edge from wrapper to it.
+CREATE SCHEMA app;
+
+CREATE FUNCTION app.wrapper(v text)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ IMMUTABLE
+AS $function$
+BEGIN
+  RETURN app.z_helper(v);
+END;
+$function$;
+
+CREATE DOMAIN app.checked_text AS text
+  CONSTRAINT checked_text_ok CHECK (app.wrapper(VALUE));
+
+CREATE TABLE app.entries (
+  id bigint PRIMARY KEY
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-domain-check-default/b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-domain-check-default/b.sql
@@ -1,0 +1,35 @@
+-- `ADD COLUMN val app.checked_text DEFAULT 'ok'` on a POPULATED table coerces the
+-- default into the domain, which RUNS the domain's CHECK — so the column create
+-- is an execution-time statement that executes app.wrapper() and, through its
+-- opaque PL/pgSQL body, app.z_helper().
+--
+-- A domain's CHECK constraints are CHILD facts (kind `constraint`, parent kind
+-- `domain`), NOT outgoing edges of the domain fact. The column's only recorded
+-- dependency is `column -> domain`, so a reachability walk that follows edges
+-- alone finds no routine, leaves the column in the definition stratum, and its
+-- weight (5) beats the new helper's routine weight (8).
+CREATE SCHEMA app;
+
+CREATE FUNCTION app.z_helper(v text)
+ RETURNS boolean
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$SELECT length(v) > 0$function$;
+
+CREATE FUNCTION app.wrapper(v text)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ IMMUTABLE
+AS $function$
+BEGIN
+  RETURN app.z_helper(v);
+END;
+$function$;
+
+CREATE DOMAIN app.checked_text AS text
+  CONSTRAINT checked_text_ok CHECK (app.wrapper(VALUE));
+
+CREATE TABLE app.entries (
+  id bigint PRIMARY KEY,
+  val app.checked_text DEFAULT 'ok'
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-domain-check-default/seed-b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-domain-check-default/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.entries (id) VALUES (1);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-domain-check-default/seed.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-domain-check-default/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.entries (id) VALUES (1);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-generated-column/a.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-generated-column/a.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA app;
+
+CREATE TABLE app.downloads (
+  id bigint PRIMARY KEY
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-generated-column/b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-generated-column/b.sql
@@ -1,0 +1,33 @@
+-- Same opaque routine chain as function-ops--quoted-body-default-evaluation,
+-- but materialized through a STORED generated column instead of a DEFAULT.
+--
+-- A generated column carries NO `default` fact: the extractor shadows the
+-- expression's pg_depend edges onto the COLUMN fact itself. The backfill still
+-- RUNS api_request_client_info() while the ADD COLUMN applies, and the quoted
+-- bodies below hide the api_request_header / api_request_headers hops from the
+-- catalog. Generation expressions must be IMMUTABLE, hence the chain is
+-- immutable here.
+CREATE SCHEMA app;
+
+CREATE FUNCTION app.api_request_headers()
+ RETURNS jsonb
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$SELECT '{"user-agent": "pgdelta"}'::jsonb$function$;
+
+CREATE FUNCTION app.api_request_header(header_name text)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$SELECT app.api_request_headers() ->> header_name$function$;
+
+CREATE FUNCTION app.api_request_client_info()
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$SELECT coalesce(app.api_request_header('user-agent'), 'unknown')$function$;
+
+CREATE TABLE app.downloads (
+  id bigint PRIMARY KEY,
+  client_info text GENERATED ALWAYS AS (app.api_request_client_info() || ':' || id::text) STORED
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-generated-column/seed-b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-generated-column/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.downloads (id) VALUES (1);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-generated-column/seed.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-generated-column/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.downloads (id) VALUES (1);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-index-expression/a.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-index-expression/a.sql
@@ -1,0 +1,6 @@
+CREATE SCHEMA app;
+
+CREATE TABLE app.documents (
+  id bigint PRIMARY KEY,
+  title text NOT NULL
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-index-expression/b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-index-expression/b.sql
@@ -1,0 +1,29 @@
+-- Building an expression index EVALUATES the expression for every existing row,
+-- so `app.normalize_title()` runs at apply time and its quoted SQL body's call
+-- to `app.normalize_title_inner()` is invisible to pg_depend (index expressions
+-- must be IMMUTABLE, hence the chain is immutable).
+--
+-- Indexes carry the heaviest create weight in the rule table (14), so this
+-- class already ordered correctly before the evaluator stratum existed; the
+-- scenario is a PIN that keeps it that way as weights evolve.
+CREATE SCHEMA app;
+
+CREATE TABLE app.documents (
+  id bigint PRIMARY KEY,
+  title text NOT NULL
+);
+
+CREATE FUNCTION app.normalize_title_inner(input text)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$SELECT lower(btrim(input))$function$;
+
+CREATE FUNCTION app.normalize_title(input text)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$SELECT app.normalize_title_inner(input)$function$;
+
+CREATE INDEX documents_title_norm_idx
+  ON app.documents ((app.normalize_title(title)));

--- a/packages/pg-delta/corpus/function-ops--quoted-body-index-expression/seed-b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-index-expression/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.documents (id, title) VALUES (1, '  Hello World  ');

--- a/packages/pg-delta/corpus/function-ops--quoted-body-index-expression/seed.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-index-expression/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.documents (id, title) VALUES (1, '  Hello World  ');

--- a/packages/pg-delta/corpus/function-ops--quoted-body-matview-evaluation/a.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-matview-evaluation/a.sql
@@ -1,0 +1,6 @@
+CREATE SCHEMA app;
+
+CREATE TABLE app.source_rows (
+  id bigint PRIMARY KEY,
+  code text NOT NULL
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-matview-evaluation/b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-matview-evaluation/b.sql
@@ -1,0 +1,38 @@
+-- `CREATE MATERIALIZED VIEW … AS <query>` is emitted WITHOUT `WITH NO DATA`, so
+-- applying it RUNS the query — a matview create is an execution-time statement,
+-- not a definition-time one.
+--
+-- app.a_eval's query calls app.wrapper() (a recorded pg_depend edge, via the
+-- matview's _RETURN rewrite rule). wrapper's QUOTED SQL body then calls
+-- app.z_helper(), which the catalog never records. z_helper is in turn BLOCKED
+-- behind app.z_blocker (`RETURNS SETOF app.z_blocker` is a real edge), so it
+-- cannot be created until that matview is.
+--
+-- Both matviews carry the same create weight (13), and `a_eval` sorts before
+-- `z_blocker` by encoded subject id — so without an evaluator stratum the
+-- populating matview runs first and its query calls a routine that does not
+-- exist yet.
+CREATE SCHEMA app;
+
+CREATE TABLE app.source_rows (
+  id bigint PRIMARY KEY,
+  code text NOT NULL
+);
+
+CREATE MATERIALIZED VIEW app.z_blocker AS
+  SELECT id, code FROM app.source_rows;
+
+CREATE FUNCTION app.z_helper()
+ RETURNS SETOF app.z_blocker
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT * FROM app.z_blocker$function$;
+
+CREATE FUNCTION app.wrapper()
+ RETURNS bigint
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT count(*) FROM app.z_helper()$function$;
+
+CREATE MATERIALIZED VIEW app.a_eval AS
+  SELECT app.wrapper() AS blocked_row_count;

--- a/packages/pg-delta/corpus/function-ops--quoted-body-matview-evaluation/seed-b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-matview-evaluation/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.source_rows (id, code) VALUES (1, 'ok'), (2, 'also-ok');

--- a/packages/pg-delta/corpus/function-ops--quoted-body-matview-evaluation/seed.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-matview-evaluation/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.source_rows (id, code) VALUES (1, 'ok'), (2, 'also-ok');

--- a/packages/pg-delta/corpus/function-ops--quoted-body-matview-via-view/a.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-matview-via-view/a.sql
@@ -1,0 +1,6 @@
+CREATE SCHEMA app;
+
+CREATE TABLE app.source_rows (
+  id bigint PRIMARY KEY,
+  code text NOT NULL
+);

--- a/packages/pg-delta/corpus/function-ops--quoted-body-matview-via-view/b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-matview-via-view/b.sql
@@ -1,0 +1,41 @@
+-- A matview's evaluated "expression" is a whole QUERY, so a routine it executes
+-- need not be a DIRECT dependency: `app.a_eval` selects from the plain view
+-- `app.bridge`, and its only recorded pg_depend edge is to that view. Populating
+-- a_eval expands bridge and RUNS app.wrapper() anyway.
+--
+-- (`CREATE VIEW` itself evaluates nothing — bridge is a definition, and its edge
+-- to wrapper is enough to order it. Only the matview populates.)
+--
+-- wrapper's QUOTED SQL body then calls app.z_helper(), which the catalog never
+-- records, and z_helper is BLOCKED behind app.z_blocker (`RETURNS SETOF
+-- app.z_blocker` is a real edge). Both matviews share create weight 13 and
+-- `a_eval` sorts before `z_blocker` by encoded subject id, so a classifier that
+-- only looks for a DIRECT routine edge leaves a_eval in the definition stratum
+-- and the populate runs before z_helper exists.
+CREATE SCHEMA app;
+
+CREATE TABLE app.source_rows (
+  id bigint PRIMARY KEY,
+  code text NOT NULL
+);
+
+CREATE MATERIALIZED VIEW app.z_blocker AS
+  SELECT id, code FROM app.source_rows;
+
+CREATE FUNCTION app.z_helper()
+ RETURNS SETOF app.z_blocker
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT * FROM app.z_blocker$function$;
+
+CREATE FUNCTION app.wrapper()
+ RETURNS bigint
+ LANGUAGE sql
+ STABLE
+AS $function$SELECT count(*) FROM app.z_helper()$function$;
+
+CREATE VIEW app.bridge AS
+  SELECT app.wrapper() AS blocked_row_count;
+
+CREATE MATERIALIZED VIEW app.a_eval AS
+  SELECT * FROM app.bridge;

--- a/packages/pg-delta/corpus/function-ops--quoted-body-matview-via-view/seed-b.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-matview-via-view/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.source_rows (id, code) VALUES (1, 'ok'), (2, 'also-ok');

--- a/packages/pg-delta/corpus/function-ops--quoted-body-matview-via-view/seed.sql
+++ b/packages/pg-delta/corpus/function-ops--quoted-body-matview-via-view/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO app.source_rows (id, code) VALUES (1, 'ok'), (2, 'also-ok');

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -53,6 +53,32 @@ export type SubEntityKind = (typeof SUBENTITY_KINDS)[number];
 export const ROUTINE_KINDS = ["function", "procedure", "aggregate"] as const;
 export type RoutineKind = (typeof ROUTINE_KINDS)[number];
 
+/**
+ * Kinds whose fact materializes a USER EXPRESSION that PostgreSQL EVALUATES
+ * while the DDL is applied, rather than merely recording it:
+ *   - `default`   — `ADD COLUMN … DEFAULT f()` / `SET DEFAULT` (attmissingval
+ *                   or a full rewrite);
+ *   - `column`    — a STORED generated column (it carries NO `default` fact:
+ *                   the extractor shadows the expression's edges onto the
+ *                   column itself), backfilled on ADD COLUMN;
+ *   - `constraint`— a VALIDATED CHECK scans the existing rows (PK/UNIQUE/FK
+ *                   never reference a routine, so listing the whole kind
+ *                   over-marks nothing in practice, and an EXCLUDE builds an
+ *                   index anyway);
+ *   - `index`     — an expression index evaluates its expression per row.
+ *
+ * The planner's evaluator stratum (plan/internal.ts) uses this to sink such
+ * actions below every simultaneously-ready DEFINITION action, because their
+ * routine's OPAQUE quoted body may call helpers pg_depend never recorded.
+ * Kept next to ROUTINE_KINDS so the classifier needs no FactKind literals.
+ */
+export const EVALUATED_EXPRESSION_KINDS = [
+  "column",
+  "constraint",
+  "default",
+  "index",
+] as const satisfies readonly FactKind[];
+
 export type StableId =
   | { kind: SimpleKind; name: string }
   | { kind: QualifiedKind; schema: string; name: string }

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -82,10 +82,12 @@ export type RoutineKind = (typeof ROUTINE_KINDS)[number];
  *
  * This list gates WHICH facts get tested; the test itself is transitive — *an
  * action is an evaluator iff applying it can execute a user routine, i.e. a
- * routine is REACHABLE from its evaluated expression's recorded dependencies.*
- * The subquery-free kinds (`default`, `column`, `constraint`, `index`) can only
- * reference a routine directly, but a `materializedView`'s expression is a whole
- * query, so its routine may sit behind an intermediate view.
+ * routine is REACHABLE from its evaluated expression's recorded structure.* That
+ * structure is the `depends` edges PLUS the parent→child descents declared in
+ * EVALUATED_CHILD_DESCENT below. The subquery-free kinds (`default`, `column`,
+ * `constraint`, `index`) can only reference a routine directly, but a
+ * `materializedView`'s expression is a whole query, so its routine may sit behind
+ * an intermediate view.
  */
 export const EVALUATED_EXPRESSION_KINDS = [
   "column",
@@ -94,6 +96,24 @@ export const EVALUATED_EXPRESSION_KINDS = [
   "index",
   "materializedView",
 ] as const satisfies readonly FactKind[];
+
+/**
+ * `[parent, child]` kind pairs the evaluator reachability walk descends INTO, on
+ * top of `depends` edges. Some expressions a statement executes are recorded as
+ * CHILD facts of a referenced object rather than as edges out of it:
+ *
+ *   - `["domain", "constraint"]` — a domain's CHECKs are children of the domain,
+ *     and nothing links the domain fact to the routines they call. Storing a
+ *     value in that domain RUNS them, so `ADD COLUMN col <domain> DEFAULT …`
+ *     (whose only edge is `column -> domain`) must see them.
+ *
+ * Deliberately a narrow allowlist, NOT general child descent: a matview over a
+ * table must not inherit the table's column defaults — populating a matview
+ * never evaluates them, and inheriting them would sink half the plan.
+ */
+export const EVALUATED_CHILD_DESCENT = [
+  ["domain", "constraint"],
+] as const satisfies ReadonlyArray<readonly [FactKind, FactKind]>;
 
 export type StableId =
   | { kind: SimpleKind; name: string }

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -79,6 +79,13 @@ export type RoutineKind = (typeof ROUTINE_KINDS)[number];
  * actions below every simultaneously-ready DEFINITION action, because their
  * routine's OPAQUE quoted body may call helpers pg_depend never recorded.
  * Kept next to ROUTINE_KINDS so the classifier needs no FactKind literals.
+ *
+ * This list gates WHICH facts get tested; the test itself is transitive — *an
+ * action is an evaluator iff applying it can execute a user routine, i.e. a
+ * routine is REACHABLE from its evaluated expression's recorded dependencies.*
+ * The subquery-free kinds (`default`, `column`, `constraint`, `index`) can only
+ * reference a routine directly, but a `materializedView`'s expression is a whole
+ * query, so its routine may sit behind an intermediate view.
  */
 export const EVALUATED_EXPRESSION_KINDS = [
   "column",

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -65,7 +65,15 @@ export type RoutineKind = (typeof ROUTINE_KINDS)[number];
  *                   never reference a routine, so listing the whole kind
  *                   over-marks nothing in practice, and an EXCLUDE builds an
  *                   index anyway);
- *   - `index`     — an expression index evaluates its expression per row.
+ *   - `index`     — an expression index evaluates its expression per row;
+ *   - `materializedView`
+ *                 — the create rule emits `CREATE MATERIALIZED VIEW … AS
+ *                   <query>` with NO `WITH NO DATA` (plan/rules/views.ts), so
+ *                   applying it RUNS the query. The `_RETURN` rewrite rule's
+ *                   deps are attributed to the matview fact itself
+ *                   (extract/dependencies.ts), so a routine the query calls IS
+ *                   a `depends` edge on this fact. A plain `view` is NOT
+ *                   listed: `CREATE VIEW` only records the rewrite rule.
  *
  * The planner's evaluator stratum (plan/internal.ts) uses this to sink such
  * actions below every simultaneously-ready DEFINITION action, because their
@@ -77,6 +85,7 @@ export const EVALUATED_EXPRESSION_KINDS = [
   "constraint",
   "default",
   "index",
+  "materializedView",
 ] as const satisfies readonly FactKind[];
 
 export type StableId =

--- a/packages/pg-delta/src/plan/evaluator-stratum.test.ts
+++ b/packages/pg-delta/src/plan/evaluator-stratum.test.ts
@@ -86,6 +86,16 @@ const referenced = routine(
 );
 const helper = routine("api_request_header", "SELECT 'user-agent'");
 
+const relationFact =
+  (kind: "view" | "materializedView") =>
+  (name: string, def: string): Fact => ({
+    id: { kind, schema: "app", name },
+    parent: schemaId,
+    payload: { owner: "test", def, reloptions: null },
+  });
+const matview = relationFact("materializedView");
+const view = relationFact("view");
+
 // the ONLY recorded edge: the default's direct reference.
 const edges: DependencyEdge[] = [
   { from: defaultId, to: referenced.id, kind: "depends" },
@@ -130,11 +140,6 @@ describe("evaluator stratum", () => {
     // `z_blocker` (`RETURNS SETOF z_blocker` — a recorded edge). Both matviews
     // share weight 13 and `a_eval` sorts first by encoded id, so only the
     // stratum can keep the populating one last.
-    const matview = (name: string, def: string): Fact => ({
-      id: { kind: "materializedView", schema: "app", name },
-      parent: schemaId,
-      payload: { owner: "test", def, reloptions: null },
-    });
     const blocker = matview("z_blocker", "SELECT 1 AS n");
     const evaluating = matview("a_eval", "SELECT app.wrapper() AS n");
     const wrapper = routine("wrapper", "SELECT count(*) FROM app.z_helper()");
@@ -145,6 +150,41 @@ describe("evaluator stratum", () => {
       [schemaFact, blocker, evaluating, wrapper, blockedHelper],
       [
         { from: evaluating.id, to: wrapper.id, kind: "depends" },
+        { from: blockedHelper.id, to: blocker.id, kind: "depends" },
+      ],
+    );
+
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    const evaluatingAt = sql.findIndex((s) =>
+      s.startsWith(`CREATE MATERIALIZED VIEW "app"."a_eval"`),
+    );
+    const helperAt = sql.findIndex((s) =>
+      s.includes(`FUNCTION "app"."z_helper"`),
+    );
+    expect(evaluatingAt).toBeGreaterThanOrEqual(0);
+    expect(helperAt).toBeGreaterThanOrEqual(0);
+    expect(helperAt).toBeLessThan(evaluatingAt);
+  });
+
+  test("a populating matview is an evaluator THROUGH a plain view", () => {
+    // A matview's evaluated expression is a whole QUERY, so the routine it runs
+    // need not be a DIRECT dependency: `a_eval` selects from the view `bridge`
+    // and records an edge only to it. Populating a_eval expands bridge and runs
+    // `wrapper` anyway, so the classifier must follow `depends` edges TRANSITIVELY
+    // to find the routine. (`bridge` itself evaluates nothing at CREATE VIEW.)
+    const blocker = matview("z_blocker", "SELECT 1 AS n");
+    const evaluating = matview("a_eval", "SELECT * FROM app.bridge");
+    const bridge = view("bridge", "SELECT app.wrapper() AS n");
+    const wrapper = routine("wrapper", "SELECT count(*) FROM app.z_helper()");
+    const blockedHelper = routine("z_helper", "SELECT * FROM app.z_blocker");
+
+    const source = buildFactBase([schemaFact], []);
+    const desired = buildFactBase(
+      [schemaFact, blocker, evaluating, bridge, wrapper, blockedHelper],
+      [
+        // NOTE: no a_eval -> wrapper edge; the routine is two hops away.
+        { from: evaluating.id, to: bridge.id, kind: "depends" },
+        { from: bridge.id, to: wrapper.id, kind: "depends" },
         { from: blockedHelper.id, to: blocker.id, kind: "depends" },
       ],
     );

--- a/packages/pg-delta/src/plan/evaluator-stratum.test.ts
+++ b/packages/pg-delta/src/plan/evaluator-stratum.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The evaluator stratum: an action that makes PostgreSQL RUN a user expression
+ * while applying (a column DEFAULT backfill, a generated-column backfill, a
+ * CHECK validation scan, an expression-index build) needs the TRANSITIVE
+ * closure of the routine call graph — but pg_depend only records the DIRECT
+ * reference. A quoted (non-`BEGIN ATOMIC`) SQL body's internal calls are
+ * invisible to the catalog, so the engine cannot learn them.
+ *
+ * The scheduler therefore sinks evaluator actions below every simultaneously
+ * ready DEFINITION action: `ADD COLUMN … DEFAULT referenced()` must not
+ * overtake a still-ready `CREATE FUNCTION helper()` just because the column
+ * kind weight (5) sorts ahead of the routine weight (8).
+ *
+ * Pure — no DB. Only `referenced` carries a pg_depend edge from the default;
+ * `helper` is the hop hidden inside `referenced`'s quoted body, so it is
+ * unreachable through the graph and only the tie-break can order it first.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type DependencyEdge, type Fact } from "../core/fact.ts";
+import type { StableId } from "../core/stable-id.ts";
+import { plan } from "./plan.ts";
+
+const schemaId: StableId = { kind: "schema", name: "app" };
+const schemaFact: Fact = { id: schemaId, payload: { owner: "test" } };
+
+const tableId: StableId = { kind: "table", schema: "app", name: "downloads" };
+const tableFact: Fact = {
+  id: tableId,
+  parent: schemaId,
+  payload: { owner: "test", persistence: "p" },
+};
+const idColumn: Fact = {
+  id: { kind: "column", schema: "app", table: "downloads", name: "id" },
+  parent: tableId,
+  payload: {
+    _position: 1,
+    type: "bigint",
+    notNull: true,
+    collation: null,
+    generatedExpr: null,
+  },
+};
+const clientInfoId: StableId = {
+  kind: "column",
+  schema: "app",
+  table: "downloads",
+  name: "client_info",
+};
+const clientInfoColumn: Fact = {
+  id: clientInfoId,
+  parent: tableId,
+  payload: {
+    _position: 2,
+    type: "text",
+    notNull: false,
+    collation: null,
+    generatedExpr: null,
+  },
+};
+const defaultId: StableId = {
+  kind: "default",
+  schema: "app",
+  table: "downloads",
+  name: "client_info",
+};
+const defaultFact: Fact = {
+  id: defaultId,
+  parent: clientInfoId,
+  payload: { expr: `app.api_request_client_info()` },
+};
+
+// `api_request_client_info` sorts BEFORE `api_request_header` by encoded id, so
+// the pre-fix tie-break created the referenced routine, then took the (lighter)
+// column create, leaving the helper for last.
+const routine = (name: string, body: string): Fact => ({
+  id: { kind: "function", schema: "app", name, args: [] },
+  parent: schemaId,
+  payload: {
+    def: `CREATE FUNCTION "app"."${name}"() RETURNS text LANGUAGE sql STABLE AS $$${body}$$`,
+  },
+});
+const referenced = routine(
+  "api_request_client_info",
+  "SELECT app.api_request_header()",
+);
+const helper = routine("api_request_header", "SELECT 'user-agent'");
+
+// the ONLY recorded edge: the default's direct reference.
+const edges: DependencyEdge[] = [
+  { from: defaultId, to: referenced.id, kind: "depends" },
+];
+
+describe("evaluator stratum", () => {
+  test("both routine creates precede the default-bearing ADD COLUMN", () => {
+    const source = buildFactBase([schemaFact, tableFact, idColumn], []);
+    const desired = buildFactBase(
+      [
+        schemaFact,
+        tableFact,
+        idColumn,
+        clientInfoColumn,
+        defaultFact,
+        referenced,
+        helper,
+      ],
+      edges,
+    );
+
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    const addColumn = sql.findIndex((s) => s.includes("ADD COLUMN"));
+    const referencedAt = sql.findIndex((s) =>
+      s.includes(`"api_request_client_info"`),
+    );
+    const helperAt = sql.findIndex((s) => s.includes(`"api_request_header"`));
+
+    expect(addColumn).toBeGreaterThanOrEqual(0);
+    expect(referencedAt).toBeGreaterThanOrEqual(0);
+    expect(helperAt).toBeGreaterThanOrEqual(0);
+    // the graph edge only guarantees the FIRST of these; the stratum guarantees
+    // the second, and it is the one that was broken.
+    expect(referencedAt).toBeLessThan(addColumn);
+    expect(helperAt).toBeLessThan(addColumn);
+  });
+
+  test("a routine-free default is NOT sunk (no ordering churn)", () => {
+    // same shape, but the default is a literal with no routine edge: the column
+    // create keeps its ordinary weight-5 slot ahead of the routine creates.
+    const constantDefault: Fact = {
+      id: defaultId,
+      parent: clientInfoId,
+      payload: { expr: `'unknown'::text` },
+    };
+    const source = buildFactBase([schemaFact, tableFact, idColumn], []);
+    const desired = buildFactBase(
+      [
+        schemaFact,
+        tableFact,
+        idColumn,
+        clientInfoColumn,
+        constantDefault,
+        referenced,
+        helper,
+      ],
+      [],
+    );
+
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    const addColumn = sql.findIndex((s) => s.includes("ADD COLUMN"));
+    const referencedAt = sql.findIndex((s) =>
+      s.includes(`"api_request_client_info"`),
+    );
+    expect(addColumn).toBeLessThan(referencedAt);
+  });
+});

--- a/packages/pg-delta/src/plan/evaluator-stratum.test.ts
+++ b/packages/pg-delta/src/plan/evaluator-stratum.test.ts
@@ -1,10 +1,11 @@
 /**
  * The evaluator stratum: an action that makes PostgreSQL RUN a user expression
  * while applying (a column DEFAULT backfill, a generated-column backfill, a
- * CHECK validation scan, an expression-index build) needs the TRANSITIVE
- * closure of the routine call graph — but pg_depend only records the DIRECT
- * reference. A quoted (non-`BEGIN ATOMIC`) SQL body's internal calls are
- * invisible to the catalog, so the engine cannot learn them.
+ * CHECK validation scan, an expression-index build, a materialized-view
+ * populate) needs the TRANSITIVE closure of the routine call graph — but
+ * pg_depend only records the DIRECT reference. A quoted (non-`BEGIN ATOMIC`)
+ * SQL body's internal calls are invisible to the catalog, so the engine cannot
+ * learn them.
  *
  * The scheduler therefore sinks evaluator actions below every simultaneously
  * ready DEFINITION action: `ADD COLUMN … DEFAULT referenced()` must not
@@ -120,6 +121,44 @@ describe("evaluator stratum", () => {
     // the second, and it is the one that was broken.
     expect(referencedAt).toBeLessThan(addColumn);
     expect(helperAt).toBeLessThan(addColumn);
+  });
+
+  test("a populating matview waits for a routine blocked behind another matview", () => {
+    // `CREATE MATERIALIZED VIEW … AS <query>` carries no `WITH NO DATA`, so
+    // applying it RUNS the query. `a_eval` calls `wrapper` (recorded edge);
+    // wrapper's opaque body calls `z_helper`, which is itself blocked behind
+    // `z_blocker` (`RETURNS SETOF z_blocker` — a recorded edge). Both matviews
+    // share weight 13 and `a_eval` sorts first by encoded id, so only the
+    // stratum can keep the populating one last.
+    const matview = (name: string, def: string): Fact => ({
+      id: { kind: "materializedView", schema: "app", name },
+      parent: schemaId,
+      payload: { owner: "test", def, reloptions: null },
+    });
+    const blocker = matview("z_blocker", "SELECT 1 AS n");
+    const evaluating = matview("a_eval", "SELECT app.wrapper() AS n");
+    const wrapper = routine("wrapper", "SELECT count(*) FROM app.z_helper()");
+    const blockedHelper = routine("z_helper", "SELECT * FROM app.z_blocker");
+
+    const source = buildFactBase([schemaFact], []);
+    const desired = buildFactBase(
+      [schemaFact, blocker, evaluating, wrapper, blockedHelper],
+      [
+        { from: evaluating.id, to: wrapper.id, kind: "depends" },
+        { from: blockedHelper.id, to: blocker.id, kind: "depends" },
+      ],
+    );
+
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    const evaluatingAt = sql.findIndex((s) =>
+      s.startsWith(`CREATE MATERIALIZED VIEW "app"."a_eval"`),
+    );
+    const helperAt = sql.findIndex((s) =>
+      s.includes(`FUNCTION "app"."z_helper"`),
+    );
+    expect(evaluatingAt).toBeGreaterThanOrEqual(0);
+    expect(helperAt).toBeGreaterThanOrEqual(0);
+    expect(helperAt).toBeLessThan(evaluatingAt);
   });
 
   test("a routine-free default is NOT sunk (no ordering churn)", () => {

--- a/packages/pg-delta/src/plan/evaluator-stratum.test.ts
+++ b/packages/pg-delta/src/plan/evaluator-stratum.test.ts
@@ -201,6 +201,104 @@ describe("evaluator stratum", () => {
     expect(helperAt).toBeLessThan(evaluatingAt);
   });
 
+  test("an ADD COLUMN of a DOMAIN type waits for the routine its CHECK calls", () => {
+    // A domain's CHECK constraints are CHILD facts (kind `constraint`, parent
+    // kind `domain`), NOT outgoing edges of the domain fact. Coercing the new
+    // column's default into the domain RUNS those CHECKs, so reachability has to
+    // descend domain -> constraint to see `wrapper` two hops away.
+    //
+    // The domain, its CHECK and `wrapper` are UNCHANGED (present on both sides),
+    // so no domain action is emitted — the column create is the only evaluator,
+    // and its weight (5) beats the new helper's routine weight (8).
+    const domainId: StableId = {
+      kind: "domain",
+      schema: "app",
+      name: "checked_text",
+    };
+    const domainFact: Fact = {
+      id: domainId,
+      parent: schemaId,
+      payload: {
+        owner: "test",
+        baseType: "text",
+        collation: null,
+        default: null,
+        notNull: false,
+      },
+    };
+    const domainCheck: Fact = {
+      id: {
+        kind: "constraint",
+        schema: "app",
+        table: "checked_text",
+        name: "checked_text_ok",
+      },
+      parent: domainId,
+      payload: {
+        def: "CHECK ((app.wrapper(VALUE)))",
+        type: "c",
+        validated: true,
+      },
+    };
+    const wrapper = routine("wrapper", "SELECT app.z_helper($1)");
+    const blockedHelper = routine("z_helper", "SELECT true");
+    const valColumnId: StableId = {
+      kind: "column",
+      schema: "app",
+      table: "downloads",
+      name: "val",
+    };
+    const valColumn: Fact = {
+      id: valColumnId,
+      parent: tableId,
+      payload: {
+        _position: 2,
+        type: "app.checked_text",
+        notNull: false,
+        collation: null,
+        generatedExpr: null,
+      },
+    };
+    const valDefault: Fact = {
+      id: { kind: "default", schema: "app", table: "downloads", name: "val" },
+      parent: valColumnId,
+      payload: { expr: `'ok'::text` },
+    };
+
+    // `wrapper` is only ever reachable THROUGH the domain's child constraint —
+    // there is deliberately no column/default -> wrapper edge.
+    const unchanged: Fact[] = [
+      schemaFact,
+      tableFact,
+      idColumn,
+      wrapper,
+      domainFact,
+      domainCheck,
+    ];
+    const unchangedEdges: DependencyEdge[] = [
+      { from: domainCheck.id, to: wrapper.id, kind: "depends" },
+      { from: domainCheck.id, to: domainId, kind: "depends" },
+    ];
+    const source = buildFactBase(unchanged, unchangedEdges);
+    const desired = buildFactBase(
+      [...unchanged, valColumn, valDefault, blockedHelper],
+      [
+        ...unchangedEdges,
+        { from: valColumnId, to: domainId, kind: "depends" },
+        { from: valDefault.id, to: domainId, kind: "depends" },
+      ],
+    );
+
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    const addColumn = sql.findIndex((s) => s.includes(`ADD COLUMN "val"`));
+    const helperAt = sql.findIndex((s) =>
+      s.includes(`FUNCTION "app"."z_helper"`),
+    );
+    expect(addColumn).toBeGreaterThanOrEqual(0);
+    expect(helperAt).toBeGreaterThanOrEqual(0);
+    expect(helperAt).toBeLessThan(addColumn);
+  });
+
   test("a routine-free default is NOT sunk (no ordering churn)", () => {
     // same shape, but the default is a literal with no routine edge: the column
     // create keeps its ordinary weight-5 slot ahead of the routine creates.

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -113,54 +113,74 @@ export function buildActionGraph(
   // legitimately contains CYCLES (function <-> table), so the walk carries a
   // visited set.
   //
-  // The memo is shared across the whole classification pass, so total work is
-  // O(V+E) over the depends subgraph: a completed routine-free walk proves every
-  // node it reached is routine-free, so the negative answer is memoized for the
-  // ENTIRE explored set — which is the hot path (most facts reach no routine).
-  // A positive answer memoizes only the queried root, since a path to the
-  // routine does not tell us which explored nodes were on it.
+  // The memo is shared across the whole classification pass, so total work stays
+  // O(V+E) over the traversed subgraph in BOTH outcomes:
+  //  - routine-free: a completed walk proves every node it reached is
+  //    routine-free, so the answer is memoized for the ENTIRE explored set (the
+  //    hot path — most facts reach no routine);
+  //  - routine found: only the nodes on the DISCOVERY PATH from the root to the
+  //    node that saw the routine are provably true, so exactly those are
+  //    memoized (`discoveredFrom` is the DFS-tree parent link, and a DFS-tree
+  //    path is a real path in the graph). Memoizing the whole visited set would
+  //    be WRONG — a sibling branch may reach nothing. Without this, N evaluators
+  //    sharing one deep chain re-traverse it each time (quadratic).
   const routineReachable = new Map<string, boolean>();
   const reachesRoutine = (root: StableId, rootKey: string): boolean => {
     const memoized = routineReachable.get(rootKey);
     if (memoized !== undefined) return memoized;
     const visited = new Set<string>([rootKey]);
-    const stack: StableId[] = [root];
-    let found = false;
+    // node key -> key it was first reached from (undefined for the root)
+    const discoveredFrom = new Map<string, string | undefined>([
+      [rootKey, undefined],
+    ]);
+    const stack: Array<[StableId, string]> = [[root, rootKey]];
+    // key of the node whose successors saw the routine, once one does
+    let hitAt: string | undefined;
     // true when `next` settles the question (it IS a routine, or is already
     // memoized as reaching one); otherwise enqueues it when still unexplored.
-    const consider = (next: StableId): boolean => {
+    const consider = (next: StableId, fromKey: string): boolean => {
       if (ROUTINE_KIND_SET.has(next.kind)) return true;
       const key = encodeId(next);
       const known = routineReachable.get(key);
       if (known === true) return true;
       if (known === false || visited.has(key)) return false;
       visited.add(key);
-      stack.push(next);
+      discoveredFrom.set(key, fromKey);
+      stack.push([next, key]);
       return false;
     };
-    while (stack.length > 0 && !found) {
-      const current = stack.pop() as StableId;
+    while (stack.length > 0 && hitAt === undefined) {
+      const [current, currentKey] = stack.pop() as [StableId, string];
       for (const edge of desired.outgoingEdges(current)) {
         if (edge.kind !== "depends") continue;
-        if (consider(edge.to)) {
-          found = true;
+        if (consider(edge.to, currentKey)) {
+          hitAt = currentKey;
           break;
         }
       }
-      if (found) break;
+      if (hitAt !== undefined) break;
       const descendInto = EVALUATED_DESCENT.get(current.kind);
       if (descendInto === undefined) continue;
       for (const child of desired.childrenOf(current)) {
         if (!descendInto.has(child.id.kind)) continue;
-        if (consider(child.id)) {
-          found = true;
+        if (consider(child.id, currentKey)) {
+          hitAt = currentKey;
           break;
         }
       }
     }
-    if (found) routineReachable.set(rootKey, true);
-    else for (const key of visited) routineReachable.set(key, false);
-    return found;
+    if (hitAt === undefined) {
+      for (const key of visited) routineReachable.set(key, false);
+      return false;
+    }
+    for (
+      let key: string | undefined = hitAt;
+      key !== undefined;
+      key = discoveredFrom.get(key)
+    ) {
+      routineReachable.set(key, true);
+    }
+    return true;
   };
 
   // cache encoded -> StableId for ids we encounter

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -12,7 +12,12 @@
  * boundary, so their invariants are testable in isolation.
  */
 import type { FactBase } from "../core/fact.ts";
-import { encodeId, type StableId } from "../core/stable-id.ts";
+import {
+  encodeId,
+  EVALUATED_EXPRESSION_KINDS,
+  ROUTINE_KINDS,
+  type StableId,
+} from "../core/stable-id.ts";
 import { type ApplierCapability, canSetOwner } from "../policy/capability.ts";
 import { extensionMemberClosure } from "../policy/view.ts";
 import type { Action, SafetyReport } from "./plan.ts";
@@ -20,6 +25,9 @@ import { ruleFlag } from "./rule-flags.ts";
 import { defaultRulesForId, type FoldHint, type RulesForId } from "./rules.ts";
 import { renderGrantSql } from "./rules/helpers.ts";
 import { schemaCreateSql } from "./rules/schemas.ts";
+
+const ROUTINE_KIND_SET = new Set<string>(ROUTINE_KINDS);
+const EVALUATED_KIND_SET = new Set<string>(EVALUATED_EXPRESSION_KINDS);
 
 /**
  * Build the action dependency graph (edges as `[fromIndex, toIndex]`) and check
@@ -51,6 +59,29 @@ export function buildActionGraph(
   // `CREATE EXTENSION … SCHEMA <schema>` whose schema object is filtered out of
   // the view is a valid dependency target, not a stranded reference.
   assumedSchemaNames: ReadonlySet<string> = new Set(),
+  // OUT-param (optional): collects the indices of EVALUATOR actions — actions
+  // that make PostgreSQL RUN a user expression while the statement applies.
+  //
+  // INVARIANT the tie-break then enforces: *no user expression evaluates before
+  // all ready definitions are applied.* Definition-time DDL only needs its
+  // DIRECT references (pg_depend records those completely, and the
+  // check_function_bodies=off preamble covers opaque bodies at CREATE FUNCTION
+  // time); execution-time DDL needs the TRANSITIVE closure of the routine call
+  // graph, which Postgres does NOT record for quoted SQL/PLpgSQL bodies. So an
+  // `ADD COLUMN … DEFAULT wrapper()` whose wrapper's opaque body calls a helper
+  // must not overtake that still-ready helper's CREATE FUNCTION.
+  //
+  // An action qualifies iff it materializes an EVALUATED_EXPRESSION_KINDS fact
+  // that has a pg_depend `depends` edge to a user routine — so `DEFAULT 0` and
+  // `DEFAULT now()` (no edge) stay in the definition stratum and ordering churn
+  // is minimal. Over-marking is SAFE (an action sunk unnecessarily is only
+  // cosmetically later); under-marking reintroduces the bug, so any new rule
+  // that inlines an evaluated expression must have its fact kind listed in
+  // EVALUATED_EXPRESSION_KINDS.
+  //
+  // Collected here rather than in a second pass so it rides the edge walk this
+  // function already performs.
+  evaluatorActions?: Set<number>,
 ): Array<[number, number]> {
   const edges: Array<[number, number]> = [];
 
@@ -178,12 +209,38 @@ export function buildActionGraph(
         );
       }
     }
+    // An alter materializes nothing, so its expression fact is CONSUMED, not
+    // produced: `VALIDATE CONSTRAINT` (NOT VALID → VALID) rescans every row and
+    // `SET DEFAULT` / a generated-expression change re-evaluate the expression.
+    // Same classification, over the consumed ids (see the `evaluatorActions`
+    // parameter doc). Runs before the produces walk below so both paths feed
+    // one set.
+    if (evaluatorActions !== undefined && action.verb === "alter") {
+      for (const id of action.consumes) {
+        if (!EVALUATED_KIND_SET.has(id.kind) || !desired.has(id)) continue;
+        const evaluates = desired
+          .outgoingEdges(id)
+          .some((e) => e.kind === "depends" && ROUTINE_KIND_SET.has(e.to.kind));
+        if (evaluates) {
+          evaluatorActions.add(index);
+          break;
+        }
+      }
+    }
     // build order from the DESIRED state's dependency edges
     const producesKeys = new Set(action.produces.map((id) => encodeId(id)));
     for (const id of action.produces) {
       remember(id);
       if (!desired.has(id)) continue;
+      // hoisted out of the edge loop: the evaluator test below is only a
+      // `depends`-edge-to-routine probe on top of this walk.
+      const evaluatorSink = EVALUATED_KIND_SET.has(id.kind)
+        ? evaluatorActions
+        : undefined;
       for (const edge of desired.outgoingEdges(id)) {
+        if (edge.kind === "depends" && ROUTINE_KIND_SET.has(edge.to.kind)) {
+          evaluatorSink?.add(index);
+        }
         // a rename does not CREATE the owner edge (PG carries the owner across
         // RENAME); ordering the new owner's producer before the rename would,
         // paired with the source-side teardown edge below, form a cycle (P1 #2)
@@ -303,9 +360,10 @@ export function buildActionGraph(
 
 /**
  * Deterministic tie-break key for an action at index `i`: drops first
- * (descending kind weight), then creates/alters (ascending weight), then by
- * subject id, then by emission index (zero-padded so "10" sorts after "9" —
- * multi-spec sequences like the enum value-set migration rely on it).
+ * (descending kind weight), then creates/alters by STRATUM (definitions before
+ * evaluators), then ascending weight, then by subject id, then by emission
+ * index (zero-padded so "10" sorts after "9" — multi-spec sequences like the
+ * enum value-set migration rely on it).
  */
 export function actionTieKey(
   actions: readonly Action[],
@@ -321,6 +379,10 @@ export function actionTieKey(
   // columns in declared order. Returns undefined to fall back to the encoded
   // subject id (every other action is unaffected).
   subjectKeyOf?: (subject: StableId, action: Action) => string | undefined,
+  // Evaluator action indices (buildActionGraph's out-param). Purely a TIE-BREAK
+  // input: no graph edge is added, so genuine function<->table cycles stay
+  // plannable via the existing default-split machinery.
+  evaluatorActions?: ReadonlySet<number>,
 ): string {
   const action = actions[i] as Action;
   const subject =
@@ -335,10 +397,14 @@ export function actionTieKey(
   })();
   const phase = action.verb === "drop" ? "0" : "1";
   const w = action.verb === "drop" ? 99 - weight : weight;
+  // Drops never execute a user body, so the teardown phase is forced to the
+  // definition stratum and stays byte-identical to a stratum-free key.
+  const stratum =
+    action.verb !== "drop" && evaluatorActions?.has(i) === true ? "1" : "0";
   const subjectKey =
     (subject !== undefined ? subjectKeyOf?.(subject, action) : undefined) ??
     (subject ? encodeId(subject) : "");
-  return `${phase}|${String(w).padStart(2, "0")}|${subjectKey}|${String(i).padStart(6, "0")}`;
+  return `${phase}|${stratum}|${String(w).padStart(2, "0")}|${subjectKey}|${String(i).padStart(6, "0")}`;
 }
 
 /**

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -72,11 +72,19 @@ export function buildActionGraph(
   // must not overtake that still-ready helper's CREATE FUNCTION.
   //
   // An action qualifies iff it materializes an EVALUATED_EXPRESSION_KINDS fact
-  // that has a pg_depend `depends` edge to a user routine — so `DEFAULT 0` and
-  // `DEFAULT now()` (no edge) stay in the definition stratum and ordering churn
-  // is minimal. Over-marking is SAFE (an action sunk unnecessarily is only
-  // cosmetically later); under-marking reintroduces the bug, so any new rule
-  // that inlines an evaluated expression must have its fact kind listed in
+  // from which a user routine is REACHABLE by following `depends` edges — i.e.
+  // *applying it can execute a user routine*. Reachability, not a direct edge:
+  // a matview's evaluated expression is a whole QUERY, so a matview selecting
+  // from a plain VIEW that calls an opaque wrapper records an edge only to the
+  // view, yet populating it expands the view and runs the wrapper. (Direct-only
+  // would be exact for the subquery-free kinds — defaults, CHECKs, index
+  // expressions, generated columns cannot contain subqueries — but the query
+  // kinds need the closure.) `DEFAULT 0` / `DEFAULT now()` still reach nothing,
+  // so ordering churn stays small.
+  //
+  // Over-marking is SAFE (an action sunk unnecessarily is only cosmetically
+  // later); under-marking reintroduces the bug, so any new rule that inlines an
+  // evaluated expression must have its fact kind listed in
   // EVALUATED_EXPRESSION_KINDS.
   //
   // Collected here rather than in a second pass so it rides the edge walk this
@@ -84,6 +92,48 @@ export function buildActionGraph(
   evaluatorActions?: Set<number>,
 ): Array<[number, number]> {
   const edges: Array<[number, number]> = [];
+
+  // Memoized "can applying this fact's expression execute a user routine?" —
+  // plain reachability over `depends` edges in the DESIRED state, stopping at
+  // the first ROUTINE_KINDS endpoint. The fact graph legitimately contains
+  // CYCLES (function <-> table), so the walk carries a visited set.
+  //
+  // The memo is shared across the whole classification pass, so total work is
+  // O(V+E) over the depends subgraph: a completed routine-free walk proves every
+  // node it reached is routine-free, so the negative answer is memoized for the
+  // ENTIRE explored set — which is the hot path (most facts reach no routine).
+  // A positive answer memoizes only the queried root, since a path to the
+  // routine does not tell us which explored nodes were on it.
+  const routineReachable = new Map<string, boolean>();
+  const reachesRoutine = (root: StableId, rootKey: string): boolean => {
+    const memoized = routineReachable.get(rootKey);
+    if (memoized !== undefined) return memoized;
+    const visited = new Set<string>([rootKey]);
+    const stack: StableId[] = [root];
+    let found = false;
+    while (stack.length > 0 && !found) {
+      const current = stack.pop() as StableId;
+      for (const edge of desired.outgoingEdges(current)) {
+        if (edge.kind !== "depends") continue;
+        if (ROUTINE_KIND_SET.has(edge.to.kind)) {
+          found = true;
+          break;
+        }
+        const key = encodeId(edge.to);
+        const known = routineReachable.get(key);
+        if (known === true) {
+          found = true;
+          break;
+        }
+        if (known === false || visited.has(key)) continue;
+        visited.add(key);
+        stack.push(edge.to);
+      }
+    }
+    if (found) routineReachable.set(rootKey, true);
+    else for (const key of visited) routineReachable.set(key, false);
+    return found;
+  };
 
   // cache encoded -> StableId for ids we encounter
   const parseKeyCache = new Map<string, StableId>();
@@ -218,10 +268,7 @@ export function buildActionGraph(
     if (evaluatorActions !== undefined && action.verb === "alter") {
       for (const id of action.consumes) {
         if (!EVALUATED_KIND_SET.has(id.kind) || !desired.has(id)) continue;
-        const evaluates = desired
-          .outgoingEdges(id)
-          .some((e) => e.kind === "depends" && ROUTINE_KIND_SET.has(e.to.kind));
-        if (evaluates) {
+        if (reachesRoutine(id, encodeId(id))) {
           evaluatorActions.add(index);
           break;
         }
@@ -232,15 +279,18 @@ export function buildActionGraph(
     for (const id of action.produces) {
       remember(id);
       if (!desired.has(id)) continue;
-      // hoisted out of the edge loop: the evaluator test below is only a
-      // `depends`-edge-to-routine probe on top of this walk.
-      const evaluatorSink = EVALUATED_KIND_SET.has(id.kind)
-        ? evaluatorActions
-        : undefined;
+      // Evaluator classification (see the `evaluatorActions` parameter doc): the
+      // reachability walk is memoized across the pass, and the kind gate keeps
+      // it off every non-expression fact.
+      if (
+        evaluatorActions !== undefined &&
+        !evaluatorActions.has(index) &&
+        EVALUATED_KIND_SET.has(id.kind) &&
+        reachesRoutine(id, encodeId(id))
+      ) {
+        evaluatorActions.add(index);
+      }
       for (const edge of desired.outgoingEdges(id)) {
-        if (edge.kind === "depends" && ROUTINE_KIND_SET.has(edge.to.kind)) {
-          evaluatorSink?.add(index);
-        }
         // a rename does not CREATE the owner edge (PG carries the owner across
         // RENAME); ordering the new owner's producer before the rename would,
         // paired with the source-side teardown edge below, form a cycle (P1 #2)

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -14,6 +14,7 @@
 import type { FactBase } from "../core/fact.ts";
 import {
   encodeId,
+  EVALUATED_CHILD_DESCENT,
   EVALUATED_EXPRESSION_KINDS,
   ROUTINE_KINDS,
   type StableId,
@@ -28,6 +29,16 @@ import { schemaCreateSql } from "./rules/schemas.ts";
 
 const ROUTINE_KIND_SET = new Set<string>(ROUTINE_KINDS);
 const EVALUATED_KIND_SET = new Set<string>(EVALUATED_EXPRESSION_KINDS);
+/** parent kind -> child kinds the evaluator reachability walk descends into. */
+const EVALUATED_DESCENT = ((): ReadonlyMap<string, ReadonlySet<string>> => {
+  const byParent = new Map<string, Set<string>>();
+  for (const [parent, child] of EVALUATED_CHILD_DESCENT) {
+    const children = byParent.get(parent) ?? new Set<string>();
+    children.add(child);
+    byParent.set(parent, children);
+  }
+  return byParent;
+})();
 
 /**
  * Build the action dependency graph (edges as `[fromIndex, toIndex]`) and check
@@ -72,15 +83,16 @@ export function buildActionGraph(
   // must not overtake that still-ready helper's CREATE FUNCTION.
   //
   // An action qualifies iff it materializes an EVALUATED_EXPRESSION_KINDS fact
-  // from which a user routine is REACHABLE by following `depends` edges — i.e.
+  // from which a user routine is REACHABLE through the recorded structure —
+  // `depends` edges plus the EVALUATED_CHILD_DESCENT parent→child pairs — i.e.
   // *applying it can execute a user routine*. Reachability, not a direct edge:
-  // a matview's evaluated expression is a whole QUERY, so a matview selecting
-  // from a plain VIEW that calls an opaque wrapper records an edge only to the
-  // view, yet populating it expands the view and runs the wrapper. (Direct-only
-  // would be exact for the subquery-free kinds — defaults, CHECKs, index
-  // expressions, generated columns cannot contain subqueries — but the query
-  // kinds need the closure.) `DEFAULT 0` / `DEFAULT now()` still reach nothing,
-  // so ordering churn stays small.
+  //   - a matview's evaluated expression is a whole QUERY, so a matview selecting
+  //     from a plain VIEW that calls an opaque wrapper records an edge only to
+  //     the view, yet populating it expands the view and runs the wrapper;
+  //   - `ADD COLUMN col <domain> DEFAULT …` records only `column -> domain`, yet
+  //     coercing the default into the domain runs the domain's CHECKs, which are
+  //     CHILDREN of the domain fact.
+  // `DEFAULT 0` / `DEFAULT now()` still reach nothing, so churn stays small.
   //
   // Over-marking is SAFE (an action sunk unnecessarily is only cosmetically
   // later); under-marking reintroduces the bug, so any new rule that inlines an
@@ -94,9 +106,12 @@ export function buildActionGraph(
   const edges: Array<[number, number]> = [];
 
   // Memoized "can applying this fact's expression execute a user routine?" —
-  // plain reachability over `depends` edges in the DESIRED state, stopping at
-  // the first ROUTINE_KINDS endpoint. The fact graph legitimately contains
-  // CYCLES (function <-> table), so the walk carries a visited set.
+  // reachability in the DESIRED state over `depends` edges PLUS the parent→child
+  // descents declared in EVALUATED_CHILD_DESCENT (a domain's CHECKs are CHILDREN
+  // of the domain, not edges out of it, yet coercing a value into that domain
+  // RUNS them). Stops at the first ROUTINE_KINDS endpoint. The fact graph
+  // legitimately contains CYCLES (function <-> table), so the walk carries a
+  // visited set.
   //
   // The memo is shared across the whole classification pass, so total work is
   // O(V+E) over the depends subgraph: a completed routine-free walk proves every
@@ -111,23 +126,36 @@ export function buildActionGraph(
     const visited = new Set<string>([rootKey]);
     const stack: StableId[] = [root];
     let found = false;
+    // true when `next` settles the question (it IS a routine, or is already
+    // memoized as reaching one); otherwise enqueues it when still unexplored.
+    const consider = (next: StableId): boolean => {
+      if (ROUTINE_KIND_SET.has(next.kind)) return true;
+      const key = encodeId(next);
+      const known = routineReachable.get(key);
+      if (known === true) return true;
+      if (known === false || visited.has(key)) return false;
+      visited.add(key);
+      stack.push(next);
+      return false;
+    };
     while (stack.length > 0 && !found) {
       const current = stack.pop() as StableId;
       for (const edge of desired.outgoingEdges(current)) {
         if (edge.kind !== "depends") continue;
-        if (ROUTINE_KIND_SET.has(edge.to.kind)) {
+        if (consider(edge.to)) {
           found = true;
           break;
         }
-        const key = encodeId(edge.to);
-        const known = routineReachable.get(key);
-        if (known === true) {
+      }
+      if (found) break;
+      const descendInto = EVALUATED_DESCENT.get(current.kind);
+      if (descendInto === undefined) continue;
+      for (const child of desired.childrenOf(current)) {
+        if (!descendInto.has(child.id.kind)) continue;
+        if (consider(child.id)) {
           found = true;
           break;
         }
-        if (known === false || visited.has(key)) continue;
-        visited.add(key);
-        stack.push(edge.to);
       }
     }
     if (found) routineReachable.set(rootKey, true);

--- a/packages/pg-delta/src/plan/phases/action-graph.ts
+++ b/packages/pg-delta/src/plan/phases/action-graph.ts
@@ -93,6 +93,12 @@ export function finalizeActions(input: FinalizeInput): FinalizeOutput {
   } = input;
 
   // ── graph edges + deterministic order ─────────────────────────────────
+  // Actions that RUN a user expression at apply time (a DEFAULT / generated
+  // column backfill, a validated CHECK scan, an expression-index build).
+  // Classified during the edge walk and fed to the tie-break ONLY — never as an
+  // edge — so they sink below every simultaneously ready DEFINITION action
+  // without making legitimate routine<->relation cycles unplannable.
+  const evaluatorActions = new Set<number>();
   const edges = buildActionGraph(
     actions,
     producerOf,
@@ -102,6 +108,7 @@ export function finalizeActions(input: FinalizeInput): FinalizeOutput {
     renameActionIndices,
     assumedRoleNames,
     assumedSchemaNames,
+    evaluatorActions,
   );
 
   // Order a table's ADD COLUMN creates by declared column position
@@ -126,7 +133,8 @@ export function finalizeActions(input: FinalizeInput): FinalizeOutput {
   const order = topoSort(
     actions.length,
     edges,
-    (i) => actionTieKey(actions, i, rulesForId, columnSubjectKey),
+    (i) =>
+      actionTieKey(actions, i, rulesForId, columnSubjectKey, evaluatorActions),
     (i) => (actions[i] as Action).sql,
   );
 


### PR DESCRIPTION
## Problem

Actions that *execute* user routine bodies at apply time — `ADD COLUMN ... DEFAULT f()` backfill, generated-column backfill, CHECK validation over existing rows, expression-index builds, materialized-view population — could be scheduled before helper routines called inside the directly-referenced routine's opaque quoted body. pg_depend records only the direct expression→routine edge, never the body call graph, and `check_function_bodies=off` only protects `CREATE FUNCTION`, not execution-time evaluation. With the tie key sorting column (weight 5) / default (6) before function (8), a ready `ADD COLUMN ... DEFAULT wrapper()` overtook still-ready helpers and apply failed with `function ... does not exist`.

Real-world instance: the dbdev migration chain `api_request_headers() → api_request_header(text) → api_request_client_info() → column DEFAULT` (`tests/fixtures/dbdev-migrations/migrations/20230405163940_download_metrics.sql`), surfaced by the Supabase CLI integration.

## Fix: evaluator stratum

A new component in the create-phase tie key: `${phase}|${stratum}|${weight}|${subject}|${index}`. Among simultaneously-ready actions, all definition actions now schedule before any **evaluator** action — an action materializing an evaluated expression from which a user routine is reachable via recorded pg_depend `depends` edges (transitively — e.g. a materialized view selecting from a view that calls the routine) (`DEFAULT 0` doesn't move; `DEFAULT app.f()` sinks). Classification piggybacks on the edge walk `buildActionGraph` already performs; a new `EVALUATED_EXPRESSION_KINDS` set in `stable-id.ts` (`column`/`constraint`/`default`/`index`/`materializedView` — generated columns shadow their routine edges onto the `column` fact) keeps the kind-literal ratchet untouched.

The stratum is **tie-break only** — no new graph edges, so real catalog dependencies stay authoritative and legitimate function↔table cycles (`table-fn-circular--setof-and-default`) keep converging. Sink-late is the ceiling of pure ordering: if an evaluator runs only when no definition is ready, the only remaining failures are genuine execution-dependency cycles no ordering could satisfy. Drop-phase ordering is byte-identical (stratum forced to 0).

## RED → GREEN evidence

RED (commit 1, tests only):

- `bun test src/plan/evaluator-stratum.test.ts` → `Expected: < 1, Received: 2` (helper CREATE FUNCTION scheduled after the ADD COLUMN)
- `PGDELTA_NEXT_ONLY=quoted-body PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts` → 3 failures:
  - `quoted-body-default-evaluation:forward` — `apply failed at action 1: function app.api_request_header(unknown) does not exist`
  - `quoted-body-generated-column:forward` — same error
  - `quoted-body-check-validation:forward` — `function app.z_valid_codes() does not exist`
  - `quoted-body-index-expression` — already green pre-fix (index weight 14 sorts after functions); kept as an honest pin, labelled as such in the fixture

GREEN (commit 2):

- `bun test src/` → 1029 pass / 0 fail
- `PGDELTA_NEXT_ONLY=quoted-body ...` → 8 pass / 0 fail
- Ordering regression families (`table-fn-circular`, `sql-body-cross-reference`, `ordering-validation`, `fk-ordering`, `check-ordering`, `function-ops`, `default-privileges-ordering`, `complex-dependency-ordering`, `generated-column`, `constraint-ops`, `index-operations`, `column-type`) → 142 pass / 0 fail
- All 7 `budget.json`-bearing scenarios → 72 pass / 0 fail — **zero action-shape churn**
- `bun run build`, `format-and-lint`, `check-types` clean (root `knip` failure on pg-topo unused files is pre-existing and untouched by this PR)

## Notes for reviewers

- Constraint classification covers the whole `constraint` kind rather than only checks: PK/UNIQUE/FK never carry a routine `depends` edge, EXCLUDE builds an index anyway, and over-marking is safe (cosmetically later) while under-marking is not.
- The check-validation fixture blocks its helper behind a `RETURNS SETOF <view>` dependency (weight 12 > constraint 10) so the RED is genuine — a plain CHECK scenario already passed by weight.
- Follow-up risk documented at the classification site: any future rule inlining an evaluated expression under a new fact kind must be added to `EVALUATED_EXPRESSION_KINDS`.

Full corpus + supabase-image gate to be run before merge (no test CI runs on PRs into `feat/pg-delta-next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

