### PR TITLE
fix(pg-delta): exclude pg_depend-internal objects from unmodeled-kind detection

### DIFF
--- a/.changeset/range-cast-unmodeled-false-positive.md
+++ b/.changeset/range-cast-unmodeled-false-positive.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix a false-positive `unmodeled_kind` warning for the range→multirange cast that `CREATE TYPE ... AS RANGE` auto-creates. Unmodeled-kind detection now excludes objects registered as `pg_depend`-internal (`deptype = 'i'`) to another object, since such objects are created and dropped alongside their owner and can never be independently managed DDL — the owner's own fact already covers their lifecycle. Explicit user-authored objects (e.g. a hand-written `CREATE CAST`) are unaffected and still warn.

--- a/packages/pg-delta/src/extract/unmodeled.ts
+++ b/packages/pg-delta/src/extract/unmodeled.ts
@@ -64,6 +64,30 @@ function isExtensionMember(classid: string, oid: string): string {
       AND de.objid = ${oid} AND de.deptype = 'e')`;
 }
 
+/**
+ * Internally dependent on another object (deptype 'i' on the dependent side).
+ * An internal dependent is owned outright by the object it depends on — it is
+ * created alongside that object and dropped when that object is dropped, so
+ * it can never be independently managed DDL. It is that object's internals,
+ * not user state — reporting it as unmodeled would be a false positive as
+ * long as the owning object itself is modeled.
+ *
+ * The canonical case is the range->multirange cast that `CREATE TYPE ... AS
+ * RANGE` auto-creates: it is a `pg_cast` row registered with deptype 'i'
+ * against the range type, and the modeled range type fact already covers its
+ * lifecycle. Deliberately NOT 'a' (auto dependents) — those remain
+ * independently droppable and so stay reportable.
+ *
+ * Mirrors the routine extractor's own `deptype = 'i'` anti-join
+ * (extract/routines.ts), which excludes internally-dependent functions from
+ * extraction for the same reason.
+ */
+function isInternalDependent(classid: string, oid: string): string {
+  return `EXISTS (SELECT 1 FROM pg_depend idep
+    WHERE idep.classid = '${classid}'::regclass
+      AND idep.objid = ${oid} AND idep.deptype = 'i')`;
+}
+
 const PROBES: readonly UnmodeledProbe[] = [
   {
     kind: "cast",
@@ -161,6 +185,7 @@ function probeSql(p: UnmodeledProbe): string {
     p.where,
     `${p.oid} >= ${FIRST_NORMAL_OID}`,
     `NOT ${isExtensionMember(p.classid, p.oid)}`,
+    `NOT ${isInternalDependent(p.classid, p.oid)}`,
   ].filter(Boolean);
   return `SELECT '${p.kind}'::text AS kind,
             count(*)::int AS count,

--- a/packages/pg-delta/tests/unmodeled-kinds.test.ts
+++ b/packages/pg-delta/tests/unmodeled-kinds.test.ts
@@ -105,3 +105,31 @@ describe("extract: unmodeled-kind detection is provenance-aware", () => {
     expect(unmodeled).toEqual([]);
   });
 });
+
+describe("extract: unmodeled-kind detection is deptype='i' aware", () => {
+  let rangeDb: TestDb;
+  let rangeResult: ExtractResult;
+
+  beforeAll(async () => {
+    rangeDb = await createTestDb("unmodeled_range");
+    // CREATE TYPE ... AS RANGE auto-creates a range->multirange cast
+    // (pg_depend deptype = 'i', internal to the range type). The range type
+    // itself is modeled, so its auto-cast is not a silent miss and must NOT
+    // be reported as an unmodeled kind.
+    await rangeDb.pool.query(
+      `CREATE TYPE public.floatrange AS RANGE (subtype = float8)`,
+    );
+    rangeResult = await extract(rangeDb.pool);
+  }, 120_000);
+
+  afterAll(async () => {
+    await rangeDb.drop();
+  });
+
+  test("the range type's auto-created multirange cast is NOT reported", () => {
+    const unmodeled = rangeResult.diagnostics.filter(
+      (d) => d.code === "unmodeled_kind",
+    );
+    expect(unmodeled).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Every schema containing a user-defined range type gets a spurious `unmodeled_kind` warning for a cast:

```
1 unmodeled "cast" object not managed by this engine (e.g. public.floatrange AS public.floatmultirange) — v1 detects but does not model this kind
```

`CREATE TYPE … AS RANGE` makes Postgres auto-create a range→multirange cast (`pg_cast` row with a user-range OID, not extension-owned), so it passes both of the detector's provenance filters. But that cast is registered in `pg_depend` with `deptype = 'i'` (internal) against the range type: it cannot be created or dropped independently, and `DROP TYPE` removes it automatically (verified empirically on PG 14 and PG 17). Since the range type itself is a modeled fact, the cast is the type's internals, not unmanaged user state — a false positive. A genuinely user-authored `CREATE CAST` carries `deptype = 'n'` and must keep warning.

## Fix

Add an `isInternalDependent()` predicate to `src/extract/unmodeled.ts` and apply it as a third filter in `probeSql()`, alongside the existing `FIRST_NORMAL_OID` and extension-member exclusions — generic across all probes. Only `deptype = 'i'` is excluded, deliberately not `'a'` (auto dependents remain independently droppable and stay reportable). This mirrors the routine extractor's existing `deptype = 'i'` anti-join (`src/extract/routines.ts`), which is why the range type's auto-created constructor functions never had this problem.

Not a regression relative to either predecessor: the legacy engine on `main` has no `pg_cast` model and silently ignores all casts with no completeness check at all. Modeling user casts as a first-class fact kind is tracked in [CLI-2147](https://linear.app/supabase/issue/CLI-2147/pg-delta-model-create-cast-pg-cast-as-a-first-class-fact-kind).

## RED → GREEN

RED (first commit, tests only — before the fix):

```
- []
+ [{ code: "unmodeled_kind", context: { count: 1, kind: "cast",
+     samples: ["public.floatrange AS public.floatmultirange"] }, ... }]
(fail) extract: unmodeled-kind detection is deptype='i' aware >
  the range type's auto-created multirange cast is NOT reported
```

GREEN (second commit): the new test passes, and the existing "user `CREATE CAST` still warns" test still passes as the over-filtering guard.

## Validation

- `tests/unmodeled-kinds.test.ts` (postgres:17-alpine): 6 pass / 0 fail
- Full unit suite (`bun test src/`): 1032 pass / 0 fail
- Full corpus (`tests/engine.test.ts`, postgres:17-alpine): 662 pass / 0 fail
- `format-and-lint` clean, `check-types` pass; `knip` findings are pre-existing and unrelated
- Changeset included (`@supabase/pg-delta` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)