### PR TITLE
test(pg-delta): guard isolatedClusterPair against system_identifier collisions

### DIFF
--- a/packages/pg-delta/tests/containers.ts
+++ b/packages/pg-delta/tests/containers.ts
@@ -245,10 +245,48 @@ export async function sharedCluster(): Promise<Cluster> {
   return shared;
 }
 
+async function systemIdentifier(cluster: Cluster): Promise<string> {
+  const res = await cluster.adminPool.query<{ id: string }>(
+    `SELECT system_identifier::text AS id FROM pg_catalog.pg_control_system()`,
+  );
+  const id = res.rows[0]?.id;
+  if (id === undefined) {
+    throw new Error("could not read pg_control_system().system_identifier");
+  }
+  return id;
+}
+
+/** initdb derives pg_control_system().system_identifier from the wall clock
+ *  (seconds + microseconds) and initdb's pid, so two containers initdb'ing
+ *  concurrently can — rarely — collide (observed once on CI PG 15). The
+ *  isolated-shadow lineage guard keys on that identifier, so a colliding pair
+ *  makes every isolated-shadow test fail while all other pair tests pass.
+ *  Verify distinctness and restart the second cluster on collision (a retry
+ *  initdb runs at a later wall-clock second, so one retry suffices). */
+async function startDistinctLineagePair(): Promise<[Cluster, Cluster]> {
+  const [first, second] = await Promise.all([startCluster(), startCluster()]);
+  let candidate = second;
+  for (let attempt = 0; ; attempt++) {
+    const [firstId, candidateId] = await Promise.all([
+      systemIdentifier(first),
+      systemIdentifier(candidate),
+    ]);
+    if (firstId !== candidateId) return [first, candidate];
+    if (attempt >= 2) {
+      throw new Error(
+        "isolatedClusterPair: clusters share a system_identifier after 3 attempts",
+      );
+    }
+    await candidate.stop();
+    candidate = await startCluster();
+  }
+}
+
 let isolatedPair: Promise<[Cluster, Cluster]> | null = null;
-/** Two extra clusters for cluster-level-difference scenarios (A-side, B-side). */
+/** Two extra clusters for cluster-level-difference scenarios (A-side, B-side).
+ *  Guaranteed to be two distinct PostgreSQL lineages (system identifiers). */
 export async function isolatedClusterPair(): Promise<[Cluster, Cluster]> {
-  isolatedPair ??= Promise.all([startCluster(), startCluster()]);
+  isolatedPair ??= startDistinctLineagePair();
   return isolatedPair;
 }
 


### PR DESCRIPTION
## Summary

Hardens the `isolatedClusterPair()` test fixture so the two clusters it returns are guaranteed to be distinct PostgreSQL lineages (distinct `pg_control_system().system_identifier`s).

**Why:** on PR #299's CI run 31271200473, the PG 15 integration leg failed on exactly the two isolated-shadow lineage-guard tests:

- `public schema frontends > planSchemaFiles tolerates a pre-provisioned isolated shadow (Supabase CLI seam)`
- `CLI: schema apply --scope cluster --isolated-shadow > role-containing export reloads and creates the role under cluster scope`

both with "an isolated shadow requires a different PostgreSQL lineage; the supplied shadow shares the target lineage". Every other test that uses the same pair (role renames, memberships, cluster-scope roles) passed, proving the pair was two genuinely distinct clusters that nonetheless shared a `system_identifier`. `initdb` derives that identifier from the wall clock (seconds + microseconds) plus initdb's pid, and the fixture started both containers concurrently with `Promise.all` — two simultaneous initdbs can (rarely) collide. The engine's fail-closed guard is correct; the fixture just broke the contract its name promises.

The fix:
1. Extracts a `systemIdentifier()` helper that queries `pg_control_system().system_identifier`
2. `startDistinctLineagePair()` starts the two clusters and verifies their identifiers differ
3. On collision, restarts the second cluster and retries (bounded at 3 attempts; a retried initdb runs at a later wall-clock second, so one retry suffices)
4. `isolatedClusterPair()` uses it instead of the naive `Promise.all`

No deterministic RED test is practical (it would mean racing initdb's microsecond clock); the RED evidence is the CI failure above — the parent commit's run was green on identical test code, and a re-run of the failed job passed. Validated on `postgres:15-alpine`: `tests/schema-frontends.test.ts` 12/12, `tests/cli.test.ts` 66/66.

## Linked issue

Refs #299 (fixes the flaky PG 15 integration leg observed there)

- [ ] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [ ] Changeset added if this is a user-facing fix/feature (`bunx changeset`) — not needed: test-infrastructure only, no package behavior change
- [x] `bun run format-and-lint` and `bun run check-types` pass

https://claude.ai/code/session_01V8sEZbvNxn7j8UKpxZVwdP