### PR TITLE
feat(pg-delta): pg_partman create_parent intent capture and replay

### DIFF
--- a/.changeset/pg-partman-create-parent-intent.md
+++ b/.changeset/pg-partman-create-parent-intent.md
@@ -44,7 +44,8 @@ driving `plan()` directly: the handler now emits intent facts, and `plan()`
 must be given their replay rules or the rule resolver throws rather than
 silently dropping declared intent. The supported way to obtain them is a
 profile: wrap the handlers in an `IntegrationProfile`
-(`{ id, handlers: [pgPartmanHandler, …] }`), call `resolveProfile(profile)`,
-and spread the returned `planOptions` (which carries `intentRules`) into
-`plan()` — hand-assembling the recipe without a profile is not a supported
-composition.
+(`{ id, handlers: [pgPartmanHandler, …] }`), call
+`await resolveProfile(pool, profile)` (async — it resolves against a live
+connection), and spread the returned `planOptions` (which carries
+`intentRules`) into `plan()` — hand-assembling the recipe without a profile is
+not a supported composition.

--- a/.changeset/pg-partman-create-parent-intent.md
+++ b/.changeset/pg-partman-create-parent-intent.md
@@ -39,8 +39,12 @@ partition at every level stays tagged `managedBy`, so nothing ever plans a
 `DROP TABLE` against them, and partman's auto-created template table is now
 tagged too.
 
-Note for existing callers driving `plan()` directly with `pgPartmanHandler`
-(rather than through `resolveProfile`): the handler now emits intent facts, so
-`plan()` must be given its replay rules via
-`intentRules: buildIntentRuleIndex([pgPartmanHandler])`. Without them the rule
-resolver throws rather than silently dropping declared intent.
+Note for existing callers passing `pgPartmanHandler` to `extract()` and then
+driving `plan()` directly: the handler now emits intent facts, and `plan()`
+must be given their replay rules or the rule resolver throws rather than
+silently dropping declared intent. The supported way to obtain them is a
+profile: wrap the handlers in an `IntegrationProfile`
+(`{ id, handlers: [pgPartmanHandler, …] }`), call `resolveProfile(profile)`,
+and spread the returned `planOptions` (which carries `intentRules`) into
+`plan()` — hand-assembling the recipe without a profile is not a supported
+composition.

--- a/.changeset/pg-partman-create-parent-intent.md
+++ b/.changeset/pg-partman-create-parent-intent.md
@@ -1,0 +1,46 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Capture and replay pg_partman parent registrations as extension intent (CLI-2044).
+
+Registering a partitioned parent with pg_partman is not schema DDL —
+`partman.create_parent(...)` is a function call that writes a row to partman's
+own `part_config` registry and premakes the child partitions. Until now a
+from-scratch declarative rebuild therefore produced a BARE
+`PARTITION BY RANGE` parent: no registration, no children, no maintenance.
+
+`pgPartmanHandler` now captures each `part_config` row as an `extensionIntent`
+fact keyed by the catalog-canonical `<schema>.<table>` and replays it through
+partman's own API — `select partman.create_parent(…)`, ordered after
+`CREATE EXTENSION pg_partman` (a `depends` edge) and after the parent's
+`CREATE TABLE` (a `consumes` edge). The eleven intent columns `create_parent`
+has no argument for (retention, `optimize_constraint`,
+`infinite_time_partitions`, …) replay as a follow-up `UPDATE part_config`,
+emitted only when they differ from partman's own defaults, so they are neither
+lost nor noisy. A database containing a configured parent now round-trips
+through `schema export` → load into a fresh shadow → re-extract with an empty
+diff and an identical `part_config` row.
+
+The full `part_config` column disposition — which of the 29 columns are intent
+reachable from a `create_parent` argument, intent settable only by updating
+`part_config`, or pure runtime state — is documented in the handler header and
+in `docs/architecture/extension-intent.md` §3.3.1, audited against pg_partman
+5.3.1.
+
+Deliberate scope, each recorded in `docs/roadmap/pg-delta-next-follow-ups.md`:
+removing a registration DEREGISTERS it (`DELETE FROM part_config`,
+`dataLoss: "none"`) and destroys no partition — `undo_partition()` needs a
+separate target table and is loop-batched, so it is not renderable as a replay —
+which leaves the orphaned partitions for an explicit second sync round.
+Sub-partitioned sets (`create_sub_parent`) emit the `intent-unsupported` warning
+instead of a fact that could never converge. Phase A is unchanged: every
+partition at every level stays tagged `managedBy`, so nothing ever plans a
+`DROP TABLE` against them, and partman's auto-created template table is now
+tagged too.
+
+Note for existing callers driving `plan()` directly with `pgPartmanHandler`
+(rather than through `resolveProfile`): the handler now emits intent facts, so
+`plan()` must be given its replay rules via
+`intentRules: buildIntentRuleIndex([pgPartmanHandler])`. Without them the rule
+resolver throws rather than silently dropping declared intent.

--- a/docs/architecture/extension-intent.md
+++ b/docs/architecture/extension-intent.md
@@ -242,6 +242,60 @@ it is platform history, not something a policy can express.
   after `CREATE TABLE` + columns/PK. **produces**: the parent intent fact + (via
   `managedBy`) its operational children.
 
+#### 3.3.1 As built (CLI-2044), and where it deviates from the sketch above
+
+The sketch above predates the implementation. `src/policy/extensions/pg-partman.ts`
+is authoritative; its header carries the **full `part_config` column
+disposition table**, audited against **pg_partman 5.3.1** (the version shipped
+in `supabase/postgres:17.6.1.135`). All 29 columns of 5.3.1 are classified:
+
+| class | count | what it is | how it replays |
+|---|---|---|---|
+| (a) | 13 | intent reachable from a `create_parent()` argument | rendered as that named argument |
+| (b) | 11 | intent with **no** `create_parent()` argument (`retention*`, `optimize_constraint`, `infinite_time_partitions`, `inherit_privileges`, `constraint_valid`, `ignore_default_data`, `maintenance_order`) | a follow-up `UPDATE part_config`, emitted only when the intent differs from partman's own defaults |
+| (c) | 5 | runtime state (`datetime_string`, `undo_in_progress`, `maintenance_last_run`, `async_partitioning_in_progress`, `sub_partition_set_full`) | never captured |
+
+Every (a) and (b) column is on the hashed payload, so drift in a (b) column is
+**visible** (it replaces the intent) rather than silently dropped. A unit test
+asserts `payloadAttrs` covers every captured key, so a column added by a future
+partman cannot slip through unnoticed.
+
+Deviations from the sketch, each deliberate:
+
+- **No `parent_sub` intent kind.** A sub-partitioned set is **scoped out** with
+  an `INTENT_UNSUPPORTED` warning (mirroring pgmq's partitioned queues):
+  `create_sub_parent` writes a `part_config_sub` row on the top parent *and* a
+  `part_config` row per partman-created sub-parent, so neither row is a faithful
+  `create_parent` replay. Their partitions stay `managedBy`-tagged at every
+  level, so nothing plans a `DROP TABLE`.
+- **Drop is `DELETE FROM part_config`, not `undo_partition`.**
+  `undo_partition()` requires a separate `p_target_table` to move rows into and
+  is batched by `p_loop_count` (verified on 5.3.1), so it cannot be a replay at
+  all. Deregistering is the minimal honest inverse and destroys nothing
+  (`dataLoss: "none"`); the now-unmanaged partitions surface as ordinary user
+  tables that a second sync round removes under the normal data-loss gate. See
+  the CLI-2044 triage in `docs/roadmap/pg-delta-next-follow-ups.md`.
+- **`partition_type` is `range`/`list` only** (5.3.1's own
+  `check_partition_type`), and `p_type` **does** exist in 5.3.x — it was removed
+  in 5.0 and later reintroduced.
+- **`p_default_table` has no `part_config` column** but is real intent, so it is
+  recovered structurally from `pg_partitioned_table.partdefid <> 0`.
+  `p_start_partition` / `p_offset_id` are one-shot boundaries for the first
+  premade set and are NOT captured; `p_control_not_null` is a pure guard
+  (partman raises on a nullable control column, never mutates) and is always
+  passed as `false`.
+- **`partmanSchema` rides on the payload.** pg_partman is relocatable and an
+  `IntentKindRule` sees only the fact (there is no view on `drop`), so the
+  install schema must be on the payload for the replay to be renderable.
+- **The auto-created template table is `managedBy`.** `create_parent` creates
+  `<partman_schema>.template_<parent_schema>_<parent_name>`, which carries no
+  `pg_depend deptype='e'` and would otherwise export as a user table — an
+  ordering hazard the by-object loader cannot resolve, since `create_parent`
+  creates it `IF NOT EXISTS` and the later `CREATE TABLE` would then fail
+  permanently. A user-supplied template table stays a normal fact and is
+  `consumes`d by the replay (partman errors on a missing one, so the loader's
+  retry rounds converge).
+
 ### 3.4 supabase_vault / pg_net (boundary cases)
 
 - **vault**: **presence-only** handler. Captures "enabled"; never reads

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1228,3 +1228,53 @@ Round 4 (final round — loop capped per the automated-review policy):
   the kept-delta / managed views, mirroring the `USER_MAPPING_UNREADABLE`
   gate's zero-over-block approach lower in the same function.
 
+
+## CLI-2044 triage — pg_partman `create_parent` intent capture and replay
+
+- **Deferred — the DROP path needs a second sync round to converge.**
+  Deregistering a parent is `DELETE FROM part_config` (`dataLoss: "none"`).
+  There is no single-statement inverse of `create_parent`: `undo_partition()`
+  requires a separate `p_target_table` to move rows into and is batched by
+  `p_loop_count` (verified on pg_partman 5.3.1), so it cannot be rendered as a
+  replay. The consequence is deliberate: once the `part_config` row is gone the
+  premade children and the template table lose their `managedBy` tag and become
+  ORDINARY user tables, which the plan — computed before that projection change
+  — did not account for, so a one-shot `apply` leaves them behind and its proof
+  reports drift. A second sync round then drops them explicitly under the normal
+  data-loss gate. The alternative (an opaque `DO` block that mass-`DROP TABLE`s
+  every descendant) was rejected: it would destroy partition data the user never
+  saw planned. A converging one-shot drop needs the planner to re-project after
+  an intent removal, which is planner machinery this slice deliberately left
+  alone. Covered by an explicit assertion in
+  `tests/extension-intent-partman.test.ts` ("drop: an unregistered desired state
+  DEREGISTERS the parent without destroying a single partition"), which asserts
+  the true two-round behaviour rather than a false convergence.
+
+- **Deferred — sub-partitioned sets are scoped out, not replayed.** A
+  `create_sub_parent` set writes a `part_config_sub` row on the top parent AND a
+  partman-authored `part_config` row per sub-parent. Neither is a faithful
+  `create_parent` replay, so both emit `INTENT_UNSUPPORTED` and no fact (their
+  partitions stay `managedBy` at every level, so nothing is ever dropped).
+  Replaying them needs a second intent kind driven by `part_config_sub` plus
+  ordering between the two levels. Same fail-loud gap as pgmq's partitioned
+  queues: a sub-partitioned set declared in the DESIRED state is silently left
+  unmanaged rather than failing the plan — see the CLI-2054 triage above, whose
+  `plan()`-level `intent-unsupported` gate would cover this case too.
+
+- **Deferred — customizations to partman's AUTO-created template table are not
+  captured.** `<partman_schema>.template_<parent_schema>_<parent_name>` is tagged
+  `managedBy` and recreated by `create_parent`, so an index or default a user
+  added to it is lost on a rebuild. Not fixed here because leaving it as an
+  exported fact creates a worse failure: `create_parent` creates it
+  `IF NOT EXISTS`, so under the default by-object export layout the later
+  `CREATE TABLE` fails permanently with "already exists" and no retry round can
+  recover. Users who need a customized template should supply their own via
+  `p_template_table` — that path keeps full fidelity and is `consumes`-ordered.
+
+- **Note for CLI-2054 (pgmq partitioned queues).** The CLI-2054 triage above
+  anticipated that this handler would make pgmq's partitioned queues replayable
+  by sourcing their intervals from `part_config`. That revisit is deliberately
+  NOT done here: a pgmq partitioned queue's parent is registered in
+  `part_config` like any other, so the intervals ARE now captured, but wiring
+  pgmq's `create_partitioned` to consume another handler's facts is a
+  cross-handler dependency this slice did not take on.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1372,3 +1372,22 @@ two are real but out of this PR's partman scope; recorded here.
   planner-machinery family as the two-round drop above. Until then the
   supported path for repartitioning a live set is partman's own tooling,
   not a pg-delta replay.
+
+### Round 3
+
+- **Fixed — the changeset's migration snippet called `resolveProfile(profile)`.**
+  The real signature is `await resolveProfile(pool, profile)` (async, pool
+  first), so a typed caller following the note verbatim failed to compile and
+  an untyped one threw at runtime. Snippet corrected in the changeset.
+
+- **Deferred — switching `templateTable` from partman's auto-created template
+  to a user-supplied one orphans the old auto template.** A second instance of
+  the materialized-set replace class above: the replacement replays
+  `DELETE FROM part_config` + `create_parent(p_template_table := …)` without
+  touching the old `template_<schema>_<name>` table, which the next capture no
+  longer recognises as the configured auto template — it surfaces as an
+  ordinary (empty) user table, the proof reports the drift loudly, and the
+  second sync round drops it under the normal gate, exactly like the two-round
+  deregister path. A faithful one-shot transition needs the same in-place
+  ALTER hook / planner transition gate as the `p_default_table` corner, so it
+  lands with that machinery, not piecemeal here.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1274,7 +1274,101 @@ Round 4 (final round — loop capped per the automated-review policy):
 - **Note for CLI-2054 (pgmq partitioned queues).** The CLI-2054 triage above
   anticipated that this handler would make pgmq's partitioned queues replayable
   by sourcing their intervals from `part_config`. That revisit is deliberately
-  NOT done here: a pgmq partitioned queue's parent is registered in
-  `part_config` like any other, so the intervals ARE now captured, but wiring
-  pgmq's `create_partitioned` to consume another handler's facts is a
-  cross-handler dependency this slice did not take on.
+  NOT done here — and after the PR #400 review fix below, pgmq-owned
+  `part_config` rows (both the `q_` queue table and the `a_` archive table that
+  `pgmq.create_partitioned` registers) are explicitly SKIPPED with an
+  `INTENT_UNSUPPORTED` warning rather than captured. Capturing them produced a
+  wrong replay: an export / from-empty plan contained
+  `create_parent('pgmq.q_x', …)` consuming a table nothing in the plan creates,
+  and a live↔live diff whose desired side lacked the queue planned a
+  `DELETE FROM part_config` that would disable pgmq's own maintenance. Making
+  partitioned queues replayable therefore needs BOTH a pgmq-side intent (the
+  intervals re-sourced from `part_config`) and cross-handler ordering — a
+  dependency no slice has taken on yet.
+
+## PR #400 review triage (Codex) — pg_partman create_parent intent
+
+Five findings; two fixed in the PR (partman scope only), two deferred here, one
+redirected to the pgmq PR (#399).
+
+- **Fixed — pgmq-owned `part_config` rows leaked into create_parent intents
+  (P1).** See the reworded CLI-2054 note above for the failure modes. The fix
+  resolves pgmq's installed schema from `pg_extension` and skips rows whose
+  parent matches a registered queue in `<pgmq_schema>.meta` (both `q_` and `a_`
+  prefixes — `create_partitioned` registers TWO parents, verified on pgmq
+  1.5.1). Detection must come from the catalog: handler capture runs on the
+  RAW pre-projection fact base, so neither fact presence nor cross-handler
+  `managedBy` edges can identify the rows.
+
+- **Fixed — `create_parent` under-reported its relation lock (P2).** The
+  replay spec inherited the intent-rule default `lockClass: "none"`, but
+  `create_parent` takes an explicit `LOCK TABLE … IN ACCESS EXCLUSIVE MODE` on
+  the parent (`pg_partman--5.3.1.sql:1348`). Now `accessExclusive`. The
+  settings `UPDATE` and the deregister `DELETE` stay `"none"` (plain row DML).
+
+- **Deferred — version-keyed handler gating (P1/P2, two findings).** The
+  partman capture projects 5.3.1-audited `part_config` columns
+  (`time_encoder`, `maintenance_order`, …) and pgmq's projects `is_unlogged`;
+  on an older installed extension version the query fails with
+  `undefined_column` and aborts extraction instead of degrading to filter-only
+  behavior. This is the `versions?` handler field the architecture doc already
+  promises (`docs/architecture/extension-intent.md` §risks: "handlers are
+  version-keyed; unsupported versions degrade to filter-only with a notice")
+  but which was never implemented — and it equally affects the shipped pg_cron
+  handler (comment-only "stable since 1.4" posture). Fixing it per-handler
+  inside feature PRs is piecemeal hardening of a framework contract; do it
+  once, across pg_cron + pgmq + pg_partman: resolve `extversion` in capture,
+  compare against a per-handler supported range, and degrade to Phase-A
+  tagging plus a diagnostic outside it.
+
+- **Redirected to PR #399 — `pgmq.drop_queue` lock class (P2).** Valid
+  one-liner (`drop_queue` drops the queue and archive tables → access
+  exclusive), but it is pgmq-handler code owned by the stacked pgmq PR, not
+  this one. Landed there (see the PR #399 triage above).
+
+### Round 2 (post-rebase)
+
+Codex's second pass ran against a rebase that had transiently dropped the
+round-1 fixes (restored since), so one finding is a stale artifact. The other
+two are real but out of this PR's partman scope; recorded here.
+
+- **Stale — "the claimed accessExclusive fix is absent".** True of the
+  reviewed commit only: the branch was rebased over the round-1 push before
+  the re-review ran. The fix commits are restored on top of the rebase;
+  nothing to change.
+
+- **Verified, redirected to the plan/export plumbing — `schema export`
+  bypasses the desired-side intent gates.** The chain is real:
+  `buildSchemaExport` → `reconstructManagedView` → `resolveView` →
+  `buildFactBase` (twice), and `buildFactBase` constructs a fresh
+  `FactBase` whose `.diagnostics` is always `[]` (the constructor cannot
+  carry them), so by the time `export-sql-files` calls `plan()` the
+  desired-side `INTENT_UNKEYED` / `INTENT_UNSUPPORTED` gates read empty
+  diagnostics and pass. Consequence: exporting a database that holds an
+  unreplayable intent (partitioned pgmq queue, sub-partitioned partman set)
+  silently emits an incomplete bare schema instead of failing loudly. NOT
+  new to the partman PR — the `INTENT_UNKEYED` gate on main has the same
+  hole for pg_cron — and the fix (preserve diagnostics across managed-view
+  reconstruction, or evaluate the gate on the pre-projection base) is
+  fact-base/plan plumbing shared with the gate that shipped on the pgmq
+  side of this stack. Fix it there as its own slice, with an export-path
+  regression test.
+
+- **Deferred — arg-backed payload changes on a MATERIALIZED partition set
+  do not converge (Codex round 2 raised the `p_default_table` true→false
+  corner).** Every intent `payloadAttrs` entry is `"replace"` (drop +
+  create), so any arg-backed change replays `DELETE FROM part_config` +
+  `create_parent(...)` against a parent whose partitions (and default
+  partition) already exist physically. For `defaultTable` specifically the
+  replay cannot converge: `create_parent(p_default_table := false)` does
+  not remove the existing default partition, and the next capture recomputes
+  `defaultTable` from `pg_partitioned_table.partdefid`, so the diff
+  reappears (the proof loop reports the drift — the failure is loud, not
+  silent). This is one corner of a class: the intent-rule interface has no
+  in-place ALTER hook, and the handler's `create()` sees only the desired
+  fact, so a faithful transition (`DETACH`/`DROP` of the default partition
+  under the data-loss gate) cannot be expressed today. Needs either an
+  alter-capable intent rule or a planner-level transition gate — the same
+  planner-machinery family as the two-round drop above. Until then the
+  supported path for repartitioning a live set is partman's own tooling,
+  not a pg-delta replay.

--- a/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
@@ -71,7 +71,10 @@ interface ConfigRow {
 /** A `part_config` row with partman 5.3.1's own defaults, plus the auto-created
  *  template table partman names `template_<parent_schema>_<parent_name>`. */
 const config = (
-  overrides: Partial<ConfigRow> & { parent_schema: string; parent_name: string },
+  overrides: Partial<ConfigRow> & {
+    parent_schema: string;
+    parent_name: string;
+  },
 ): ConfigRow => ({
   control: "created_at",
   partition_interval: "1 day",
@@ -264,7 +267,11 @@ describe("pgPartmanHandler.capture", () => {
     const result = await pgPartmanHandler.capture(ctx, current);
 
     expect(result.edges.filter((e) => e.kind === "depends")).toEqual([
-      { from: parentIntentId("public.events"), to: PG_PARTMAN, kind: "depends" },
+      {
+        from: parentIntentId("public.events"),
+        to: PG_PARTMAN,
+        kind: "depends",
+      },
       { from: parentIntentId("app.logs"), to: PG_PARTMAN, kind: "depends" },
     ]);
   });
@@ -294,9 +301,10 @@ describe("pgPartmanHandler.capture", () => {
 
     const result = await pgPartmanHandler.capture(ctx, current);
 
-    expect(
-      (result.facts[0]?.payload as { templateTable: unknown }).templateTable,
-    ).toBeNull();
+    const payload = result.facts[0]?.payload as
+      | { templateTable: unknown }
+      | undefined;
+    expect(payload?.templateTable).toBeNull();
     expect(result.edges.filter((e) => e.kind === "managedBy")).toEqual([
       {
         from: tableId("partman", "template_public_events"),
@@ -328,9 +336,13 @@ describe("pgPartmanHandler.capture", () => {
 
     const result = await pgPartmanHandler.capture(ctx, current);
 
-    expect(
-      (result.facts[0]?.payload as { templateTable: unknown }).templateTable,
-    ).toEqual({ schema: "public", name: "my_template" });
+    const payload = result.facts[0]?.payload as
+      | { templateTable: unknown }
+      | undefined;
+    expect(payload?.templateTable).toEqual({
+      schema: "public",
+      name: "my_template",
+    });
     // NOT managed: the user declared it, so it must keep diffing normally
     expect(result.edges.filter((e) => e.kind === "managedBy")).toEqual([]);
   });
@@ -438,7 +450,9 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       undefined as never,
     );
     expect(actions).toHaveLength(1);
-    expect(actions?.[0]?.sql).toMatchInlineSnapshot(`"select "partman".create_parent(p_parent_table := 'public.events', p_control := 'created_at', p_interval := '1 day', p_type := 'range', p_epoch := 'none', p_premake := 4, p_default_table := true, p_automatic_maintenance := 'on', p_constraint_cols := NULL, p_jobmon := true, p_date_trunc_interval := NULL, p_control_not_null := false, p_time_encoder := NULL, p_time_decoder := NULL)"`);
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(
+      `"select "partman".create_parent(p_parent_table := 'public.events', p_control := 'created_at', p_interval := '1 day', p_type := 'range', p_epoch := 'none', p_premake := 4, p_default_table := true, p_automatic_maintenance := 'on', p_constraint_cols := NULL, p_jobmon := true, p_date_trunc_interval := NULL, p_control_not_null := false, p_time_encoder := NULL, p_time_decoder := NULL)"`,
+    );
   });
 
   test("create: the call CONSUMES the parent table so it orders after CREATE TABLE", () => {
@@ -458,7 +472,9 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       }),
       undefined as never,
     );
-    expect(actions?.[0]?.sql).toMatchInlineSnapshot(`"select "partman".create_parent(p_parent_table := 'public.events', p_control := 'created_at', p_interval := '1 day', p_type := 'range', p_epoch := 'none', p_premake := 4, p_default_table := true, p_automatic_maintenance := 'on', p_constraint_cols := NULL, p_jobmon := true, p_date_trunc_interval := NULL, p_control_not_null := false, p_time_encoder := NULL, p_time_decoder := NULL, p_template_table := 'public.my_template')"`);
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(
+      `"select "partman".create_parent(p_parent_table := 'public.events', p_control := 'created_at', p_interval := '1 day', p_type := 'range', p_epoch := 'none', p_premake := 4, p_default_table := true, p_automatic_maintenance := 'on', p_constraint_cols := NULL, p_jobmon := true, p_date_trunc_interval := NULL, p_control_not_null := false, p_time_encoder := NULL, p_time_decoder := NULL, p_template_table := 'public.my_template')"`,
+    );
     expect(actions?.[0]?.consumes).toEqual([
       { kind: "table", schema: "public", name: "events" },
       { kind: "table", schema: "public", name: "my_template" },
@@ -476,7 +492,9 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       undefined as never,
     );
     expect(actions).toHaveLength(2);
-    expect(actions?.[1]?.sql).toMatchInlineSnapshot(`"update "partman".part_config set "retention" = '3 months', "retention_schema" = NULL, "retention_keep_index" = true, "retention_keep_table" = false, "retention_keep_publication" = false, "optimize_constraint" = 10, "infinite_time_partitions" = true, "inherit_privileges" = false, "constraint_valid" = true, "ignore_default_data" = true, "maintenance_order" = NULL where "parent_table" = 'public.events'"`);
+    expect(actions?.[1]?.sql).toMatchInlineSnapshot(
+      `"update "partman".part_config set "retention" = '3 months', "retention_schema" = NULL, "retention_keep_index" = true, "retention_keep_table" = false, "retention_keep_publication" = false, "optimize_constraint" = 10, "infinite_time_partitions" = true, "inherit_privileges" = false, "constraint_valid" = true, "ignore_default_data" = true, "maintenance_order" = NULL where "parent_table" = 'public.events'"`,
+    );
   });
 
   test("create: every non-default argument is rendered, and the partman schema is quoted", () => {
@@ -498,12 +516,16 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       }),
       undefined as never,
     );
-    expect(actions?.[0]?.sql).toMatchInlineSnapshot(`"select "my partman".create_parent(p_parent_table := 'app.logs', p_control := 'ts', p_interval := '1 week', p_type := 'list', p_epoch := 'seconds', p_premake := 10, p_default_table := false, p_automatic_maintenance := 'off', p_constraint_cols := ARRAY['a', 'b']::text[], p_jobmon := false, p_date_trunc_interval := '1 day', p_control_not_null := false, p_time_encoder := 'public.enc', p_time_decoder := 'public.dec')"`);
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(
+      `"select "my partman".create_parent(p_parent_table := 'app.logs', p_control := 'ts', p_interval := '1 week', p_type := 'list', p_epoch := 'seconds', p_premake := 10, p_default_table := false, p_automatic_maintenance := 'off', p_constraint_cols := ARRAY['a', 'b']::text[], p_jobmon := false, p_date_trunc_interval := '1 day', p_control_not_null := false, p_time_encoder := 'public.enc', p_time_decoder := 'public.dec')"`,
+    );
   });
 
   test("drop: deregisters the parent and is NOT flagged destructive (no table is dropped)", () => {
     const action = parentRule?.drop(parentFact("public.events"));
-    expect(action?.sql).toMatchInlineSnapshot(`"delete from "partman".part_config where "parent_table" = 'public.events'"`);
+    expect(action?.sql).toMatchInlineSnapshot(
+      `"delete from "partman".part_config where "parent_table" = 'public.events'"`,
+    );
     expect(action?.dataLoss ?? "none").toBe("none");
   });
 });

--- a/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
@@ -1,0 +1,519 @@
+/**
+ * Unit tests for the pg_partman handler (docs/architecture/extension-intent.md
+ * §3.3, CLI-2044). No database — a fake `HandlerContext` returns canned rows
+ * keyed off the SQL the handler issues. Covers: the Phase-A `managedBy` walk
+ * (unchanged), the Phase-B `part_config` intent capture (fact shape, payload
+ * split, depends edge, auto-created template-table tagging), the
+ * sub-partitioning `INTENT_UNSUPPORTED` scope-out, and the `intentKinds.parent`
+ * create/drop rendering.
+ */
+import { describe, expect, test } from "bun:test";
+import { INTENT_UNSUPPORTED } from "../../core/diagnostic.ts";
+import { buildFactBase, type Fact } from "../../core/fact.ts";
+import type { HandlerContext } from "../../extract/handler.ts";
+import type { Row } from "../../extract/scope.ts";
+import type { StableId } from "../../core/stable-id.ts";
+import { pgPartmanHandler } from "./pg-partman.ts";
+
+const PG_PARTMAN: StableId = { kind: "extension", name: "pg_partman" };
+const partmanFact: Fact = { id: PG_PARTMAN, payload: {} };
+
+const tableId = (schema: string, name: string): StableId => ({
+  kind: "table",
+  schema,
+  name,
+});
+const tableFact = (schema: string, name: string): Fact => ({
+  id: tableId(schema, name),
+  payload: {},
+});
+
+const parentIntentId = (key: string): StableId => ({
+  kind: "extensionIntent",
+  ext: "pg_partman",
+  intentKind: "parent",
+  key,
+});
+
+/** One `part_config` row as the handler's capture query projects it. */
+interface ConfigRow {
+  parent_schema: string;
+  parent_name: string;
+  control: string;
+  partition_interval: string;
+  partition_type: string;
+  epoch: string;
+  premake: number;
+  automatic_maintenance: string;
+  constraint_cols: string[] | null;
+  template_schema: string | null;
+  template_name: string | null;
+  jobmon: boolean;
+  date_trunc_interval: string | null;
+  time_encoder: string | null;
+  time_decoder: string | null;
+  default_table: boolean;
+  retention: string | null;
+  retention_schema: string | null;
+  retention_keep_index: boolean;
+  retention_keep_table: boolean;
+  retention_keep_publication: boolean;
+  optimize_constraint: number;
+  infinite_time_partitions: boolean;
+  inherit_privileges: boolean;
+  constraint_valid: boolean;
+  ignore_default_data: boolean;
+  maintenance_order: number | null;
+  is_sub_partition_set: boolean;
+  is_sub_partition_child: boolean;
+}
+
+/** A `part_config` row with partman 5.3.1's own defaults, plus the auto-created
+ *  template table partman names `template_<parent_schema>_<parent_name>`. */
+const config = (
+  overrides: Partial<ConfigRow> & { parent_schema: string; parent_name: string },
+): ConfigRow => ({
+  control: "created_at",
+  partition_interval: "1 day",
+  partition_type: "range",
+  epoch: "none",
+  premake: 4,
+  automatic_maintenance: "on",
+  constraint_cols: null,
+  template_schema: "partman",
+  template_name: `template_${overrides.parent_schema}_${overrides.parent_name}`,
+  jobmon: true,
+  date_trunc_interval: null,
+  time_encoder: null,
+  time_decoder: null,
+  default_table: true,
+  retention: null,
+  retention_schema: null,
+  retention_keep_index: true,
+  retention_keep_table: true,
+  retention_keep_publication: false,
+  optimize_constraint: 30,
+  infinite_time_partitions: false,
+  inherit_privileges: false,
+  constraint_valid: true,
+  ignore_default_data: true,
+  maintenance_order: null,
+  is_sub_partition_set: false,
+  is_sub_partition_child: false,
+  ...overrides,
+});
+
+/** A row of the Phase-A `pg_inherits` descendant walk. */
+interface ChildRow {
+  schema: string;
+  name: string;
+}
+
+/** Build a fake ctx: detect() returns partman's install schema (or no rows when
+ *  the extension is absent); the descendant walk and the part_config projection
+ *  return the supplied rows. */
+function fakeCtx(
+  rows: { children?: ChildRow[]; configs?: ConfigRow[] },
+  installed = true,
+): HandlerContext {
+  return {
+    query: async (sql: string): Promise<Row[]> => {
+      if (/pg_extension/i.test(sql)) {
+        return installed ? [{ schema: "partman" }] : [];
+      }
+      if (/descendants\b/i.test(sql) && !/part_config_sub/i.test(sql)) {
+        return (rows.children ?? []) as unknown as Row[];
+      }
+      if (/part_config\b/i.test(sql)) {
+        return (rows.configs ?? []) as unknown as Row[];
+      }
+      throw new Error(`fakeCtx: unexpected query: ${sql}`);
+    },
+  };
+}
+
+describe("pgPartmanHandler.capture", () => {
+  test("not installed → no facts, no edges", async () => {
+    const ctx = fakeCtx({}, false);
+    const current = buildFactBase([], []);
+    const result = await pgPartmanHandler.capture(ctx, current);
+    expect(result.facts).toEqual([]);
+    expect(result.edges).toEqual([]);
+  });
+
+  test("installed with no registered parent → no facts, no edges", async () => {
+    const ctx = fakeCtx({});
+    const current = buildFactBase([partmanFact], []);
+    const result = await pgPartmanHandler.capture(ctx, current);
+    expect(result.facts).toEqual([]);
+    expect(result.edges).toEqual([]);
+  });
+
+  // ── Phase A (unchanged behaviour) ────────────────────────────────────────
+  test("Phase A: every pg_inherits descendant of a registered parent is tagged managedBy", async () => {
+    const ctx = fakeCtx({
+      children: [
+        { schema: "public", name: "events_default" },
+        { schema: "public", name: "events_p20260101" },
+      ],
+    });
+    const current = buildFactBase(
+      [
+        partmanFact,
+        tableFact("public", "events"),
+        tableFact("public", "events_default"),
+        tableFact("public", "events_p20260101"),
+      ],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.edges.filter((e) => e.kind === "managedBy")).toEqual([
+      {
+        from: tableId("public", "events_default"),
+        to: PG_PARTMAN,
+        kind: "managedBy",
+      },
+      {
+        from: tableId("public", "events_p20260101"),
+        to: PG_PARTMAN,
+        kind: "managedBy",
+      },
+    ]);
+  });
+
+  test("Phase A: a child that is not a fact produces no dangling managedBy edge", async () => {
+    const ctx = fakeCtx({
+      children: [
+        { schema: "public", name: "events_default" },
+        { schema: "public", name: "events_p20260101" },
+      ],
+    });
+    const current = buildFactBase(
+      [partmanFact, tableFact("public", "events_default")],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.edges.filter((e) => e.kind === "managedBy")).toEqual([
+      {
+        from: tableId("public", "events_default"),
+        to: PG_PARTMAN,
+        kind: "managedBy",
+      },
+    ]);
+  });
+
+  // ── Phase B: part_config intent capture ──────────────────────────────────
+  test("a registered parent becomes one intent fact keyed by <schema>.<name>", async () => {
+    const ctx = fakeCtx({
+      configs: [config({ parent_schema: "public", parent_name: "events" })],
+    });
+    const current = buildFactBase(
+      [partmanFact, tableFact("public", "events")],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.facts).toHaveLength(1);
+    expect(result.facts[0]?.id).toEqual(parentIntentId("public.events"));
+    expect(result.facts[0]?.payload).toEqual({
+      partmanSchema: "partman",
+      control: "created_at",
+      partitionInterval: "1 day",
+      partitionType: "range",
+      epoch: "none",
+      premake: 4,
+      automaticMaintenance: "on",
+      constraintCols: null,
+      templateTable: null,
+      jobmon: true,
+      dateTruncInterval: null,
+      timeEncoder: null,
+      timeDecoder: null,
+      defaultTable: true,
+      retention: null,
+      retentionSchema: null,
+      retentionKeepIndex: true,
+      retentionKeepTable: true,
+      retentionKeepPublication: false,
+      optimizeConstraint: 30,
+      infiniteTimePartitions: false,
+      inheritPrivileges: false,
+      constraintValid: true,
+      ignoreDefaultData: true,
+      maintenanceOrder: null,
+    });
+  });
+
+  test("each intent fact carries a depends edge on the pg_partman extension fact", async () => {
+    const ctx = fakeCtx({
+      configs: [
+        config({ parent_schema: "public", parent_name: "events" }),
+        config({ parent_schema: "app", parent_name: "logs" }),
+      ],
+    });
+    const current = buildFactBase(
+      [partmanFact, tableFact("public", "events"), tableFact("app", "logs")],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.edges.filter((e) => e.kind === "depends")).toEqual([
+      { from: parentIntentId("public.events"), to: PG_PARTMAN, kind: "depends" },
+      { from: parentIntentId("app.logs"), to: PG_PARTMAN, kind: "depends" },
+    ]);
+  });
+
+  test("depends edge is guarded by current.has(pg_partman) — omitted when the extension fact is absent", async () => {
+    const ctx = fakeCtx({
+      configs: [config({ parent_schema: "public", parent_name: "events" })],
+    });
+    const current = buildFactBase([], []);
+    const result = await pgPartmanHandler.capture(ctx, current);
+    expect(result.facts).toHaveLength(1);
+    expect(result.edges.filter((e) => e.kind === "depends")).toEqual([]);
+  });
+
+  test("partman's AUTO-created template table is tagged managedBy and the payload records templateTable: null", async () => {
+    const ctx = fakeCtx({
+      configs: [config({ parent_schema: "public", parent_name: "events" })],
+    });
+    const current = buildFactBase(
+      [
+        partmanFact,
+        tableFact("public", "events"),
+        tableFact("partman", "template_public_events"),
+      ],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(
+      (result.facts[0]?.payload as { templateTable: unknown }).templateTable,
+    ).toBeNull();
+    expect(result.edges.filter((e) => e.kind === "managedBy")).toEqual([
+      {
+        from: tableId("partman", "template_public_events"),
+        to: PG_PARTMAN,
+        kind: "managedBy",
+      },
+    ]);
+  });
+
+  test("a USER-supplied template table stays a user fact and lands in the payload", async () => {
+    const ctx = fakeCtx({
+      configs: [
+        config({
+          parent_schema: "public",
+          parent_name: "events",
+          template_schema: "public",
+          template_name: "my_template",
+        }),
+      ],
+    });
+    const current = buildFactBase(
+      [
+        partmanFact,
+        tableFact("public", "events"),
+        tableFact("public", "my_template"),
+      ],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(
+      (result.facts[0]?.payload as { templateTable: unknown }).templateTable,
+    ).toEqual({ schema: "public", name: "my_template" });
+    // NOT managed: the user declared it, so it must keep diffing normally
+    expect(result.edges.filter((e) => e.kind === "managedBy")).toEqual([]);
+  });
+
+  test("a sub-partitioned parent emits no fact and one INTENT_UNSUPPORTED warning", async () => {
+    const ctx = fakeCtx({
+      configs: [
+        config({
+          parent_schema: "public",
+          parent_name: "events",
+          is_sub_partition_set: true,
+        }),
+        config({ parent_schema: "app", parent_name: "logs" }),
+      ],
+    });
+    const current = buildFactBase(
+      [partmanFact, tableFact("public", "events"), tableFact("app", "logs")],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.facts.map((f) => (f.id as { key: string }).key)).toEqual([
+      "app.logs",
+    ]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics?.[0]?.code).toBe(INTENT_UNSUPPORTED);
+    expect(result.diagnostics?.[0]?.severity).toBe("warning");
+    expect(result.diagnostics?.[0]?.message).toMatch(/public\.events/);
+    expect(result.diagnostics?.[0]?.context).toEqual({
+      ext: "pg_partman",
+      intentKind: "parent",
+    });
+  });
+
+  test("a partman-created SUB-parent (a child that is itself registered) emits no fact and one warning", async () => {
+    const ctx = fakeCtx({
+      configs: [
+        config({
+          parent_schema: "public",
+          parent_name: "events_p2026",
+          is_sub_partition_child: true,
+        }),
+      ],
+    });
+    const current = buildFactBase([partmanFact], []);
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.facts).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics?.[0]?.code).toBe(INTENT_UNSUPPORTED);
+  });
+});
+
+describe("pgPartmanHandler.intentKinds.parent", () => {
+  const parentRule = pgPartmanHandler.intentKinds?.["parent"];
+
+  const payload = (overrides: Record<string, unknown> = {}) => ({
+    partmanSchema: "partman",
+    control: "created_at",
+    partitionInterval: "1 day",
+    partitionType: "range",
+    epoch: "none",
+    premake: 4,
+    automaticMaintenance: "on",
+    constraintCols: null,
+    templateTable: null,
+    jobmon: true,
+    dateTruncInterval: null,
+    timeEncoder: null,
+    timeDecoder: null,
+    defaultTable: true,
+    retention: null,
+    retentionSchema: null,
+    retentionKeepIndex: true,
+    retentionKeepTable: true,
+    retentionKeepPublication: false,
+    optimizeConstraint: 30,
+    infiniteTimePartitions: false,
+    inheritPrivileges: false,
+    constraintValid: true,
+    ignoreDefaultData: true,
+    maintenanceOrder: null,
+    ...overrides,
+  });
+
+  const parentFact = (
+    key: string,
+    overrides: Record<string, unknown> = {},
+  ): Fact => ({
+    id: parentIntentId(key),
+    payload: payload(overrides),
+  });
+
+  test("payloadAttrs covers EVERY captured payload key (no silent drift hole)", () => {
+    expect([...(parentRule?.payloadAttrs ?? [])].sort()).toEqual(
+      Object.keys(payload()).sort(),
+    );
+  });
+
+  test("create: a default-shaped parent renders one create_parent call, no part_config UPDATE", () => {
+    const actions = parentRule?.create(
+      parentFact("public.events"),
+      undefined as never,
+    );
+    expect(actions).toHaveLength(1);
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot();
+  });
+
+  test("create: the call CONSUMES the parent table so it orders after CREATE TABLE", () => {
+    const actions = parentRule?.create(
+      parentFact("public.events"),
+      undefined as never,
+    );
+    expect(actions?.[0]?.consumes).toEqual([
+      { kind: "table", schema: "public", name: "events" },
+    ]);
+  });
+
+  test("create: a user-supplied template table is passed AND consumed", () => {
+    const actions = parentRule?.create(
+      parentFact("public.events", {
+        templateTable: { schema: "public", name: "my_template" },
+      }),
+      undefined as never,
+    );
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot();
+    expect(actions?.[0]?.consumes).toEqual([
+      { kind: "table", schema: "public", name: "events" },
+      { kind: "table", schema: "public", name: "my_template" },
+    ]);
+  });
+
+  test("create: non-default (b) columns add a second statement — an UPDATE of part_config", () => {
+    const actions = parentRule?.create(
+      parentFact("public.events", {
+        retention: "3 months",
+        retentionKeepTable: false,
+        infiniteTimePartitions: true,
+        optimizeConstraint: 10,
+      }),
+      undefined as never,
+    );
+    expect(actions).toHaveLength(2);
+    expect(actions?.[1]?.sql).toMatchInlineSnapshot();
+  });
+
+  test("create: every non-default argument is rendered, and the partman schema is quoted", () => {
+    const actions = parentRule?.create(
+      parentFact("app.logs", {
+        partmanSchema: "my partman",
+        control: "ts",
+        partitionInterval: "1 week",
+        partitionType: "list",
+        epoch: "seconds",
+        premake: 10,
+        automaticMaintenance: "off",
+        constraintCols: ["a", "b"],
+        jobmon: false,
+        dateTruncInterval: "1 day",
+        timeEncoder: "public.enc",
+        timeDecoder: "public.dec",
+        defaultTable: false,
+      }),
+      undefined as never,
+    );
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot();
+  });
+
+  test("drop: deregisters the parent and is NOT flagged destructive (no table is dropped)", () => {
+    const action = parentRule?.drop(parentFact("public.events"));
+    expect(action?.sql).toMatchInlineSnapshot();
+    expect(action?.dataLoss ?? "none").toBe("none");
+  });
+});
+
+describe("pgPartmanHandler shape", () => {
+  test("declares the pg_partman extension", () => {
+    expect(pgPartmanHandler.extension).toBe("pg_partman");
+  });
+
+  test("has NO shadowPrecheck — partman works in any database (unlike pg_cron)", () => {
+    expect(pgPartmanHandler.shadowPrecheck).toBeUndefined();
+  });
+});

--- a/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
@@ -66,6 +66,7 @@ interface ConfigRow {
   maintenance_order: number | null;
   is_sub_partition_set: boolean;
   is_sub_partition_child: boolean;
+  is_pgmq_queue: boolean;
 }
 
 /** A `part_config` row with partman 5.3.1's own defaults, plus the auto-created
@@ -103,6 +104,7 @@ const config = (
   maintenance_order: null,
   is_sub_partition_set: false,
   is_sub_partition_child: false,
+  is_pgmq_queue: false,
   ...overrides,
 });
 
@@ -112,16 +114,20 @@ interface ChildRow {
   name: string;
 }
 
-/** Build a fake ctx: detect() returns partman's install schema (or no rows when
- *  the extension is absent); the descendant walk and the part_config projection
- *  return the supplied rows. */
+/** Build a fake ctx: the extension-schema probes return partman's (and pgmq's)
+ *  install schema, or no rows when that extension is absent; the descendant walk
+ *  and the part_config projection return the supplied rows. */
 function fakeCtx(
   rows: { children?: ChildRow[]; configs?: ConfigRow[] },
   installed = true,
+  pgmqSchema: string | null = "pgmq",
 ): HandlerContext {
   return {
     query: async (sql: string): Promise<Row[]> => {
       if (/pg_extension/i.test(sql)) {
+        if (/'pgmq'/.test(sql)) {
+          return pgmqSchema === null ? [] : [{ schema: pgmqSchema }];
+        }
         return installed ? [{ schema: "partman" }] : [];
       }
       if (/descendants\b/i.test(sql) && !/part_config_sub/i.test(sql)) {
@@ -402,6 +408,92 @@ describe("pgPartmanHandler.capture", () => {
       "public.events_p2026",
     );
   });
+
+  test("a pgmq-OWNED parent (a partitioned queue's q_/a_ table) emits no fact and one INTENT_UNSUPPORTED warning", async () => {
+    const ctx = fakeCtx({
+      configs: [
+        config({
+          parent_schema: "pgmq",
+          parent_name: "q_jobs",
+          is_pgmq_queue: true,
+        }),
+        config({
+          parent_schema: "pgmq",
+          parent_name: "a_jobs",
+          is_pgmq_queue: true,
+        }),
+        // a sibling ORDINARY parent in the same run: the guard must not be
+        // over-broad and swallow user registrations too
+        config({ parent_schema: "public", parent_name: "events" }),
+      ],
+    });
+    const current = buildFactBase(
+      [
+        partmanFact,
+        tableFact("pgmq", "q_jobs"),
+        tableFact("pgmq", "a_jobs"),
+        tableFact("public", "events"),
+      ],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.facts.map((f) => (f.id as { key: string }).key)).toEqual([
+      "public.events",
+    ]);
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics?.[0]?.code).toBe(INTENT_UNSUPPORTED);
+    expect(result.diagnostics?.[0]?.severity).toBe("warning");
+    expect(result.diagnostics?.[0]?.message).toMatch(/pgmq/);
+    expect(result.diagnostics?.[0]?.message).toMatch(/pgmq\.q_jobs/);
+    expect(result.diagnostics?.[0]?.context).toEqual({
+      ext: "pg_partman",
+      intentKind: "parent",
+    });
+  });
+
+  test("a pgmq-owned parent leaks NO facts or edges — not even its template table", async () => {
+    const ctx = fakeCtx({
+      configs: [
+        config({
+          parent_schema: "pgmq",
+          parent_name: "q_jobs",
+          template_schema: "public",
+          template_name: "my_template",
+          is_pgmq_queue: true,
+        }),
+      ],
+    });
+    const current = buildFactBase(
+      [partmanFact, tableFact("pgmq", "q_jobs"), tableFact("public", "my_template")],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.facts).toEqual([]);
+    expect(result.edges).toEqual([]);
+  });
+
+  test("pgmq NOT installed → ordinary parents still capture (the queue probe degrades)", async () => {
+    const ctx = fakeCtx(
+      { configs: [config({ parent_schema: "public", parent_name: "events" })] },
+      true,
+      null,
+    );
+    const current = buildFactBase(
+      [partmanFact, tableFact("public", "events")],
+      [],
+    );
+
+    const result = await pgPartmanHandler.capture(ctx, current);
+
+    expect(result.facts.map((f) => (f.id as { key: string }).key)).toEqual([
+      "public.events",
+    ]);
+    expect(result.diagnostics ?? []).toEqual([]);
+  });
 });
 
 describe("pgPartmanHandler.intentKinds.parent", () => {
@@ -461,6 +553,17 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
     );
   });
 
+  test("create: create_parent REPORTS its ACCESS EXCLUSIVE lock on the parent", () => {
+    // pg_partman 5.3.1 takes it EXPLICITLY inside create_parent
+    // (`LOCK TABLE %I.%I IN ACCESS EXCLUSIVE MODE`), so the intent-rule default
+    // of "none" would under-report the plan's strongest lock.
+    const actions = parentRule?.create(
+      parentFact("public.events"),
+      undefined as never,
+    );
+    expect(actions?.[0]?.lockClass).toBe("accessExclusive");
+  });
+
   test("create: the call CONSUMES the parent table so it orders after CREATE TABLE", () => {
     const actions = parentRule?.create(
       parentFact("public.events"),
@@ -498,6 +601,8 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       undefined as never,
     );
     expect(actions).toHaveLength(2);
+    // plain row DML on partman's registry — no relation lock to report
+    expect(actions?.[1]?.lockClass).toBeUndefined();
     expect(actions?.[1]?.sql).toMatchInlineSnapshot(
       `"update "partman".part_config set "retention" = '3 months', "retention_schema" = NULL, "retention_keep_index" = true, "retention_keep_table" = false, "retention_keep_publication" = false, "optimize_constraint" = 10, "infinite_time_partitions" = true, "inherit_privileges" = false, "constraint_valid" = true, "ignore_default_data" = true, "maintenance_order" = NULL where "parent_table" = 'public.events'"`,
     );
@@ -533,6 +638,8 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       `"delete from "partman".part_config where "parent_table" = 'public.events'"`,
     );
     expect(action?.dataLoss ?? "none").toBe("none");
+    // plain row DML on partman's registry — no relation lock to report
+    expect(action?.lockClass).toBeUndefined();
   });
 });
 

--- a/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
@@ -447,9 +447,13 @@ describe("pgPartmanHandler.capture", () => {
     expect(result.diagnostics?.[0]?.severity).toBe("warning");
     expect(result.diagnostics?.[0]?.message).toMatch(/pgmq/);
     expect(result.diagnostics?.[0]?.message).toMatch(/pgmq\.q_jobs/);
+    // `key` rides on the context per the collision-gate contract, so a
+    // desired-side partitioned queue warns instead of tripping the
+    // conservative keyless refusal in plan().
     expect(result.diagnostics?.[0]?.context).toEqual({
       ext: "pg_partman",
       intentKind: "parent",
+      key: "pgmq.q_jobs",
     });
   });
 
@@ -466,7 +470,11 @@ describe("pgPartmanHandler.capture", () => {
       ],
     });
     const current = buildFactBase(
-      [partmanFact, tableFact("pgmq", "q_jobs"), tableFact("public", "my_template")],
+      [
+        partmanFact,
+        tableFact("pgmq", "q_jobs"),
+        tableFact("public", "my_template"),
+      ],
       [],
     );
 

--- a/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
@@ -438,7 +438,7 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       undefined as never,
     );
     expect(actions).toHaveLength(1);
-    expect(actions?.[0]?.sql).toMatchInlineSnapshot();
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(`"select "partman".create_parent(p_parent_table := 'public.events', p_control := 'created_at', p_interval := '1 day', p_type := 'range', p_epoch := 'none', p_premake := 4, p_default_table := true, p_automatic_maintenance := 'on', p_constraint_cols := NULL, p_jobmon := true, p_date_trunc_interval := NULL, p_control_not_null := false, p_time_encoder := NULL, p_time_decoder := NULL)"`);
   });
 
   test("create: the call CONSUMES the parent table so it orders after CREATE TABLE", () => {
@@ -458,7 +458,7 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       }),
       undefined as never,
     );
-    expect(actions?.[0]?.sql).toMatchInlineSnapshot();
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(`"select "partman".create_parent(p_parent_table := 'public.events', p_control := 'created_at', p_interval := '1 day', p_type := 'range', p_epoch := 'none', p_premake := 4, p_default_table := true, p_automatic_maintenance := 'on', p_constraint_cols := NULL, p_jobmon := true, p_date_trunc_interval := NULL, p_control_not_null := false, p_time_encoder := NULL, p_time_decoder := NULL, p_template_table := 'public.my_template')"`);
     expect(actions?.[0]?.consumes).toEqual([
       { kind: "table", schema: "public", name: "events" },
       { kind: "table", schema: "public", name: "my_template" },
@@ -476,7 +476,7 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       undefined as never,
     );
     expect(actions).toHaveLength(2);
-    expect(actions?.[1]?.sql).toMatchInlineSnapshot();
+    expect(actions?.[1]?.sql).toMatchInlineSnapshot(`"update "partman".part_config set "retention" = '3 months', "retention_schema" = NULL, "retention_keep_index" = true, "retention_keep_table" = false, "retention_keep_publication" = false, "optimize_constraint" = 10, "infinite_time_partitions" = true, "inherit_privileges" = false, "constraint_valid" = true, "ignore_default_data" = true, "maintenance_order" = NULL where "parent_table" = 'public.events'"`);
   });
 
   test("create: every non-default argument is rendered, and the partman schema is quoted", () => {
@@ -498,12 +498,12 @@ describe("pgPartmanHandler.intentKinds.parent", () => {
       }),
       undefined as never,
     );
-    expect(actions?.[0]?.sql).toMatchInlineSnapshot();
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(`"select "my partman".create_parent(p_parent_table := 'app.logs', p_control := 'ts', p_interval := '1 week', p_type := 'list', p_epoch := 'seconds', p_premake := 10, p_default_table := false, p_automatic_maintenance := 'off', p_constraint_cols := ARRAY['a', 'b']::text[], p_jobmon := false, p_date_trunc_interval := '1 day', p_control_not_null := false, p_time_encoder := 'public.enc', p_time_decoder := 'public.dec')"`);
   });
 
   test("drop: deregisters the parent and is NOT flagged destructive (no table is dropped)", () => {
     const action = parentRule?.drop(parentFact("public.events"));
-    expect(action?.sql).toMatchInlineSnapshot();
+    expect(action?.sql).toMatchInlineSnapshot(`"delete from "partman".part_config where "parent_table" = 'public.events'"`);
     expect(action?.dataLoss ?? "none").toBe("none");
   });
 });

--- a/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.test.ts
@@ -372,9 +372,12 @@ describe("pgPartmanHandler.capture", () => {
     expect(result.diagnostics?.[0]?.code).toBe(INTENT_UNSUPPORTED);
     expect(result.diagnostics?.[0]?.severity).toBe("warning");
     expect(result.diagnostics?.[0]?.message).toMatch(/public\.events/);
+    // `key` is the collision-gate contract: plan() rebuilds the would-be
+    // intent id from this context to refuse only same-key collisions
     expect(result.diagnostics?.[0]?.context).toEqual({
       ext: "pg_partman",
       intentKind: "parent",
+      key: "public.events",
     });
   });
 
@@ -395,6 +398,9 @@ describe("pgPartmanHandler.capture", () => {
     expect(result.facts).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics?.[0]?.code).toBe(INTENT_UNSUPPORTED);
+    expect(result.diagnostics?.[0]?.context?.["key"]).toBe(
+      "public.events_p2026",
+    );
   });
 });
 

--- a/packages/pg-delta/src/policy/extensions/pg-partman.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.ts
@@ -166,8 +166,11 @@ async function detect(ctx: HandlerContext): Promise<string | null> {
   return (rows[0]?.["schema"] as string | undefined) ?? null;
 }
 
-/** A schema-qualified relation reference carried on a payload. */
+/** A schema-qualified relation reference carried on a payload. The index
+ *  signature is what makes it assignable to `PayloadValue`'s object arm (so the
+ *  content hash canonicalises it like any other nested payload object). */
 interface RelRef {
+  [key: string]: string;
   schema: string;
   name: string;
 }
@@ -627,7 +630,9 @@ export const pgPartmanHandler: ExtensionHandler = {
           specs.push({
             sql:
               `update ${s}.part_config set ` +
-              settings.map(([col, value]) => `${qid(col)} = ${value}`).join(", ") +
+              settings
+                .map(([col, value]) => `${qid(col)} = ${value}`)
+                .join(", ") +
               ` where ${qid("parent_table")} = ${lit(key)}`,
           });
         }

--- a/packages/pg-delta/src/policy/extensions/pg-partman.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.ts
@@ -469,7 +469,11 @@ export const pgPartmanHandler: ExtensionHandler = {
             `${schema}.part_config_sub row and a part_config row per sub-parent), ` +
             `so its registration is left unmanaged; its partitions are still ` +
             `tagged managedBy and are never dropped`,
-          context: { ext: "pg_partman", intentKind: "parent" },
+          // `key` is the collision-gate contract (see plan()'s unsupported-
+          // intent gate): it lets a same-key collision with a fact on the
+          // opposite side refuse the plan while a standalone sub-partitioned
+          // set stays a non-blocking warning.
+          context: { ext: "pg_partman", intentKind: "parent", key },
         });
         continue;
       }

--- a/packages/pg-delta/src/policy/extensions/pg-partman.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.ts
@@ -121,6 +121,19 @@
  * `managedBy` either way — the Phase-A walk is recursive, so it already covers
  * every sub-level — so nothing plans a `DROP TABLE` against them.
  *
+ * ### pgmq-owned parents are scoped OUT
+ * `pgmq.create_partitioned(q)` creates `pgmq.q_<q>` / `pgmq.a_<q>` as its own
+ * tables and registers BOTH in `part_config`. Replaying those as `create_parent`
+ * is wrong twice over: the replay would `consume` a table nothing in the plan
+ * creates (the pgmq handler deliberately emits no fact for a partitioned queue,
+ * and the Supabase profile projects the whole `pgmq` schema out), so an
+ * export / from-empty load cannot apply; and a live↔live diff whose desired side
+ * lacks the queue would plan `DELETE FROM part_config` against a live database,
+ * silently disabling pgmq's own partition maintenance. Both rows therefore emit
+ * an `INTENT_UNSUPPORTED` warning and NO fact, exactly like the sub-partition
+ * case. Phase A is deliberately NOT restricted, so the queue's partitions stay
+ * tagged `managedBy` and nothing plans a `DROP TABLE` against them.
+ *
  * ### `drop` deregisters; it does not destroy
  * There is no single-statement inverse of `create_parent`: `undo_partition()`
  * requires a separate `p_target_table` to move rows into and is batched by
@@ -155,13 +168,17 @@ function quoteIdent(name: string): string {
   return `"${name.replaceAll('"', '""')}"`;
 }
 
-/** Resolve the schema pg_partman is installed into, or null if absent. */
-async function detect(ctx: HandlerContext): Promise<string | null> {
+/** Resolve the schema `extname` is installed into, or null if absent. Used for
+ *  pg_partman itself and — see the pgmq scope-out below — for pgmq. */
+async function extensionSchema(
+  ctx: HandlerContext,
+  extname: string,
+): Promise<string | null> {
   const rows = await ctx.query(
     `SELECT n.nspname AS schema
        FROM pg_extension e
        JOIN pg_namespace n ON n.oid = e.extnamespace
-      WHERE e.extname = 'pg_partman'`,
+      WHERE e.extname = ${lit(extname)}`,
   );
   return (rows[0]?.["schema"] as string | undefined) ?? null;
 }
@@ -208,6 +225,7 @@ interface ConfigRow {
   maintenance_order: number | null;
   is_sub_partition_set: boolean;
   is_sub_partition_child: boolean;
+  is_pgmq_queue: boolean;
 }
 
 /** The captured intent of one registered parent. Split (a) / (b) exactly as the
@@ -349,8 +367,9 @@ export const pgPartmanHandler: ExtensionHandler = {
     ctx: HandlerContext,
     current: FactBase,
   ): Promise<CaptureResult> {
-    const schema = await detect(ctx);
+    const schema = await extensionSchema(ctx, "pg_partman");
     if (schema === null) return { facts: [], edges: [] };
+    const pgmqSchema = await extensionSchema(ctx, "pgmq");
 
     const facts: Fact[] = [];
     const edges: DependencyEdge[] = [];
@@ -396,6 +415,30 @@ export const pgPartmanHandler: ExtensionHandler = {
     // `default_table` comes from `pg_partitioned_table.partdefid` — the only
     // structural record of `p_default_table`, which partman does not store.
     // The two sub-partition flags mark rows this slice cannot replay.
+    //
+    // `is_pgmq_queue` marks the OTHER unreplayable shape: a queue table
+    // `pgmq.create_partitioned(...)` registered for itself (see the header).
+    // It has to come from the CATALOG — pgmq's own registry — because neither
+    // cheaper signal exists at capture time:
+    //   * fact presence: handlers run at the END of `extract()` on the RAW,
+    //     unfiltered fact base; the Supabase profile's `pgmq` system-schema
+    //     projection happens later, in `plan()`. `current.has(q_x)` is TRUE here.
+    //   * a cross-handler `managedBy` edge: handlers run sequentially and each
+    //     one is handed the PRE-handler fact base, so pgmq's edges are invisible.
+    // The name test mirrors pgmq's `format_table_name`
+    // (`lower(prefix || '_' || queue_name)`), spelled out rather than calling
+    // that internal helper so it does not depend on a particular pgmq version,
+    // and referencing only `meta.queue_name`, which every version has. BOTH
+    // prefixes are covered: `create_partitioned` registers the `q_` queue table
+    // AND its `a_` archive table (verified on pgmq 1.5.1).
+    const isPgmqQueue =
+      pgmqSchema === null
+        ? "false"
+        : `(pn.nspname = ${lit(pgmqSchema)} AND EXISTS (
+                  SELECT 1 FROM ${quoteIdent(pgmqSchema)}.meta m
+                   WHERE pc_rel.relname IN (lower('q_' || m.queue_name),
+                                            lower('a_' || m.queue_name))
+                ))`;
     const configs = (await ctx.query(
       `WITH RECURSIVE managed_parents AS (
          SELECT to_regclass(parent_table)::oid AS oid
@@ -438,6 +481,7 @@ export const pgPartmanHandler: ExtensionHandler = {
               pc.constraint_valid               AS constraint_valid,
               pc.ignore_default_data            AS ignore_default_data,
               pc.maintenance_order              AS maintenance_order,
+              ${isPgmqQueue}                    AS is_pgmq_queue,
               EXISTS (
                 SELECT 1 FROM ${quoteIdent(schema)}.part_config_sub s
                  WHERE s.sub_parent = pc.parent_table
@@ -458,6 +502,29 @@ export const pgPartmanHandler: ExtensionHandler = {
 
     for (const row of configs) {
       const key = `${row.parent_schema}.${row.parent_name}`;
+
+      // pgmq's, not the user's — skipped BEFORE the template handling below so
+      // the row leaks no fact and no edge at all.
+      if (row.is_pgmq_queue) {
+        diagnostics.push({
+          code: INTENT_UNSUPPORTED,
+          severity: "warning",
+          message:
+            `pg_partman parent '${key}' is a pgmq-managed queue table registered ` +
+            `by pgmq.create_partitioned(), so replaying it through create_parent() ` +
+            `cannot converge: the queue table is extension-managed rather than ` +
+            `user DDL, and pgmq itself captures no intent for a partitioned ` +
+            `queue. Its registration is left unmanaged (never deregistered) and ` +
+            `its partitions stay tagged managedBy; cross-handler replay of ` +
+            `partitioned queues is a recorded follow-up`,
+          // `key` is the collision-gate contract (same as the sub-partition
+          // skip below): a keyless diagnostic would hit plan()'s conservative
+          // fallback and refuse the whole plan; with the key, both sides skip
+          // the same row so no collision forms and this stays a warning.
+          context: { ext: "pg_partman", intentKind: "parent", key },
+        });
+        continue;
+      }
 
       if (row.is_sub_partition_set || row.is_sub_partition_child) {
         diagnostics.push({
@@ -597,6 +664,12 @@ export const pgPartmanHandler: ExtensionHandler = {
           {
             sql: `select ${s}.create_parent(${args.join(", ")})`,
             consumes,
+            // create_parent takes it EXPLICITLY on the parent —
+            // `LOCK TABLE %I.%I IN ACCESS EXCLUSIVE MODE`, the only such LOCK in
+            // pg_partman--5.3.1.sql's create_parent body (line 1348) — so the
+            // intent-rule default of "none" would under-report the plan's
+            // strongest lock. (Its ATTACH PARTITIONs are weaker; this dominates.)
+            lockClass: "accessExclusive",
           },
         ];
 

--- a/packages/pg-delta/src/policy/extensions/pg-partman.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-partman.ts
@@ -1,5 +1,7 @@
 /**
- * pg_partman handler (docs/architecture/extension-intent.md §3.3, Deliverable A).
+ * pg_partman handler (docs/architecture/extension-intent.md §3.3).
+ *
+ * ## Phase A (Deliverable A, CLI-1555 / CLI-1591) — `managedBy` provenance
  *
  * pg_partman child partitions are real user-schema tables that carry NO
  * `pg_depend` edge to the extension (so the core extractor's `deptype='e'`
@@ -14,13 +16,136 @@
  * a declarative sync never `DROP`s them (CLI-1555). Native AND legacy
  * (trigger-based) partitioning both use `pg_inherits`, so the recursive walk
  * covers every level, including `*_default` and premade children.
+ *
+ * ## Phase B (Deliverable B, CLI-2044) — `create_parent` intent
+ *
+ * Phase A alone leaves a from-scratch declarative rebuild with a BARE
+ * `PARTITION BY RANGE` parent: no partman registration and no premade children,
+ * because the registration is not schema DDL — `partman.create_parent(...)` is
+ * a function call that writes a row to partman's own `part_config` registry.
+ * So each `part_config` row is captured as an `extensionIntent` fact and
+ * replayed through partman's OWN API, exactly like a pgmq queue.
+ *
+ * ### Key
+ * `<parent_schema>.<parent_name>` taken from the CATALOG (`pg_class` /
+ * `pg_namespace` via `to_regclass(parent_table)`) rather than the raw
+ * `part_config.parent_table` text. partman stores whatever string the caller
+ * passed and parses it with `split_part(…, '.', 1|2)`, so the stored text is
+ * caller-shaped; the catalog form is canonical and therefore content-
+ * addressable — two databases built by different call sites hash the same.
+ * (partman's own `split_part` parsing means it never supported quoted or
+ * dotted identifiers, so no quoting round-trip is lost by this choice.)
+ *
+ * ### `part_config` column disposition — audited against pg_partman 5.3.1
+ * (the version in `supabase/postgres:17.6.1.135`). All 29 columns are
+ * accounted for; adding a column in a future partman version does NOT silently
+ * vanish, because `payloadAttrs` is asserted to cover every captured key.
+ *
+ * (a) INTENT, settable through a `create_parent()` argument — 13 columns:
+ *
+ *   | part_config column      | create_parent arg       | payload key            |
+ *   |-------------------------|-------------------------|------------------------|
+ *   | parent_table            | p_parent_table          | (the fact KEY)         |
+ *   | control                 | p_control               | control                |
+ *   | partition_interval      | p_interval              | partitionInterval      |
+ *   | partition_type          | p_type                  | partitionType          |
+ *   | epoch                   | p_epoch                 | epoch                  |
+ *   | premake                 | p_premake               | premake                |
+ *   | automatic_maintenance   | p_automatic_maintenance | automaticMaintenance   |
+ *   | constraint_cols         | p_constraint_cols       | constraintCols         |
+ *   | template_table          | p_template_table        | templateTable          |
+ *   | jobmon                  | p_jobmon                | jobmon                 |
+ *   | date_trunc_interval     | p_date_trunc_interval   | dateTruncInterval      |
+ *   | time_encoder            | p_time_encoder          | timeEncoder            |
+ *   | time_decoder            | p_time_decoder          | timeDecoder            |
+ *
+ * (b) INTENT, NOT reachable from any `create_parent()` argument — 11 columns.
+ *     partman's documented way to set these is to UPDATE `part_config` after
+ *     registration, so the replay does exactly that as a SECOND statement of
+ *     the same create (emitted only when at least one differs from partman's
+ *     own default, and then setting all eleven):
+ *     retention, retention_schema, retention_keep_index, retention_keep_table,
+ *     retention_keep_publication, optimize_constraint,
+ *     infinite_time_partitions, inherit_privileges, constraint_valid,
+ *     ignore_default_data, maintenance_order.
+ *     They are all in the payload regardless, so a drift in one is VISIBLE
+ *     (it replaces the intent) rather than silently dropped.
+ *
+ * (c) RUNTIME state — never captured, 5 columns:
+ *     datetime_string (derived by partman from partition_interval),
+ *     undo_in_progress, maintenance_last_run, async_partitioning_in_progress
+ *     (all transient bookkeeping), and sub_partition_set_full (a flag partman
+ *     maintains for sub-partition sets, which this slice scopes out anyway).
+ *     Capturing any of them would make two otherwise-identical databases hash
+ *     differently.
+ *
+ * `create_parent()` arguments with NO `part_config` column are, correspondingly,
+ * not captured: `p_start_partition` and `p_offset_id` are one-shot boundaries
+ * for the FIRST premade set (and every premade child is `managedBy`-excluded
+ * anyway, so they cannot drift), and `p_control_not_null` is a pure GUARD —
+ * partman raises if it is true and the control column is nullable, and never
+ * mutates anything. The replay therefore always passes
+ * `p_control_not_null := false`, which is correct whether or not the column is
+ * NOT NULL. `p_default_table` has no column either, but IS real intent, so it
+ * is recovered structurally from `pg_partitioned_table.partdefid <> 0`.
+ *
+ * ### `partmanSchema` in the payload
+ * pg_partman is RELOCATABLE (it installs into `public` by default and Supabase
+ * puts it in `partman`), and an `IntentKindRule` sees only the fact — no view on
+ * `drop` — so the install schema must ride on the payload for the replay to be
+ * renderable at all. It is a listed `payloadAttr`: relocating partman genuinely
+ * invalidates every captured replay, so it must be visible as a change rather
+ * than tripping the "extend the rule vocabulary" guard.
+ *
+ * ### The template table
+ * `create_parent` auto-creates `<partman_schema>.template_<parent_schema>_<parent_name>`
+ * when `p_template_table` is NULL. That table is NOT an extension member
+ * (`pg_depend deptype='e'` is absent — verified on 5.3.1), so core extraction
+ * keeps it as an ordinary fact. It is tagged `managedBy` — it is partman's, in
+ * partman's own schema, exactly like pgmq's `q_*` / `a_*` tables — and the
+ * payload records `templateTable: null` so the replay omits the argument and
+ * lets partman recreate it. A USER-supplied template table (any other name) is
+ * left as a user fact, carried in the payload, and `consumes`d by the replay so
+ * `create_parent` runs after its `CREATE TABLE` (partman ERRORS on a missing
+ * template rather than creating one, so the loader's retry rounds also converge).
+ * Known gap: customizations made to the AUTO-created template table are not
+ * captured — supply your own template table if you need them.
+ *
+ * ### Sub-partitioning is scoped OUT
+ * `create_sub_parent()` records a `part_config_sub` row on the top parent and a
+ * `part_config` row on every child that becomes a sub-parent. Replaying those
+ * child rows as `create_parent` would be wrong (partman, not the user, created
+ * them), and replaying the top parent as `create_parent` would silently lose the
+ * sub-level. Both cases emit an `INTENT_UNSUPPORTED` warning and NO fact,
+ * mirroring pgmq's partitioned-queue scope-out. Their partitions stay tagged
+ * `managedBy` either way — the Phase-A walk is recursive, so it already covers
+ * every sub-level — so nothing plans a `DROP TABLE` against them.
+ *
+ * ### `drop` deregisters; it does not destroy
+ * There is no single-statement inverse of `create_parent`: `undo_partition()`
+ * requires a separate `p_target_table` to move rows into and is batched by
+ * `p_loop_count` (verified on 5.3.1), so it cannot be a replay. The drop is
+ * therefore the minimal honest one — `DELETE FROM part_config` — which removes
+ * exactly the captured intent and destroys nothing. Its consequence is
+ * deliberate and documented: the partitions and the template table lose their
+ * `managedBy` tag and become ORDINARY user tables, so a second sync round sees
+ * them explicitly and drops them under the normal data-loss gate. That is
+ * preferable to hiding a mass `DROP TABLE` inside an opaque replay. See the
+ * CLI-2044 triage in docs/roadmap/pg-delta-next-follow-ups.md.
+ *
+ * NO `shadowPrecheck`: partman's functions work in ANY database (pg_cron's
+ * single-database constraint has no partman analogue), which is what lets a
+ * declarative directory containing parent intent load into a shadow.
  */
-import type { DependencyEdge, FactBase } from "../../core/fact.ts";
+import type { DependencyEdge, Fact, FactBase } from "../../core/fact.ts";
+import { INTENT_UNSUPPORTED, type Diagnostic } from "../../core/diagnostic.ts";
 import type {
   CaptureResult,
   ExtensionHandler,
   HandlerContext,
 } from "../../extract/handler.ts";
+import type { ActionSpec, IntentKindRule } from "../../plan/rules.ts";
+import { lit, qid } from "../../plan/render.ts";
 import type { StableId } from "../../core/stable-id.ts";
 
 const PG_PARTMAN: StableId = { kind: "extension", name: "pg_partman" };
@@ -41,6 +166,179 @@ async function detect(ctx: HandlerContext): Promise<string | null> {
   return (rows[0]?.["schema"] as string | undefined) ?? null;
 }
 
+/** A schema-qualified relation reference carried on a payload. */
+interface RelRef {
+  schema: string;
+  name: string;
+}
+
+/** One `part_config` row as the capture query projects it (see the disposition
+ *  table in the file header — every column is either here or deliberately
+ *  runtime state). */
+interface ConfigRow {
+  parent_schema: string;
+  parent_name: string;
+  control: string;
+  partition_interval: string;
+  partition_type: string;
+  epoch: string;
+  premake: number;
+  automatic_maintenance: string;
+  constraint_cols: string[] | null;
+  template_schema: string | null;
+  template_name: string | null;
+  jobmon: boolean;
+  date_trunc_interval: string | null;
+  time_encoder: string | null;
+  time_decoder: string | null;
+  default_table: boolean;
+  retention: string | null;
+  retention_schema: string | null;
+  retention_keep_index: boolean;
+  retention_keep_table: boolean;
+  retention_keep_publication: boolean;
+  optimize_constraint: number;
+  infinite_time_partitions: boolean;
+  inherit_privileges: boolean;
+  constraint_valid: boolean;
+  ignore_default_data: boolean;
+  maintenance_order: number | null;
+  is_sub_partition_set: boolean;
+  is_sub_partition_child: boolean;
+}
+
+/** The captured intent of one registered parent. Split (a) / (b) exactly as the
+ *  file header's disposition table: the first block replays as `create_parent`
+ *  arguments, the second as the follow-up `UPDATE part_config`. */
+interface ParentPayload {
+  /** the schema pg_partman is installed into — see the header */
+  partmanSchema: string;
+  // (a) create_parent() arguments
+  control: string;
+  partitionInterval: string;
+  partitionType: string;
+  epoch: string;
+  premake: number;
+  automaticMaintenance: string;
+  constraintCols: string[] | null;
+  /** null = partman's auto-created template table (the replay omits the arg) */
+  templateTable: RelRef | null;
+  jobmon: boolean;
+  dateTruncInterval: string | null;
+  timeEncoder: string | null;
+  timeDecoder: string | null;
+  defaultTable: boolean;
+  // (b) post-registration part_config settings
+  retention: string | null;
+  retentionSchema: string | null;
+  retentionKeepIndex: boolean;
+  retentionKeepTable: boolean;
+  retentionKeepPublication: boolean;
+  optimizeConstraint: number;
+  infiniteTimePartitions: boolean;
+  inheritPrivileges: boolean;
+  constraintValid: boolean;
+  ignoreDefaultData: boolean;
+  maintenanceOrder: number | null;
+}
+
+/** Every payload key, in declaration order — the rule's `payloadAttrs`. A key
+ *  missing here would make its drift trip the planner's "extend the rule
+ *  vocabulary" guard, so this list and {@link ParentPayload} are kept in step by
+ *  a unit test. */
+const PARENT_PAYLOAD_ATTRS = [
+  "partmanSchema",
+  "control",
+  "partitionInterval",
+  "partitionType",
+  "epoch",
+  "premake",
+  "automaticMaintenance",
+  "constraintCols",
+  "templateTable",
+  "jobmon",
+  "dateTruncInterval",
+  "timeEncoder",
+  "timeDecoder",
+  "defaultTable",
+  "retention",
+  "retentionSchema",
+  "retentionKeepIndex",
+  "retentionKeepTable",
+  "retentionKeepPublication",
+  "optimizeConstraint",
+  "infiniteTimePartitions",
+  "inheritPrivileges",
+  "constraintValid",
+  "ignoreDefaultData",
+  "maintenanceOrder",
+] as const;
+
+/** pg_partman 5.3.1's own column defaults for the (b) block. The follow-up
+ *  `UPDATE part_config` is emitted only when the captured intent differs from
+ *  ALL of these — a fresh `create_parent` already leaves exactly this state. */
+const PARTMAN_DEFAULTS = {
+  retention: null,
+  retentionSchema: null,
+  retentionKeepIndex: true,
+  retentionKeepTable: true,
+  retentionKeepPublication: false,
+  optimizeConstraint: 30,
+  infiniteTimePartitions: false,
+  inheritPrivileges: false,
+  constraintValid: true,
+  ignoreDefaultData: true,
+  maintenanceOrder: null,
+} as const;
+
+function parentIntentId(key: string): StableId {
+  return {
+    kind: "extensionIntent",
+    ext: "pg_partman",
+    intentKind: "parent",
+    key,
+  };
+}
+
+/** partman names its auto-created template table `template_<schema>_<name>` in
+ *  its own install schema. Postgres truncates the identifier at 63 bytes, which
+ *  the comparison mirrors. A false negative is SAFE: the table is then treated
+ *  as user-supplied — exported and consumed — which still replays correctly. */
+function isAutoTemplate(
+  row: ConfigRow,
+  partmanSchema: string,
+  templateSchema: string,
+  templateName: string,
+): boolean {
+  if (templateSchema !== partmanSchema) return false;
+  const auto = `template_${row.parent_schema}_${row.parent_name}`;
+  return templateName === auto || templateName === auto.slice(0, 63);
+}
+
+/** The literal for a `text` argument that may be NULL. */
+function textArg(value: string | null): string {
+  return value === null ? "NULL" : lit(value);
+}
+
+/** The literal for a `text[]` argument that may be NULL. */
+function textArrayArg(value: string[] | null): string {
+  if (value === null) return "NULL";
+  return `ARRAY[${value.map(lit).join(", ")}]::text[]`;
+}
+
+/** The literal for an `integer` argument that may be NULL. */
+function intArg(value: number | null): string {
+  return value === null ? "NULL" : String(value);
+}
+
+/** Split an intent key (`<schema>.<name>`, produced from the catalog by
+ *  capture) back into its parts, so the replay can name the parent table both
+ *  as partman's `text` argument and as a consumed `StableId`. */
+function parentRef(key: string): RelRef {
+  const dot = key.indexOf(".");
+  return { schema: key.slice(0, dot), name: key.slice(dot + 1) };
+}
+
 export const pgPartmanHandler: ExtensionHandler = {
   extension: "pg_partman",
 
@@ -51,9 +349,13 @@ export const pgPartmanHandler: ExtensionHandler = {
     const schema = await detect(ctx);
     if (schema === null) return { facts: [], edges: [] };
 
-    // Every table inheriting (directly or transitively) from a parent
-    // registered in part_config is partman-managed.
-    const rows = await ctx.query(
+    const facts: Fact[] = [];
+    const edges: DependencyEdge[] = [];
+    const diagnostics: Diagnostic[] = [];
+
+    // ── Phase A: every table inheriting (directly or transitively) from a
+    //    parent registered in part_config is partman-managed. ───────────────
+    const children = await ctx.query(
       `WITH RECURSIVE managed_parents AS (
          SELECT to_regclass(parent_table)::oid AS oid
            FROM ${quoteIdent(schema)}.part_config
@@ -74,8 +376,7 @@ export const pgPartmanHandler: ExtensionHandler = {
          JOIN pg_namespace n ON n.oid = c.relnamespace`,
     );
 
-    const edges: DependencyEdge[] = [];
-    for (const row of rows) {
+    for (const row of children) {
       const child: StableId = {
         kind: "table",
         schema: String(row["schema"]),
@@ -85,6 +386,269 @@ export const pgPartmanHandler: ExtensionHandler = {
       if (!current.has(child)) continue;
       edges.push({ from: child, to: PG_PARTMAN, kind: "managedBy" });
     }
-    return { facts: [], edges };
+
+    // ── Phase B: each part_config row is one replayable `create_parent`. ────
+    // The parent is resolved through the CATALOG (`to_regclass`), which both
+    // canonicalises the key and drops rows whose table no longer exists.
+    // `default_table` comes from `pg_partitioned_table.partdefid` — the only
+    // structural record of `p_default_table`, which partman does not store.
+    // The two sub-partition flags mark rows this slice cannot replay.
+    const configs = (await ctx.query(
+      `WITH RECURSIVE managed_parents AS (
+         SELECT to_regclass(parent_table)::oid AS oid
+           FROM ${quoteIdent(schema)}.part_config
+          WHERE to_regclass(parent_table) IS NOT NULL
+       ),
+       descendants AS (
+         SELECT i.inhrelid AS oid
+           FROM pg_inherits i
+          WHERE i.inhparent IN (SELECT oid FROM managed_parents)
+         UNION ALL
+         SELECT i.inhrelid
+           FROM pg_inherits i
+           JOIN descendants d ON i.inhparent = d.oid
+       )
+       SELECT pn.nspname                        AS parent_schema,
+              pc_rel.relname                    AS parent_name,
+              pc.control                        AS control,
+              pc.partition_interval             AS partition_interval,
+              pc.partition_type                 AS partition_type,
+              pc.epoch                          AS epoch,
+              pc.premake                        AS premake,
+              pc.automatic_maintenance          AS automatic_maintenance,
+              pc.constraint_cols                AS constraint_cols,
+              tn.nspname                        AS template_schema,
+              t_rel.relname                     AS template_name,
+              pc.jobmon                         AS jobmon,
+              pc.date_trunc_interval            AS date_trunc_interval,
+              pc.time_encoder                   AS time_encoder,
+              pc.time_decoder                   AS time_decoder,
+              COALESCE(pt.partdefid, 0) <> 0    AS default_table,
+              pc.retention                      AS retention,
+              pc.retention_schema               AS retention_schema,
+              pc.retention_keep_index           AS retention_keep_index,
+              pc.retention_keep_table           AS retention_keep_table,
+              pc.retention_keep_publication     AS retention_keep_publication,
+              pc.optimize_constraint            AS optimize_constraint,
+              pc.infinite_time_partitions       AS infinite_time_partitions,
+              pc.inherit_privileges             AS inherit_privileges,
+              pc.constraint_valid               AS constraint_valid,
+              pc.ignore_default_data            AS ignore_default_data,
+              pc.maintenance_order              AS maintenance_order,
+              EXISTS (
+                SELECT 1 FROM ${quoteIdent(schema)}.part_config_sub s
+                 WHERE s.sub_parent = pc.parent_table
+              )                                 AS is_sub_partition_set,
+              EXISTS (
+                SELECT 1 FROM descendants d WHERE d.oid = pc_rel.oid
+              )                                 AS is_sub_partition_child
+         FROM ${quoteIdent(schema)}.part_config pc
+         JOIN pg_class pc_rel ON pc_rel.oid = to_regclass(pc.parent_table)
+         JOIN pg_namespace pn ON pn.oid = pc_rel.relnamespace
+         LEFT JOIN pg_partitioned_table pt ON pt.partrelid = pc_rel.oid
+         LEFT JOIN pg_class t_rel ON t_rel.oid = to_regclass(pc.template_table)
+         LEFT JOIN pg_namespace tn ON tn.oid = t_rel.relnamespace
+        ORDER BY pn.nspname, pc_rel.relname`,
+    )) as unknown as ConfigRow[];
+
+    const dependsOnExtension = current.has(PG_PARTMAN);
+
+    for (const row of configs) {
+      const key = `${row.parent_schema}.${row.parent_name}`;
+
+      if (row.is_sub_partition_set || row.is_sub_partition_child) {
+        diagnostics.push({
+          code: INTENT_UNSUPPORTED,
+          severity: "warning",
+          message:
+            `pg_partman parent '${key}' belongs to a SUB-PARTITIONED set, which ` +
+            `create_parent() alone cannot replay (create_sub_parent registers a ` +
+            `${schema}.part_config_sub row and a part_config row per sub-parent), ` +
+            `so its registration is left unmanaged; its partitions are still ` +
+            `tagged managedBy and are never dropped`,
+          context: { ext: "pg_partman", intentKind: "parent" },
+        });
+        continue;
+      }
+
+      // A template table partman created for itself is partman's, and the
+      // replay recreates it — tag it and record `null` (the omitted argument).
+      // Anything else is the user's: it stays a fact and rides on the payload.
+      let templateTable: RelRef | null = null;
+      if (row.template_schema !== null && row.template_name !== null) {
+        if (
+          isAutoTemplate(row, schema, row.template_schema, row.template_name)
+        ) {
+          const tpl: StableId = {
+            kind: "table",
+            schema: row.template_schema,
+            name: row.template_name,
+          };
+          if (current.has(tpl)) {
+            edges.push({ from: tpl, to: PG_PARTMAN, kind: "managedBy" });
+          }
+        } else {
+          templateTable = {
+            schema: row.template_schema,
+            name: row.template_name,
+          };
+        }
+      }
+
+      const id = parentIntentId(key);
+      facts.push({
+        id,
+        payload: {
+          partmanSchema: schema,
+          control: row.control,
+          partitionInterval: row.partition_interval,
+          partitionType: row.partition_type,
+          epoch: row.epoch,
+          premake: row.premake,
+          automaticMaintenance: row.automatic_maintenance,
+          constraintCols: row.constraint_cols,
+          templateTable,
+          jobmon: row.jobmon,
+          dateTruncInterval: row.date_trunc_interval,
+          timeEncoder: row.time_encoder,
+          timeDecoder: row.time_decoder,
+          defaultTable: row.default_table,
+          retention: row.retention,
+          retentionSchema: row.retention_schema,
+          retentionKeepIndex: row.retention_keep_index,
+          retentionKeepTable: row.retention_keep_table,
+          retentionKeepPublication: row.retention_keep_publication,
+          optimizeConstraint: row.optimize_constraint,
+          infiniteTimePartitions: row.infinite_time_partitions,
+          inheritPrivileges: row.inherit_privileges,
+          constraintValid: row.constraint_valid,
+          ignoreDefaultData: row.ignore_default_data,
+          maintenanceOrder: row.maintenance_order,
+        } satisfies ParentPayload,
+      });
+      if (dependsOnExtension) {
+        edges.push({ from: id, to: PG_PARTMAN, kind: "depends" });
+      }
+    }
+
+    return diagnostics.length > 0
+      ? { facts, edges, diagnostics }
+      : { facts, edges };
+  },
+
+  intentKinds: {
+    parent: {
+      payloadAttrs: PARENT_PAYLOAD_ATTRS,
+      create(fact) {
+        const key = (fact.id as Extract<StableId, { kind: "extensionIntent" }>)
+          .key;
+        const p = fact.payload as unknown as ParentPayload;
+        const s = quoteIdent(p.partmanSchema);
+        const parent = parentRef(key);
+
+        // `p_control_not_null := false` unconditionally: it is a GUARD, never a
+        // mutation (partman raises when it is true and the control column is
+        // nullable), so passing false is correct either way and keeps the
+        // parent's column nullability out of this payload.
+        const args = [
+          `p_parent_table := ${lit(key)}`,
+          `p_control := ${lit(p.control)}`,
+          `p_interval := ${lit(p.partitionInterval)}`,
+          `p_type := ${lit(p.partitionType)}`,
+          `p_epoch := ${lit(p.epoch)}`,
+          `p_premake := ${p.premake}`,
+          `p_default_table := ${p.defaultTable}`,
+          `p_automatic_maintenance := ${lit(p.automaticMaintenance)}`,
+          `p_constraint_cols := ${textArrayArg(p.constraintCols)}`,
+          `p_jobmon := ${p.jobmon}`,
+          `p_date_trunc_interval := ${textArg(p.dateTruncInterval)}`,
+          `p_control_not_null := false`,
+          `p_time_encoder := ${textArg(p.timeEncoder)}`,
+          `p_time_decoder := ${textArg(p.timeDecoder)}`,
+        ];
+        // The parent table must exist first; a user-supplied template table too
+        // (partman raises "Unable to find given template table" rather than
+        // creating one). partman's auto-created template needs no argument.
+        // Every argument is NAMED, so appending is order-independent.
+        const consumes: StableId[] = [
+          { kind: "table", schema: parent.schema, name: parent.name },
+        ];
+        if (p.templateTable !== null) {
+          args.push(
+            `p_template_table := ${lit(
+              `${p.templateTable.schema}.${p.templateTable.name}`,
+            )}`,
+          );
+          consumes.push({
+            kind: "table",
+            schema: p.templateTable.schema,
+            name: p.templateTable.name,
+          });
+        }
+
+        const specs: ActionSpec[] = [
+          {
+            sql: `select ${s}.create_parent(${args.join(", ")})`,
+            consumes,
+          },
+        ];
+
+        // (b) settings have no create_parent argument; partman's documented way
+        // to set them is to UPDATE part_config after registration. Emitted only
+        // when the intent differs from what create_parent already leaves behind.
+        const settings: Array<[string, string]> = [
+          ["retention", textArg(p.retention)],
+          ["retention_schema", textArg(p.retentionSchema)],
+          ["retention_keep_index", String(p.retentionKeepIndex)],
+          ["retention_keep_table", String(p.retentionKeepTable)],
+          ["retention_keep_publication", String(p.retentionKeepPublication)],
+          ["optimize_constraint", String(p.optimizeConstraint)],
+          ["infinite_time_partitions", String(p.infiniteTimePartitions)],
+          ["inherit_privileges", String(p.inheritPrivileges)],
+          ["constraint_valid", String(p.constraintValid)],
+          ["ignore_default_data", String(p.ignoreDefaultData)],
+          ["maintenance_order", intArg(p.maintenanceOrder)],
+        ];
+        const atDefaults =
+          p.retention === PARTMAN_DEFAULTS.retention &&
+          p.retentionSchema === PARTMAN_DEFAULTS.retentionSchema &&
+          p.retentionKeepIndex === PARTMAN_DEFAULTS.retentionKeepIndex &&
+          p.retentionKeepTable === PARTMAN_DEFAULTS.retentionKeepTable &&
+          p.retentionKeepPublication ===
+            PARTMAN_DEFAULTS.retentionKeepPublication &&
+          p.optimizeConstraint === PARTMAN_DEFAULTS.optimizeConstraint &&
+          p.infiniteTimePartitions ===
+            PARTMAN_DEFAULTS.infiniteTimePartitions &&
+          p.inheritPrivileges === PARTMAN_DEFAULTS.inheritPrivileges &&
+          p.constraintValid === PARTMAN_DEFAULTS.constraintValid &&
+          p.ignoreDefaultData === PARTMAN_DEFAULTS.ignoreDefaultData &&
+          p.maintenanceOrder === PARTMAN_DEFAULTS.maintenanceOrder;
+        if (!atDefaults) {
+          specs.push({
+            sql:
+              `update ${s}.part_config set ` +
+              settings.map(([col, value]) => `${qid(col)} = ${value}`).join(", ") +
+              ` where ${qid("parent_table")} = ${lit(key)}`,
+          });
+        }
+
+        return specs;
+      },
+      drop(fact) {
+        const key = (fact.id as Extract<StableId, { kind: "extensionIntent" }>)
+          .key;
+        const p = fact.payload as unknown as ParentPayload;
+        // NON-destructive by construction: deregistering removes exactly the
+        // captured intent. The partitions and template table survive as
+        // ordinary user tables — see the header for why that beats an opaque
+        // mass DROP TABLE.
+        return {
+          sql:
+            `delete from ${quoteIdent(p.partmanSchema)}.part_config ` +
+            `where ${qid("parent_table")} = ${lit(key)}`,
+          dataLoss: "none",
+        };
+      },
+    } satisfies IntentKindRule,
   },
 };

--- a/packages/pg-delta/tests/extension-intent-partman.test.ts
+++ b/packages/pg-delta/tests/extension-intent-partman.test.ts
@@ -616,13 +616,19 @@ describe.skipIf(!runSupabaseBareTests)(
               .some((e) => e.kind === "managedBy"),
           ).toBe(true);
         }
-        // which is exactly what the managed view relies on
+        // which is exactly what the managed view relies on. (The queue's OWN
+        // `q_pq` / `a_pq` tables survive here because only the partman handler
+        // is composed — tagging those is the pgmq handler's job, and the
+        // Supabase profile projects the whole schema out anyway.)
         const managed = resolveView(extracted.factBase, undefined);
         expect(
           managed
             .facts()
             .filter(
-              (f) => f.id.kind === "table" && f.id.schema === "pgmq",
+              (f) =>
+                f.id.kind === "table" &&
+                f.id.schema === "pgmq" &&
+                /^[qa]_pq_/.test(f.id.name),
             ),
         ).toEqual([]);
       } finally {

--- a/packages/pg-delta/tests/extension-intent-partman.test.ts
+++ b/packages/pg-delta/tests/extension-intent-partman.test.ts
@@ -1,25 +1,48 @@
 /**
- * Extension-intent Deliverable A, end-to-end against a real pg_partman DB
- * (docs/architecture/extension-intent.md §3.3, §4.3; CLI-1555 / CLI-1591).
+ * Extension-intent for pg_partman, end-to-end against a real pg_partman DB
+ * (docs/architecture/extension-intent.md §3.3, §4.3).
  *
- * Reproduces the destructive bug — a declarative diff DROPs the partman child
- * partitions — and proves the pg_partman handler + the managed view stop it,
- * while leaving the partitioned parent intact. Handlers now run INSIDE the
- * extraction transaction (`extract(pool, { handlers })`) and `resolveView`
- * (inside `plan`/`prove`) is the single projection point that drops the
- * `managedBy` children — no caller-side `excludeManaged`. Uses the Supabase
- * image, which ships pg_partman.
+ * Deliverable A (CLI-1555 / CLI-1591) reproduces the destructive bug — a
+ * declarative diff DROPs the partman child partitions — and proves the
+ * pg_partman handler + the managed view stop it, while leaving the partitioned
+ * parent intact. Handlers now run INSIDE the extraction transaction
+ * (`extract(pool, { handlers })`) and `resolveView` (inside `plan`/`prove`) is
+ * the single projection point that drops the `managedBy` children — no
+ * caller-side `excludeManaged`.
+ *
+ * Deliverable B (CLI-2044) covers the `part_config` INTENT: a from-scratch
+ * rebuild must produce a REGISTERED parent (`partman.create_parent(...)` replayed
+ * after `CREATE TABLE` and `CREATE EXTENSION`), not a bare `PARTITION BY RANGE`
+ * shell. Those scenarios drive the public profile seam (`resolveProfile`) with a
+ * custom profile carrying only `pgPartmanHandler`, exactly like
+ * `extension-intent-pgmq.test.ts`, and close with the same load-bearing
+ * `export → load into a fresh shadow → re-extract` round trip.
+ *
+ * Uses the Supabase image, which ships pg_partman.
  */
 import { afterAll, describe, expect, test } from "bun:test";
+import { apply } from "../src/apply/apply.ts";
 import { extract } from "../src/extract/extract.ts";
 import type { ExtensionHandler } from "../src/extract/handler.ts";
 import { diff, type Delta } from "../src/core/diff.ts";
 import { resolveView } from "../src/policy/policy.ts";
 import { pgPartmanHandler } from "../src/policy/extensions/index.ts";
 import { plan } from "../src/plan/plan.ts";
+import { buildIntentRuleIndex } from "../src/plan/rules.ts";
 import { provePlan } from "../src/proof/prove.ts";
+import {
+  type IntegrationProfile,
+  resolveProfile,
+} from "../src/integrations/profile.ts";
+import { buildSchemaExport } from "../src/frontends/schema-export.ts";
+import { loadSqlFiles, type SqlFile } from "../src/frontends/load-sql-files.ts";
 import type { StableId } from "../src/core/stable-id.ts";
-import { sharedCluster, supabaseCluster, type TestDb } from "./containers.ts";
+import {
+  runSupabaseBareTests,
+  sharedCluster,
+  supabaseCluster,
+  type TestDb,
+} from "./containers.ts";
 
 const eventsParent: StableId = {
   kind: "table",
@@ -131,10 +154,16 @@ describe("extension-intent: pg_partman managed partitions are not dropped (CLI-1
       `INSERT INTO public.events (created_at) VALUES (now())`,
     );
 
-    // DESIRED: the declarative source declares the extension + the partitioned
-    // parent and makes a REAL parent change (adds a column), but does NOT run
-    // create_parent — so it has no runtime children (Phase A). The plan does
-    // real work (ALTER ADD COLUMN) yet must not touch the managed partitions.
+    // DESIRED: the declarative source declares the extension, the partitioned
+    // parent, and — since Deliverable B — the SAME partman registration, while
+    // making a REAL parent change (adds a column). Its own premade children are
+    // runtime state the managed view projects out, so the plan carries only the
+    // ALTER ADD COLUMN and must not touch the source's managed partitions.
+    //
+    // The registration is declared on BOTH sides on purpose: with the
+    // `part_config` row now captured as intent, a desired state that omitted
+    // `create_parent` would be asking to DEREGISTER the parent, which is a
+    // different scenario (covered below in the Deliverable B drop test).
     const desiredDb = await cluster.createDb("partman_prove_dst");
     dbs.push(desiredDb);
     await desiredDb.pool.query(`CREATE SCHEMA IF NOT EXISTS partman`);
@@ -148,14 +177,27 @@ describe("extension-intent: pg_partman managed partitions are not dropped (CLI-1
          note text
        ) PARTITION BY RANGE (created_at)`,
     );
+    await desiredDb.pool.query(
+      `SELECT partman.create_parent(
+         p_parent_table := 'public.events',
+         p_control := 'created_at',
+         p_interval := '1 day'
+       )`,
+    );
 
     // handler-aware extraction on both sides; plan's resolveView drops the
     // managed children, so the plan only carries the parent's column add.
     const sourceFb = (await extract(source.pool, { handlers })).factBase;
     const desiredFb = (await extract(desiredDb.pool, { handlers })).factBase;
+    // Since Deliverable B the handler also captures the `part_config` row as an
+    // intent fact, so a bare `plan()` must be handed the handler's replay rules
+    // (this is what `resolveProfile` does for every real caller). Without them
+    // the resolver throws "no intent rule registered" rather than silently
+    // dropping declared intent.
     const thePlan = plan(sourceFb, desiredFb, {
       renames: "off",
       compact: true,
+      intentRules: buildIntentRuleIndex(handlers),
     });
 
     // prove against a sacrificial clone of the source, re-extracting with the
@@ -213,3 +255,393 @@ describe("extension-intent: pg_partman managed partitions are not dropped (CLI-1
     expect(seen).toBe(1);
   }, 120_000);
 });
+
+// ── Deliverable B: part_config intent capture + replay (CLI-2044) ────────────
+
+const partmanProfile: IntegrationProfile = {
+  id: "test-pg-partman",
+  handlers: [pgPartmanHandler],
+};
+
+/** Roles are cluster-global and already present; drop the CREATE ROLE file the
+ *  same way `export-fidelity.test.ts` does, across every layout's naming. */
+function forLoad(files: SqlFile[]): SqlFile[] {
+  return files.filter((f) => !/cluster[_/]roles/.test(f.name));
+}
+
+/** Install partman and register `public.events` with the given extra
+ *  `create_parent` arguments (named, so order is irrelevant). */
+async function seedPartmanParent(
+  db: TestDb,
+  extraArgs = "",
+  columns = "id bigint GENERATED ALWAYS AS IDENTITY, created_at timestamptz NOT NULL",
+): Promise<void> {
+  await db.pool.query(`CREATE SCHEMA IF NOT EXISTS partman`);
+  await db.pool.query(
+    `CREATE EXTENSION IF NOT EXISTS pg_partman WITH SCHEMA partman`,
+  );
+  await db.pool.query(
+    `CREATE TABLE public.events (${columns}) PARTITION BY RANGE (created_at)`,
+  );
+  await db.pool.query(
+    `SELECT partman.create_parent(
+       p_parent_table := 'public.events',
+       p_control := 'created_at',
+       p_interval := '1 day'${extraArgs}
+     )`,
+  );
+}
+
+/** The intent columns the replay must reproduce exactly (the runtime columns —
+ *  datetime_string, undo_in_progress, maintenance_last_run — are deliberately
+ *  excluded; see the disposition table in `src/policy/extensions/pg-partman.ts`). */
+const INTENT_COLUMNS = `parent_table, control, partition_interval, partition_type,
+    epoch, premake, automatic_maintenance, constraint_cols, template_table,
+    jobmon, date_trunc_interval, time_encoder, time_decoder, retention,
+    retention_schema, retention_keep_index, retention_keep_table,
+    retention_keep_publication, optimize_constraint, infinite_time_partitions,
+    inherit_privileges, constraint_valid, ignore_default_data, maintenance_order`;
+
+describe.skipIf(!runSupabaseBareTests)(
+  "extension-intent: pg_partman create_parent intent (CLI-2044)",
+  () => {
+    test("create: a from-scratch rebuild replays create_parent AFTER the extension and the parent table, and converges", async () => {
+      const cluster = await supabaseCluster();
+      const src = await cluster.createDb("partman_b_create_src");
+      const desired = await cluster.createDb("partman_b_create_desired");
+      try {
+        await seedPartmanParent(desired);
+
+        const ctx = await resolveProfile(src.pool, partmanProfile);
+        const sourceFb = (await ctx.extract(src.pool)).factBase; // empty DB
+        const desiredFb = (await ctx.extract(desired.pool)).factBase;
+
+        const thePlan = plan(sourceFb, desiredFb, {
+          ...ctx.planOptions,
+          renames: "off",
+        });
+
+        const sqls = thePlan.actions.map((a) => a.sql);
+        const extIdx = sqls.findIndex((s) =>
+          /CREATE EXTENSION "pg_partman"/i.test(s),
+        );
+        const tableIdx = sqls.findIndex((s) =>
+          /CREATE TABLE "public"\."events"/i.test(s),
+        );
+        const intentIdx = sqls.findIndex((s) =>
+          /create_parent\(p_parent_table := 'public\.events'/.test(s),
+        );
+        expect(extIdx).toBeGreaterThanOrEqual(0);
+        expect(tableIdx).toBeGreaterThanOrEqual(0);
+        // ordered after BOTH: the `depends` edge on the extension fact and the
+        // `consumes` on the parent table.
+        expect(intentIdx).toBeGreaterThan(extIdx);
+        expect(intentIdx).toBeGreaterThan(tableIdx);
+        expect(thePlan.actions[intentIdx]?.verb).toBe("create");
+
+        // the premade children and the auto-created template table are
+        // partman's — never schema DDL
+        const all = sqls.join("\n");
+        expect(all).not.toMatch(/CREATE TABLE "public"\."events_/i);
+        expect(all).not.toMatch(/template_public_events/i);
+
+        const report = await apply(thePlan, src.pool, ctx.applyOptions);
+        expect(report.status).toBe("applied");
+
+        // state proof: re-extracting the applied source converges on desired
+        const appliedFb = (await ctx.extract(src.pool)).factBase;
+        const residual = plan(appliedFb, desiredFb, {
+          ...ctx.planOptions,
+          renames: "off",
+        });
+        expect(residual.actions.map((a) => a.sql)).toEqual([]);
+
+        // ...and the parent really is REGISTERED, on every intent column
+        const both = await Promise.all(
+          [src, desired].map(async (db) =>
+            (
+              await db.pool.query(
+                `SELECT ${INTENT_COLUMNS} FROM partman.part_config ORDER BY parent_table`,
+              )
+            ).rows,
+          ),
+        );
+        expect(both[0]).toHaveLength(1);
+        expect(both[0]).toEqual(both[1] as never);
+
+        // premade children exist on the rebuilt source (partman ran, not DDL)
+        const { rows: children } = await src.pool.query<{ c: number }>(
+          `SELECT count(*)::int AS c FROM pg_inherits WHERE inhparent = 'public.events'::regclass`,
+        );
+        expect(children[0]?.c).toBeGreaterThan(0);
+      } finally {
+        await Promise.all([src.drop(), desired.drop()]);
+      }
+    }, 180_000);
+
+    test("create: non-argument part_config settings (retention, …) replay as a follow-up UPDATE and converge", async () => {
+      const cluster = await supabaseCluster();
+      const src = await cluster.createDb("partman_b_settings_src");
+      const desired = await cluster.createDb("partman_b_settings_desired");
+      try {
+        await seedPartmanParent(desired);
+        // These have NO create_parent argument — partman's documented way to set
+        // them is to UPDATE part_config after registration.
+        await desired.pool.query(
+          `UPDATE partman.part_config
+              SET retention = '3 months',
+                  retention_keep_table = false,
+                  infinite_time_partitions = true,
+                  optimize_constraint = 10
+            WHERE parent_table = 'public.events'`,
+        );
+
+        const ctx = await resolveProfile(src.pool, partmanProfile);
+        const sourceFb = (await ctx.extract(src.pool)).factBase;
+        const desiredFb = (await ctx.extract(desired.pool)).factBase;
+
+        const thePlan = plan(sourceFb, desiredFb, {
+          ...ctx.planOptions,
+          renames: "off",
+        });
+
+        const sqls = thePlan.actions.map((a) => a.sql);
+        const createIdx = sqls.findIndex((s) => /create_parent\(/.test(s));
+        const updateIdx = sqls.findIndex((s) =>
+          /update "partman"\.part_config set/.test(s),
+        );
+        expect(createIdx).toBeGreaterThanOrEqual(0);
+        // the UPDATE is the SECOND statement of the same create, so it must
+        // follow the registration it patches
+        expect(updateIdx).toBeGreaterThan(createIdx);
+
+        const report = await apply(thePlan, src.pool, ctx.applyOptions);
+        expect(report.status).toBe("applied");
+
+        const appliedFb = (await ctx.extract(src.pool)).factBase;
+        const residual = plan(appliedFb, desiredFb, {
+          ...ctx.planOptions,
+          renames: "off",
+        });
+        expect(residual.actions.map((a) => a.sql)).toEqual([]);
+
+        const { rows } = await src.pool.query(
+          `SELECT retention, retention_keep_table, infinite_time_partitions, optimize_constraint
+             FROM partman.part_config WHERE parent_table = 'public.events'`,
+        );
+        expect(rows).toEqual([
+          {
+            retention: "3 months",
+            retention_keep_table: false,
+            infinite_time_partitions: true,
+            optimize_constraint: 10,
+          },
+        ]);
+      } finally {
+        await Promise.all([src.drop(), desired.drop()]);
+      }
+    }, 180_000);
+
+    test("drop: an unregistered desired state DEREGISTERS the parent without destroying a single partition", async () => {
+      const cluster = await supabaseCluster();
+      const src = await cluster.createDb("partman_b_drop_src");
+      const desired = await cluster.createDb("partman_b_drop_desired");
+      try {
+        await seedPartmanParent(src);
+        await src.pool.query(
+          `INSERT INTO public.events (created_at) VALUES (now())`,
+        );
+        // DESIRED: the same extension + parent, but NO registration.
+        await desired.pool.query(`CREATE SCHEMA IF NOT EXISTS partman`);
+        await desired.pool.query(
+          `CREATE EXTENSION IF NOT EXISTS pg_partman WITH SCHEMA partman`,
+        );
+        await desired.pool.query(
+          `CREATE TABLE public.events (
+             id bigint GENERATED ALWAYS AS IDENTITY,
+             created_at timestamptz NOT NULL
+           ) PARTITION BY RANGE (created_at)`,
+        );
+
+        const ctx = await resolveProfile(src.pool, partmanProfile);
+        const sourceFb = (await ctx.extract(src.pool)).factBase;
+        const desiredFb = (await ctx.extract(desired.pool)).factBase;
+
+        const thePlan = plan(sourceFb, desiredFb, {
+          ...ctx.planOptions,
+          renames: "off",
+        });
+
+        const dropAction = thePlan.actions.find((a) =>
+          /delete from "partman"\.part_config/.test(a.sql),
+        );
+        expect(dropAction).toBeDefined();
+        expect(dropAction?.verb).toBe("drop");
+        // deregistering destroys NOTHING — see the drop rationale in the handler
+        expect(dropAction?.dataLoss ?? "none").toBe("none");
+        // and it is the ONLY thing planned: no partition is dropped
+        expect(thePlan.actions.map((a) => a.sql)).toEqual([dropAction!.sql]);
+
+        const report = await apply(thePlan, src.pool, ctx.applyOptions);
+        expect(report.status).toBe("applied");
+
+        const { rows: cfg } = await src.pool.query(
+          `SELECT * FROM partman.part_config`,
+        );
+        expect(cfg).toEqual([]);
+
+        // DOCUMENTED CONSEQUENCE (CLI-2044 triage): the partitions survive —
+        // with their rows — but lose their `managedBy` tag, so they surface as
+        // ORDINARY user tables that a SECOND sync round removes under the normal
+        // data-loss gate. That is deliberate: a one-shot replay that silently
+        // mass-DROPped them would destroy data the user never saw planned.
+        const { rows: kept } = await src.pool.query<{ c: number }>(
+          `SELECT count(*)::int AS c FROM public.events`,
+        );
+        expect(kept[0]?.c).toBe(1);
+
+        const secondRound = plan(
+          (await ctx.extract(src.pool)).factBase,
+          desiredFb,
+          { ...ctx.planOptions, renames: "off" },
+        );
+        expect(secondRound.actions.some((a) => /DROP TABLE/i.test(a.sql))).toBe(
+          true,
+        );
+      } finally {
+        await Promise.all([src.drop(), desired.drop()]);
+      }
+    }, 180_000);
+
+    test("a SUB-partitioned set emits INTENT_UNSUPPORTED, no intent fact, and keeps every level tagged managedBy", async () => {
+      const cluster = await supabaseCluster();
+      const db = await cluster.createDb("partman_b_subpart");
+      try {
+        await seedPartmanParent(db);
+        // partman refuses to sub-partition an already-populated declarative set
+        // without an explicit acknowledgement that existing children are
+        // recreated; the set is empty here, so this is safe.
+        await db.pool.query(
+          `SELECT partman.create_sub_parent(
+             p_top_parent := 'public.events',
+             p_control := 'created_at',
+             p_interval := '1 hour',
+             p_declarative_check := 'yes'
+           )`,
+        );
+
+        const extracted = await extract(db.pool, {
+          handlers: [pgPartmanHandler],
+        });
+
+        // no parent of a sub-partitioned set becomes intent…
+        const intents = extracted.factBase
+          .facts()
+          .filter((f) => f.id.kind === "extensionIntent");
+        expect(intents).toEqual([]);
+        // …and every skipped row says so
+        const unsupported = extracted.diagnostics.filter(
+          (d) => d.code === "intent-unsupported",
+        );
+        expect(unsupported.length).toBeGreaterThan(0);
+        expect(unsupported[0]?.message).toMatch(/SUB-PARTITIONED/);
+
+        // Phase A is untouched: the recursive pg_inherits walk still tags every
+        // level, so a diff against an empty desired state drops no partition.
+        const managed = resolveView(extracted.factBase, undefined);
+        const remaining = managed
+          .facts()
+          .filter(
+            (f) =>
+              f.id.kind === "table" &&
+              f.id.schema === "public" &&
+              f.id.name.startsWith("events_"),
+          );
+        expect(remaining).toEqual([]);
+      } finally {
+        await db.drop();
+      }
+    }, 180_000);
+
+    // ── the load-bearing deliverable (CLI-2044) ─────────────────────────────
+    test("ROUND TRIP: export → load into a fresh shadow → re-extract yields a CONFIGURED parent and an empty diff", async () => {
+      const cluster = await supabaseCluster();
+      const src = await cluster.createDb("partman_b_rt_src");
+      const shadow = await cluster.createDb("partman_b_rt_shadow");
+      try {
+        await seedPartmanParent(src, `, p_premake := 2`);
+        await src.pool.query(
+          `UPDATE partman.part_config
+              SET retention = '6 months', infinite_time_partitions = true
+            WHERE parent_table = 'public.events'`,
+        );
+        // real data: it must not leak into the export, and the loader's
+        // populated-table guard must not trip on partman's own registry rows.
+        await src.pool.query(
+          `INSERT INTO public.events (created_at) VALUES (now())`,
+        );
+
+        const ctx = await resolveProfile(src.pool, partmanProfile);
+
+        const exported = await buildSchemaExport(src.pool, {
+          profile: partmanProfile,
+        });
+        const files = forLoad(exported.files);
+
+        // the registration is exported as partman's OWN API call, plus the
+        // follow-up UPDATE for the settings create_parent cannot express
+        const replays = files
+          .flatMap((f) => f.sql.split("\n"))
+          .map((l) => l.trim())
+          .filter((l) => /^(select "partman"|update "partman")/i.test(l));
+        expect(replays).toMatchInlineSnapshot(`
+          [
+            "select "partman".create_parent(p_parent_table := 'public.events', p_control := 'created_at', p_interval := '1 day', p_type := 'range', p_epoch := 'none', p_premake := 2, p_default_table := true, p_automatic_maintenance := 'on', p_constraint_cols := NULL, p_jobmon := true, p_date_trunc_interval := NULL, p_control_not_null := false, p_time_encoder := NULL, p_time_decoder := NULL);",
+            "update "partman".part_config set "retention" = '6 months', "retention_schema" = NULL, "retention_keep_index" = true, "retention_keep_table" = true, "retention_keep_publication" = false, "optimize_constraint" = 30, "infinite_time_partitions" = true, "inherit_privileges" = false, "constraint_valid" = true, "ignore_default_data" = true, "maintenance_order" = NULL where "parent_table" = 'public.events';",
+          ]
+        `);
+
+        // no premade child, no auto-created template table, and no row data
+        const allSql = files.map((f) => f.sql).join("\n");
+        expect(allSql).not.toMatch(/CREATE TABLE "public"\."events_/i);
+        expect(allSql).not.toMatch(/template_public_events/i);
+        expect(allSql).not.toMatch(/INSERT INTO "public"\."events"/i);
+
+        // load the exported files into a FRESH shadow, profile-aware so the
+        // shadow's desired state is captured with the same handler.
+        const loaded = await loadSqlFiles(files, shadow.pool, {
+          extract: ctx.extract,
+        });
+
+        // convergence: the reloaded shadow diffs to nothing against the source
+        const srcFb = (await ctx.extract(src.pool)).factBase;
+        const residual = plan(loaded.factBase, srcFb, {
+          ...ctx.planOptions,
+          renames: "off",
+        });
+        expect(residual.actions.map((a) => a.sql)).toEqual([]);
+
+        // and the shadow really carries a CONFIGURED parent — identical on every
+        // intent column — with its own premade children
+        const both = await Promise.all(
+          [shadow, src].map(async (db) =>
+            (
+              await db.pool.query(
+                `SELECT ${INTENT_COLUMNS} FROM partman.part_config ORDER BY parent_table`,
+              )
+            ).rows,
+          ),
+        );
+        expect(both[0]).toHaveLength(1);
+        expect(both[0]).toEqual(both[1] as never);
+
+        const { rows: children } = await shadow.pool.query<{ c: number }>(
+          `SELECT count(*)::int AS c FROM pg_inherits WHERE inhparent = 'public.events'::regclass`,
+        );
+        expect(children[0]?.c).toBeGreaterThan(0);
+      } finally {
+        await Promise.all([src.drop(), shadow.drop()]);
+      }
+    }, 180_000);
+  },
+);

--- a/packages/pg-delta/tests/extension-intent-partman.test.ts
+++ b/packages/pg-delta/tests/extension-intent-partman.test.ts
@@ -564,6 +564,72 @@ describe.skipIf(!runSupabaseBareTests)(
       }
     }, 180_000);
 
+    test("a pgmq-OWNED partitioned queue is not captured as create_parent intent, while its partitions stay managedBy", async () => {
+      const cluster = await supabaseCluster();
+      const db = await cluster.createDb("partman_b_pgmq_queue");
+      try {
+        // an ORDINARY user parent (public.events) plus a pgmq partitioned
+        // queue. `pgmq.create_partitioned` registers BOTH `pgmq.q_pq` and
+        // `pgmq.a_pq` in partman's part_config, but the queue tables are
+        // pgmq's — the pgmq handler deliberately emits NO fact for a
+        // partitioned queue, and under the Supabase profile the whole `pgmq`
+        // schema is projected out. Replaying them as `create_parent` would
+        // consume a table nothing creates.
+        await seedPartmanParent(db);
+        await db.pool.query(`CREATE EXTENSION pgmq`);
+        await db.pool.query(`SELECT pgmq.create_partitioned('pq')`);
+
+        const extracted = await extract(db.pool, {
+          handlers: [pgPartmanHandler],
+        });
+
+        // the user's parent IS intent; neither queue table is
+        const intentKeys = extracted.factBase
+          .facts()
+          .filter((f) => f.id.kind === "extensionIntent")
+          .map((f) => (f.id as { key: string }).key);
+        expect(intentKeys).toEqual(["public.events"]);
+
+        // …and every skipped row says why
+        const unsupported = extracted.diagnostics.filter(
+          (d) => d.code === "intent-unsupported",
+        );
+        expect(unsupported.length).toBeGreaterThan(0);
+        expect(unsupported.map((d) => d.message).join("\n")).toMatch(/pgmq/);
+
+        // Phase A is untouched: the queue's OWN partitions (created by partman,
+        // not extension members) are still tagged managedBy, so nothing plans a
+        // DROP TABLE against them.
+        const queueParts = extracted.factBase
+          .facts()
+          .filter(
+            (f) =>
+              f.id.kind === "table" &&
+              f.id.schema === "pgmq" &&
+              /^[qa]_pq_/.test(f.id.name),
+          );
+        expect(queueParts.length).toBeGreaterThan(0);
+        for (const part of queueParts) {
+          expect(
+            extracted.factBase
+              .outgoingEdges(part.id)
+              .some((e) => e.kind === "managedBy"),
+          ).toBe(true);
+        }
+        // which is exactly what the managed view relies on
+        const managed = resolveView(extracted.factBase, undefined);
+        expect(
+          managed
+            .facts()
+            .filter(
+              (f) => f.id.kind === "table" && f.id.schema === "pgmq",
+            ),
+        ).toEqual([]);
+      } finally {
+        await db.drop();
+      }
+    }, 180_000);
+
     // ── the load-bearing deliverable (CLI-2044) ─────────────────────────────
     test("ROUND TRIP: export → load into a fresh shadow → re-extract yields a CONFIGURED parent and an empty diff", async () => {
       const cluster = await supabaseCluster();

--- a/packages/pg-delta/tests/extension-intent-partman.test.ts
+++ b/packages/pg-delta/tests/extension-intent-partman.test.ts
@@ -358,12 +358,13 @@ describe.skipIf(!runSupabaseBareTests)(
 
         // ...and the parent really is REGISTERED, on every intent column
         const both = await Promise.all(
-          [src, desired].map(async (db) =>
-            (
-              await db.pool.query(
-                `SELECT ${INTENT_COLUMNS} FROM partman.part_config ORDER BY parent_table`,
-              )
-            ).rows,
+          [src, desired].map(
+            async (db) =>
+              (
+                await db.pool.query(
+                  `SELECT ${INTENT_COLUMNS} FROM partman.part_config ORDER BY parent_table`,
+                )
+              ).rows,
           ),
         );
         expect(both[0]).toHaveLength(1);
@@ -624,12 +625,13 @@ describe.skipIf(!runSupabaseBareTests)(
         // and the shadow really carries a CONFIGURED parent — identical on every
         // intent column — with its own premade children
         const both = await Promise.all(
-          [shadow, src].map(async (db) =>
-            (
-              await db.pool.query(
-                `SELECT ${INTENT_COLUMNS} FROM partman.part_config ORDER BY parent_table`,
-              )
-            ).rows,
+          [shadow, src].map(
+            async (db) =>
+              (
+                await db.pool.query(
+                  `SELECT ${INTENT_COLUMNS} FROM partman.part_config ORDER BY parent_table`,
+                )
+              ).rows,
           ),
         );
         expect(both[0]).toHaveLength(1);


### PR DESCRIPTION
> **Stacked on #399** (pgmq intent) — merge that first; this branch contains its commits and uses machinery it added (`INTENT_UNSUPPORTED`, the round-trip test pattern). The partman-only commits are `81e46ac8` → `4d24ef7d` → `52559f94`.

Closes CLI-2044 (Deliverable B of CLI-1591).

## What

Extends the pg_partman handler from filter-only (Phase A) to full intent capture + replay: each `part_config` row becomes an `extensionIntent{ext:"pg_partman", intentKind:"parent"}` fact keyed by the catalog-canonical `<schema>.<name>` (resolved via `to_regclass`, which also drops rows whose table vanished), replayed as `select partman.create_parent(...)` with **named args** — `consumes` the parent table fact (orders after `CREATE TABLE`) and `depends` on the extension fact. A from-scratch rebuild now produces a **configured** parent with premade children instead of a bare one.

**The `part_config` column split is documented** (audited against pg_partman **5.3.1** on the pinned image; full disposition table in the `pg-partman.ts` header, summary in `docs/architecture/extension-intent.md` §3.3.1): 13 intent columns ride `create_parent()` args, 11 intent columns without an arg (retention*, `optimize_constraint`, `infinite_time_partitions`, …) replay as a follow-up `UPDATE part_config` emitted only when they differ from partman's defaults, 5 are runtime state and excluded. `part_config` is an extension member (`deptype='e'`), so both the function's writes and the bare `UPDATE` are exempt from the shadow loader's DML observation — **confirmed end-to-end**: the export → load-into-shadow → re-extract round trip passes with an empty diff.

Findings worth knowing:
- `p_type` exists again in partman 5.3.1 (removed in 5.0, reintroduced) — rendered.
- `p_default_table` has no `part_config` column; recovered structurally from `pg_partitioned_table.partdefid <> 0`.
- `p_control_not_null` is a guard, not a mutation — always passed `false`.
- `create_parent` auto-creates a template table that carries **no** `deptype='e'` edge; left untagged it permanently breaks the export/load cycle. It is now tagged `managedBy`; user-supplied templates stay facts and are `consumes`d by the replay.

## Decisions to review

1. **Drop = deregister, not destroy.** There is no single-statement inverse of `create_parent` (`undo_partition()` demands a target table and is batch-looped). The drop replay is `DELETE FROM part_config` with `dataLoss: "none"`: partitions become ordinary user tables, so a one-shot apply intentionally does **not** converge — a second round sees them explicitly and drops them under the normal data-loss gate. The alternative (opaque mass `DROP TABLE` inside the replay) would destroy data the user never saw planned. The integration test asserts the true two-round behavior; recorded in the CLI-2044 triage (`docs/roadmap/pg-delta-next-follow-ups.md`) alongside the one-shot-convergence follow-up option.
2. **Sub-partitioning scoped out** (`part_config_sub` + partman-authored sub-parent rows) with `intent-unsupported` warnings; the recursive Phase-A walk still tags every sub-level so nothing is dropped.
3. **One Deliverable-A test deliberately updated**: its desired state declared the parent without its registration, which post-Deliverable-B means "deregister me" — the desired state now declares the registration on both sides; the drop scenario is covered separately.
4. Known niche edges (recorded, not blocking): customizations to partman's *auto-created* template table aren't captured (supply your own template); a drop against a pre-existing registration made with quoted identifiers would `DELETE 0` rows — caught loudly by the proof loop, and partman itself barely supports quoted identifiers.

## RED → GREEN

Tests first (`81e46ac8`): 12 fail / 8 pass — the 8 passing are pre-existing Phase-A coverage; the Phase-B failures include the planner's `rule table: no intent rule registered for extension 'pg_partman' intent kind 'parent'`. Excerpts embedded in the feat commit body (`4d24ef7d`).

## Verification

| Gate | Result |
|---|---|
| `bun test src/policy/extensions/pg-partman.test.ts` | 20 pass / 0 fail |
| `bun test src/` (full unit suite) | 1070 pass / 0 fail |
| 5 supabase-image integration files (`PGDELTA_NEXT_SUPABASE_TESTS=1`) | 26 pass / 0 fail |
| Full corpus `tests/engine.test.ts` @ `postgres:17-alpine` | 662 pass / 0 fail |
| `format-and-lint:fix` / `check-types` / `knip` | clean (pg-topo knip failure pre-existing) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
