### PR TITLE
perf(pg-delta): cache and index planner hot loops

### DIFF
--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -9,6 +9,8 @@ memo for stable-id encoding, an objtype index for the default-ACL elision's
 skipping the rename discovery diff when `renames` is `"off"` (the default), and
 building the managed view's projection in a single `buildFactBase` pass.
 
-On a 21.9k-fact catalog: a tiny-delta plan drops from ~524ms to ~276ms and a
-from-empty plan of the whole catalog from ~5.6s to ~450ms. The rendered plan SQL
-is byte-identical and action counts are unchanged.
+Measured on a 21.9k-fact catalog (p50 of 10 timed reps, back-to-back on one
+machine): a tiny-delta plan drops from ~604ms to ~294ms under the Supabase
+profile and from ~248ms to ~183ms under the raw profile, and a from-empty plan of
+the whole catalog from ~2.46s to ~486ms. The rendered plan SQL is byte-identical
+(sha256) and action counts are unchanged in every cell.

--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,14 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Speed up `plan()` on large catalogs. Six behavior-preserving changes to the
+planner's hot loops — the compiled-glob cache in policy matching, a per-object
+memo for stable-id encoding, an objtype index for the default-ACL elision's
+`ALTER DEFAULT PRIVILEGES` gate, memoized tie keys in the topological sort,
+skipping the rename discovery diff when `renames` is `"off"` (the default), and
+building the managed view's projection in a single `buildFactBase` pass.
+
+On a 21.9k-fact catalog: a tiny-delta plan drops from ~524ms to ~276ms and a
+from-empty plan of the whole catalog from ~5.6s to ~450ms. The rendered plan SQL
+is byte-identical and action counts are unchanged.

--- a/packages/pg-delta/src/core/fact.test.ts
+++ b/packages/pg-delta/src/core/fact.test.ts
@@ -155,3 +155,111 @@ describe("buildFactBase", () => {
     expect(fb.get({ kind: "table", schema: "no", name: "pe" })).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// The lookup layer memoizes id encodings, but ONLY for ids the engine itself
+// registered while building a FactBase. A CALLER's query object must never enter
+// that cache: `fb.get(q)` is public, so a caller may reuse and mutate `q` between
+// lookups and must get an answer for the value `q` currently holds.
+//
+// (Mutating a fact's OWN id object — one obtained from `fb.facts()` — remains
+// undefined behavior: it desynchronizes the string-keyed indexes with or without
+// any memo. That is the pre-existing contract and is not what these pin.)
+// ---------------------------------------------------------------------------
+
+describe("FactBase lookups do not cache caller query objects", () => {
+  const alpha: StableId = { kind: "schema", name: "alpha" };
+  const beta: StableId = { kind: "schema", name: "beta" };
+  const tAlpha: StableId = { kind: "table", schema: "alpha", name: "t" };
+  const tBeta: StableId = { kind: "table", schema: "beta", name: "t" };
+
+  function twoSchemas() {
+    return buildFactBase(
+      [
+        { id: alpha, payload: {} },
+        { id: beta, payload: {} },
+        { id: tAlpha, parent: alpha, payload: {} },
+        { id: tBeta, parent: beta, payload: {} },
+      ],
+      [
+        { from: tAlpha, to: alpha, kind: "owner" },
+        { from: tBeta, to: beta, kind: "owner" },
+      ],
+    );
+  }
+
+  test("get() re-reads a mutated query object", () => {
+    const fb = twoSchemas();
+    const q: StableId = { kind: "schema", name: "alpha" };
+    expect(fb.get(q)?.id).toEqual(alpha);
+    (q as { name: string }).name = "beta";
+    expect(fb.get(q)?.id).toEqual(beta);
+  });
+
+  test("get() reports absence after a query object is mutated to a missing id", () => {
+    const fb = twoSchemas();
+    const q: StableId = { kind: "schema", name: "alpha" };
+    expect(fb.get(q)).toBeDefined();
+    (q as { name: string }).name = "gamma";
+    expect(fb.get(q)).toBeUndefined();
+  });
+
+  test("has() re-reads a mutated query object", () => {
+    const fb = twoSchemas();
+    const q: StableId = { kind: "schema", name: "alpha" };
+    expect(fb.has(q)).toBe(true);
+    (q as { name: string }).name = "gamma";
+    expect(fb.has(q)).toBe(false);
+  });
+
+  test("childrenOf() re-reads a mutated query object", () => {
+    const fb = twoSchemas();
+    const q: StableId = { kind: "schema", name: "alpha" };
+    expect(fb.childrenOf(q).map((f) => f.id)).toEqual([tAlpha]);
+    (q as { name: string }).name = "beta";
+    expect(fb.childrenOf(q).map((f) => f.id)).toEqual([tBeta]);
+  });
+
+  test("outgoingEdges() re-reads a mutated query object", () => {
+    const fb = twoSchemas();
+    const q: StableId = { kind: "table", schema: "alpha", name: "t" };
+    expect(fb.outgoingEdges(q).map((e) => e.to)).toEqual([alpha]);
+    (q as { schema: string }).schema = "beta";
+    expect(fb.outgoingEdges(q).map((e) => e.to)).toEqual([beta]);
+  });
+
+  test("incomingEdges() re-reads a mutated query object", () => {
+    const fb = twoSchemas();
+    const q: StableId = { kind: "schema", name: "alpha" };
+    expect(fb.incomingEdges(q).map((e) => e.from)).toEqual([tAlpha]);
+    (q as { name: string }).name = "beta";
+    expect(fb.incomingEdges(q).map((e) => e.from)).toEqual([tBeta]);
+  });
+
+  test("hashOf()/rollupOf() re-read a mutated query object", () => {
+    const fb = twoSchemas();
+    const q: StableId = { kind: "table", schema: "alpha", name: "t" };
+    const alphaRollup = fb.rollupOf(q);
+    (q as { schema: string }).schema = "beta";
+    expect(fb.rollupOf(q)).toBe(fb.rollupOf(tBeta));
+    expect(fb.rollupOf(q)).not.toBe(alphaRollup);
+    expect(fb.hashOf(q)).toBe(fb.hashOf(tBeta));
+  });
+
+  // Correctness of the registration memo itself: ids registered while building
+  // ONE FactBase must still resolve in ANOTHER (diff's hot pattern is
+  // `b.get(factFromA.id)`), because the memo is module-global.
+  test("an id object registered by one FactBase resolves in another", () => {
+    const a = twoSchemas();
+    const b = twoSchemas();
+    for (const fact of a.facts()) {
+      expect(b.get(fact.id)?.id).toEqual(fact.id);
+      expect(b.has(fact.id)).toBe(true);
+      expect(b.hashOf(fact.id)).toBe(a.hashOf(fact.id));
+    }
+    // and a FactBase that does NOT contain the id still answers honestly
+    const onlyAlpha = buildFactBase([{ id: alpha, payload: {} }], []);
+    expect(onlyAlpha.get(beta)).toBeUndefined();
+    expect(onlyAlpha.get(alpha)?.id).toEqual(alpha);
+  });
+});

--- a/packages/pg-delta/src/core/fact.ts
+++ b/packages/pg-delta/src/core/fact.ts
@@ -14,7 +14,7 @@ import {
   type ContentHash,
   type Payload,
 } from "./hash.ts";
-import { encodeId, type StableId } from "./stable-id.ts";
+import { encodeIdMemo, type StableId } from "./stable-id.ts";
 
 export interface Fact {
   id: StableId;
@@ -56,7 +56,7 @@ export const retainOwnerRoleDangling = (edge: DependencyEdge): boolean =>
 interface Entry {
   fact: Fact;
   encoded: string;
-  /** `encodeId(fact.parent)`, encoded once at index time: the parent chain is
+  /** `encodeIdMemo(fact.parent)`, encoded once at index time: the parent chain is
    *  walked by the acyclicity check and every hierarchy lookup. */
   parentKey: string | undefined;
   hash: ContentHash;
@@ -104,7 +104,7 @@ export class FactBase {
     this.source = source;
     this.referenceOnly = referenceOnly;
     for (const fact of facts) {
-      const encoded = encodeId(fact.id);
+      const encoded = encodeIdMemo(fact.id);
       if (this.#byId.has(encoded)) {
         throw new Error(`FactBase: duplicate fact id ${encoded}`);
       }
@@ -112,7 +112,7 @@ export class FactBase {
         fact,
         encoded,
         parentKey:
-          fact.parent === undefined ? undefined : encodeId(fact.parent),
+          fact.parent === undefined ? undefined : encodeIdMemo(fact.parent),
         hash: contentHash(fact.payload),
       });
     }
@@ -166,8 +166,8 @@ export class FactBase {
       for (const key of path) reachesRoot.add(key);
     }
     for (const edge of edges) {
-      const fromKey = encodeId(edge.from);
-      const toKey = encodeId(edge.to);
+      const fromKey = encodeIdMemo(edge.from);
+      const toKey = encodeIdMemo(edge.to);
       const fromPresent = this.#byId.has(fromKey);
       const toPresent = this.#byId.has(toKey);
       if (!fromPresent || !toPresent) {
@@ -225,39 +225,39 @@ export class FactBase {
   }
 
   get(id: StableId): Fact | undefined {
-    return this.#byId.get(encodeId(id))?.fact;
+    return this.#byId.get(encodeIdMemo(id))?.fact;
   }
 
   has(id: StableId): boolean {
-    return this.#byId.has(encodeId(id));
+    return this.#byId.has(encodeIdMemo(id));
   }
 
   /** Whether `id` is present for REFERENCE ONLY (see `referenceOnly`). Satisfies
    *  the `FactView` member so a rule can distinguish "on the target" from
    *  "produced by this plan". */
   isReferenceOnly(id: StableId): boolean {
-    return this.referenceOnly.has(encodeId(id));
+    return this.referenceOnly.has(encodeIdMemo(id));
   }
 
   hashOf(id: StableId): ContentHash {
-    const entry = this.#byId.get(encodeId(id));
-    if (!entry) throw new Error(`FactBase: unknown fact ${encodeId(id)}`);
+    const entry = this.#byId.get(encodeIdMemo(id));
+    if (!entry) throw new Error(`FactBase: unknown fact ${encodeIdMemo(id)}`);
     return entry.hash;
   }
 
   childrenOf(id: StableId): Fact[] {
-    return (this.#children.get(encodeId(id)) ?? []).map((e) => e.fact);
+    return (this.#children.get(encodeIdMemo(id)) ?? []).map((e) => e.fact);
   }
 
   outgoingEdges(id: StableId): readonly DependencyEdge[] {
-    return this.#outgoing.get(encodeId(id)) ?? [];
+    return this.#outgoing.get(encodeIdMemo(id)) ?? [];
   }
 
   /** Edges pointing AT `id` (reverse index): the facts that depend on it. Used
    *  by the planner's forced-rebuild reachability walk (O(reachable) instead of
    *  rescanning every edge each round). */
   incomingEdges(id: StableId): readonly DependencyEdge[] {
-    return this.#incoming.get(encodeId(id)) ?? [];
+    return this.#incoming.get(encodeIdMemo(id)) ?? [];
   }
 
   /** Reverse edges by already-encoded id (avoids re-encoding in hot walks). */
@@ -279,7 +279,7 @@ export class FactBase {
    * subtree propagate (a renamed child changes the parent's rollup).
    */
   rollupOf(id: StableId): ContentHash {
-    return this.#rollup(encodeId(id));
+    return this.#rollup(encodeIdMemo(id));
   }
 
   #rollup(key: string): ContentHash {
@@ -306,7 +306,7 @@ export class FactBase {
    * for container rename matching (§4.1).
    */
   structuralRollupOf(id: StableId): ContentHash {
-    return this.#structuralRollup(encodeId(id));
+    return this.#structuralRollup(encodeIdMemo(id));
   }
 
   #structuralRollup(key: string): ContentHash {
@@ -329,7 +329,7 @@ export class FactBase {
   get rootHash(): ContentHash {
     if (this.#rootHash === undefined) {
       const parts = this.roots().map(
-        (f) => `${encodeId(f.id)}=${this.rollupOf(f.id)}`,
+        (f) => `${encodeIdMemo(f.id)}=${this.rollupOf(f.id)}`,
       );
       this.#rootHash = hashString(`ROOT|${parts.join(",")}`);
     }

--- a/packages/pg-delta/src/core/fact.ts
+++ b/packages/pg-delta/src/core/fact.ts
@@ -14,7 +14,7 @@ import {
   type ContentHash,
   type Payload,
 } from "./hash.ts";
-import { encodeIdMemo, type StableId } from "./stable-id.ts";
+import { encodeIdMemo, encodeIdRegister, type StableId } from "./stable-id.ts";
 
 export interface Fact {
   id: StableId;
@@ -56,8 +56,8 @@ export const retainOwnerRoleDangling = (edge: DependencyEdge): boolean =>
 interface Entry {
   fact: Fact;
   encoded: string;
-  /** `encodeIdMemo(fact.parent)`, encoded once at index time: the parent chain is
-   *  walked by the acyclicity check and every hierarchy lookup. */
+  /** `encodeIdRegister(fact.parent)`, encoded once at index time: the parent chain
+   *  is walked by the acyclicity check and every hierarchy lookup. */
   parentKey: string | undefined;
   hash: ContentHash;
 }
@@ -103,8 +103,13 @@ export class FactBase {
   ) {
     this.source = source;
     this.referenceOnly = referenceOnly;
+    // This indexing pass is the SOLE writer of the id-encoding memo: these ids
+    // (fact ids, their parents, edge endpoints) are engine-owned and never mutated
+    // after construction, so caching them is sound. A public lookup's query object
+    // must never be cached, which is why every accessor below reads the memo via
+    // `encodeIdMemo` and only this loop writes via `encodeIdRegister`.
     for (const fact of facts) {
-      const encoded = encodeIdMemo(fact.id);
+      const encoded = encodeIdRegister(fact.id);
       if (this.#byId.has(encoded)) {
         throw new Error(`FactBase: duplicate fact id ${encoded}`);
       }
@@ -112,7 +117,7 @@ export class FactBase {
         fact,
         encoded,
         parentKey:
-          fact.parent === undefined ? undefined : encodeIdMemo(fact.parent),
+          fact.parent === undefined ? undefined : encodeIdRegister(fact.parent),
         hash: contentHash(fact.payload),
       });
     }
@@ -166,8 +171,8 @@ export class FactBase {
       for (const key of path) reachesRoot.add(key);
     }
     for (const edge of edges) {
-      const fromKey = encodeIdMemo(edge.from);
-      const toKey = encodeIdMemo(edge.to);
+      const fromKey = encodeIdRegister(edge.from);
+      const toKey = encodeIdRegister(edge.to);
       const fromPresent = this.#byId.has(fromKey);
       const toPresent = this.#byId.has(toKey);
       if (!fromPresent || !toPresent) {

--- a/packages/pg-delta/src/core/stable-id.test.ts
+++ b/packages/pg-delta/src/core/stable-id.test.ts
@@ -278,4 +278,20 @@ describe("parseId round-trips", () => {
     const d = encodeId({ kind: "table", schema: "a", name: "b.c" });
     expect(c).not.toBe(d);
   });
+
+  // `encodeId` memoizes per id OBJECT (WeakMap). Two things must hold for that
+  // to be invisible: re-encoding the same object is stable, and a structurally
+  // equal but distinct object — which misses the memo — still encodes
+  // identically. Covers every kind via the round-trip `cases` above.
+  test("memoized encoding is stable and identity-independent", () => {
+    for (const id of cases) {
+      const first = encodeId(id);
+      expect(encodeId(id)).toBe(first);
+      // a fresh deep copy shares no object identity with `id`
+      const copy = JSON.parse(JSON.stringify(id)) as StableId;
+      expect(encodeId(copy)).toBe(first);
+      // and the memo must not leak across a MUTATED copy's sibling
+      expect(parseId(encodeId(copy))).toEqual(id);
+    }
+  });
 });

--- a/packages/pg-delta/src/core/stable-id.test.ts
+++ b/packages/pg-delta/src/core/stable-id.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { encodeId, parseId, type StableId } from "./stable-id.ts";
+import { buildFactBase } from "./fact.ts";
+import { encodeId, encodeIdMemo, parseId, type StableId } from "./stable-id.ts";
 
 /** Round-trip helper: encode → parse must reproduce the value exactly. */
 function roundtrip(id: StableId): void {
@@ -279,19 +280,122 @@ describe("parseId round-trips", () => {
     expect(c).not.toBe(d);
   });
 
-  // `encodeId` memoizes per id OBJECT (WeakMap). Two things must hold for that
-  // to be invisible: re-encoding the same object is stable, and a structurally
-  // equal but distinct object — which misses the memo — still encodes
-  // identically. Covers every kind via the round-trip `cases` above.
-  test("memoized encoding is stable and identity-independent", () => {
+  // Encoding must not depend on object IDENTITY: a structurally equal but
+  // distinct object encodes identically. Covers every kind via `cases` above.
+  test("encoding is identity-independent", () => {
     for (const id of cases) {
       const first = encodeId(id);
       expect(encodeId(id)).toBe(first);
       // a fresh deep copy shares no object identity with `id`
       const copy = JSON.parse(JSON.stringify(id)) as StableId;
       expect(encodeId(copy)).toBe(first);
-      // and the memo must not leak across a MUTATED copy's sibling
       expect(parseId(encodeId(copy))).toEqual(id);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The PUBLIC `encodeId` is a pure function: it is exported API, `StableId` is a
+// structurally mutable union, and a consumer that mutates an id and re-encodes
+// must see the NEW encoding. Only the INTERNAL `encodeIdMemo` caches by object
+// identity, under the engine's never-mutate-an-id invariant.
+// ---------------------------------------------------------------------------
+
+describe("encodeId is pure (no identity cache on the public API)", () => {
+  test("reflects a mutated id on re-encode", () => {
+    const id: StableId = { kind: "schema", name: "before" };
+    expect(encodeId(id)).toBe("schema:before");
+    (id as { name: string }).name = "after";
+    expect(encodeId(id)).toBe("schema:after");
+  });
+
+  test("reflects mutation through every segment shape", () => {
+    const table: StableId = { kind: "table", schema: "s1", name: "t1" };
+    expect(encodeId(table)).toBe("table:s1.t1");
+    (table as { schema: string }).schema = "s2";
+    expect(encodeId(table)).toBe("table:s2.t1");
+
+    // a nested target id must not be cached either
+    const acl: StableId = {
+      kind: "acl",
+      target: { kind: "table", schema: "s", name: "t" },
+      grantee: "g",
+    };
+    expect(encodeId(acl)).toBe("acl:(table:s.t).g");
+    (acl as { target: { name: string } }).target.name = "t2";
+    expect(encodeId(acl)).toBe("acl:(table:s.t2).g");
+
+    // routine args are encoded per element
+    const fn: StableId = {
+      kind: "function",
+      schema: "s",
+      name: "f",
+      args: ["text"],
+    };
+    expect(encodeId(fn)).toBe("function:s.f(text)");
+    (fn as { args: string[] }).args[0] = "integer";
+    expect(encodeId(fn)).toBe("function:s.f(integer)");
+  });
+
+  test("a mutation is visible even after the id was indexed in a FactBase", () => {
+    // the FactBase lookup layer uses the MEMOIZED variant, so this pins that the
+    // two caches stay separate — indexing must not poison the public function.
+    const id: StableId = { kind: "schema", name: "indexed" };
+    const fb = buildFactBase([{ id, payload: {} }], []);
+    expect(fb.get(id)).toBeDefined();
+    (id as { name: string }).name = "renamed";
+    expect(encodeId(id)).toBe("schema:renamed");
+  });
+});
+
+describe("encodeIdMemo (internal)", () => {
+  test("agrees with encodeId across every segment shape", () => {
+    const ids: StableId[] = [
+      { kind: "schema", name: "public" },
+      { kind: "table", schema: "s", name: "t" },
+      { kind: "column", schema: "s", table: "t", name: "c" },
+      { kind: "function", schema: "s", name: "f", args: ["text", "int[]"] },
+      { kind: "membership", role: "r", member: "m" },
+      { kind: "typeAttribute", schema: "s", type: "addr", name: "city" },
+      { kind: "publicationRel", publication: "p", schema: "s", table: "t" },
+      { kind: "publicationSchema", publication: "p", schema: "s" },
+      { kind: "userMapping", server: "srv", role: "r" },
+      { kind: "comment", target: { kind: "schema", name: "s" } },
+      {
+        kind: "acl",
+        target: { kind: "table", schema: "s", name: "t" },
+        grantee: "g",
+        column: "c",
+      },
+      {
+        kind: "securityLabel",
+        target: { kind: "table", schema: "s", name: "t" },
+        provider: "dummy",
+      },
+      {
+        kind: "defaultPrivilege",
+        role: "o",
+        schema: null,
+        objtype: "r",
+        grantee: "g",
+      },
+      { kind: "extensionIntent", ext: "pg_cron", intentKind: "job", key: "k" },
+      // hostile parts that force quoting
+      { kind: "table", schema: "a.b", name: 'c"d' },
+    ];
+    for (const id of ids) {
+      // fresh structural copy so the memo cannot be primed by encodeId's call
+      const copy = JSON.parse(JSON.stringify(id)) as StableId;
+      expect(encodeIdMemo(copy)).toBe(encodeId(id));
+    }
+  });
+
+  test("caches by object identity and is stable across calls", () => {
+    const id: StableId = { kind: "schema", name: "memo" };
+    const first = encodeIdMemo(id);
+    expect(first).toBe("schema:memo");
+    for (let i = 0; i < 5; i++) expect(encodeIdMemo(id)).toBe(first);
+    // structurally equal but distinct object misses the memo and re-encodes
+    expect(encodeIdMemo({ kind: "schema", name: "memo" })).toBe(first);
   });
 });

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -258,35 +258,54 @@ export function encodeId(id: StableId): string {
 }
 
 /**
- * INTERNAL memoized `encodeId`, keyed by id OBJECT identity.
+ * INTERNAL encoding memo, keyed by id OBJECT identity.
  *
- * Not exported from the package entry points (`src/index.ts`, `src/core/index.ts`)
- * on purpose: caching by identity is only sound under an invariant the engine
- * upholds but a consumer cannot be held to. `encodeId` above stays pure for them.
+ * OWNERSHIP RULE — the memo is **registration-only**. Entries are written by
+ * exactly one caller, `buildFactBase` (src/core/fact.ts), for the fact ids, parent
+ * ids and edge endpoint ids it is already encoding as it builds its indexes.
+ * Those objects are ENGINE-OWNED and never mutated after construction. Nothing
+ * else ever writes: `encodeIdMemo` below only READS.
  *
- * Why it matters: `FactBase.get` / `has` / `hashOf` / `childrenOf` /
- * `outgoingEdges` / `incomingEdges` / `isReferenceOnly` all key their indexes by
- * the encoding, and `buildFactBase` re-encodes every fact and edge endpoint on
- * every rebuild (managed-view reconstruction, scope/target projection, identity
- * normalization). A plan performs millions of such lookups over a few tens of
- * thousands of DISTINCT id objects, so re-walking the id and re-running `seg` per
- * part dominated the lookup layer.
+ * That asymmetry is what makes the cache safe across a public boundary.
+ * `FactBase.get` / `has` / `hashOf` / `childrenOf` / `outgoingEdges` /
+ * `incomingEdges` / `isReferenceOnly` are public and take a caller's StableId. If
+ * a lookup also POPULATED the memo, a caller that reused and mutated one query
+ * object would get a stale answer on the next lookup. Because lookups only read,
+ * a caller-provided object is simply never in the map and is re-encoded from its
+ * current field values every time.
  *
- * INVARIANT: a StableId object reaching these paths is never mutated after
- * construction. Ids are built once (extract / load / snapshot decode / rule
- * construction) and thereafter only read; every transform that changes one
- * returns a NEW id (e.g. `plan/identity-normalize.ts`). This is the same
- * invariant `payloadHashes` in `core/hash.ts` already relies on for payloads.
- * Weak keys, so entries die with the facts that own them.
+ * Why bother: a plan performs millions of lookups, and `buildFactBase`
+ * re-encodes every fact and edge endpoint on every rebuild (managed-view
+ * reconstruction, scope/target projection, identity normalization). The map stays
+ * module-global — not per-FactBase — so `b.get(factFromA.id)` (diff's hot
+ * pattern) still hits for ids registered when A was built.
  *
- * Wrapper kinds (`comment` / `acl` / `securityLabel`) encode their nested
- * `target` through the PURE `encodeId`, so only the outer id is cached. That is
- * enough: the whole encoded string is memoized, so a repeat lookup of the same
- * wrapper object never re-walks the target either.
+ * Neither `encodeIdMemo` nor `encodeIdRegister` is re-exported from the package
+ * entry points (`src/index.ts`, `src/core/index.ts`), and no `exports` subpath
+ * maps to this module, so consumers only ever see the pure `encodeId`.
+ *
+ * Same invariant `payloadHashes` in `core/hash.ts` relies on for payloads. Weak
+ * keys, so entries die with the ids that own them.
  */
 const idEncodings = new WeakMap<object, string>();
 
+/**
+ * READ-ONLY memo lookup, for every path that may see a CALLER's id — i.e. all the
+ * public `FactBase` accessors. Reads the memo; on a miss it pure-encodes and does
+ * NOT write, so a caller object never enters the cache and can never go stale.
+ */
 export function encodeIdMemo(id: StableId): string {
+  return idEncodings.get(id) ?? encodeId(id);
+}
+
+/**
+ * Get-or-register. The ONLY writer of the memo: `buildFactBase`'s indexing pass,
+ * over ids it owns (fact ids, their parents, edge endpoints). Reads first so a
+ * REBUILD of the same fact objects — managed-view reconstruction, scope/target
+ * projection, identity normalization all rebuild constantly — skips the walk
+ * instead of re-encoding every fact and edge endpoint from scratch.
+ */
+export function encodeIdRegister(id: StableId): string {
   const memo = idEncodings.get(id);
   if (memo !== undefined) return memo;
   const encoded = encodeId(id);

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -205,7 +205,35 @@ function seg(part: string): string {
   return part;
 }
 
+/**
+ * StableId object -> its encoding. `encodeId` is one of the hottest functions in
+ * the engine: `FactBase.get` / `has` / `hashOf` / `childrenOf` / `outgoingEdges`
+ * all key their indexes by the encoding, so every lookup re-walks the id and
+ * re-runs `seg` over each part, and a plan performs millions of lookups over a
+ * few tens of thousands of DISTINCT id objects.
+ *
+ * INVARIANT: a StableId object is never mutated after construction. Ids are
+ * built once (extract / load / snapshot decode / rule construction) and
+ * thereafter only read; every transform that changes one returns a NEW id (e.g.
+ * `plan/identity-normalize.ts`). This is the same invariant `payloadHashes` in
+ * `core/hash.ts` already relies on for payloads. Weak keys, so entries die with
+ * the facts that own them.
+ *
+ * Memoizing the outer call subsumes the nested one: `comment` / `acl` /
+ * `securityLabel` encode their `target` id through `encodeId`, so a repeated
+ * target hits this map too.
+ */
+const idEncodings = new WeakMap<object, string>();
+
 export function encodeId(id: StableId): string {
+  const memo = idEncodings.get(id);
+  if (memo !== undefined) return memo;
+  const encoded = encodeIdUncached(id);
+  idEncodings.set(id, encoded);
+  return encoded;
+}
+
+function encodeIdUncached(id: StableId): string {
   const k = id.kind;
   switch (k) {
     case "membership":

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -206,34 +206,14 @@ function seg(part: string): string {
 }
 
 /**
- * StableId object -> its encoding. `encodeId` is one of the hottest functions in
- * the engine: `FactBase.get` / `has` / `hashOf` / `childrenOf` / `outgoingEdges`
- * all key their indexes by the encoding, so every lookup re-walks the id and
- * re-runs `seg` over each part, and a plan performs millions of lookups over a
- * few tens of thousands of DISTINCT id objects.
+ * Encode a StableId into its canonical string form.
  *
- * INVARIANT: a StableId object is never mutated after construction. Ids are
- * built once (extract / load / snapshot decode / rule construction) and
- * thereafter only read; every transform that changes one returns a NEW id (e.g.
- * `plan/identity-normalize.ts`). This is the same invariant `payloadHashes` in
- * `core/hash.ts` already relies on for payloads. Weak keys, so entries die with
- * the facts that own them.
- *
- * Memoizing the outer call subsumes the nested one: `comment` / `acl` /
- * `securityLabel` encode their `target` id through `encodeId`, so a repeated
- * target hits this map too.
+ * PURE, and deliberately NOT memoized: this is exported API (`@supabase/pg-delta`
+ * and the `/core` subpath), and `StableId` is a structurally mutable union, so a
+ * consumer that mutates an id and re-encodes must observe the NEW encoding. The
+ * engine's own hot paths use `encodeIdMemo` below instead.
  */
-const idEncodings = new WeakMap<object, string>();
-
 export function encodeId(id: StableId): string {
-  const memo = idEncodings.get(id);
-  if (memo !== undefined) return memo;
-  const encoded = encodeIdUncached(id);
-  idEncodings.set(id, encoded);
-  return encoded;
-}
-
-function encodeIdUncached(id: StableId): string {
   const k = id.kind;
   switch (k) {
     case "membership":
@@ -275,6 +255,43 @@ function encodeIdUncached(id: StableId): string {
       }
       throw new Error(`encodeId: unknown kind ${String(k)}`);
   }
+}
+
+/**
+ * INTERNAL memoized `encodeId`, keyed by id OBJECT identity.
+ *
+ * Not exported from the package entry points (`src/index.ts`, `src/core/index.ts`)
+ * on purpose: caching by identity is only sound under an invariant the engine
+ * upholds but a consumer cannot be held to. `encodeId` above stays pure for them.
+ *
+ * Why it matters: `FactBase.get` / `has` / `hashOf` / `childrenOf` /
+ * `outgoingEdges` / `incomingEdges` / `isReferenceOnly` all key their indexes by
+ * the encoding, and `buildFactBase` re-encodes every fact and edge endpoint on
+ * every rebuild (managed-view reconstruction, scope/target projection, identity
+ * normalization). A plan performs millions of such lookups over a few tens of
+ * thousands of DISTINCT id objects, so re-walking the id and re-running `seg` per
+ * part dominated the lookup layer.
+ *
+ * INVARIANT: a StableId object reaching these paths is never mutated after
+ * construction. Ids are built once (extract / load / snapshot decode / rule
+ * construction) and thereafter only read; every transform that changes one
+ * returns a NEW id (e.g. `plan/identity-normalize.ts`). This is the same
+ * invariant `payloadHashes` in `core/hash.ts` already relies on for payloads.
+ * Weak keys, so entries die with the facts that own them.
+ *
+ * Wrapper kinds (`comment` / `acl` / `securityLabel`) encode their nested
+ * `target` through the PURE `encodeId`, so only the outer id is cached. That is
+ * enough: the whole encoded string is memoized, so a repeat lookup of the same
+ * wrapper object never re-walks the target either.
+ */
+const idEncodings = new WeakMap<object, string>();
+
+export function encodeIdMemo(id: StableId): string {
+  const memo = idEncodings.get(id);
+  if (memo !== undefined) return memo;
+  const encoded = encodeId(id);
+  idEncodings.set(id, encoded);
+  return encoded;
 }
 
 class Cursor {

--- a/packages/pg-delta/src/plan/graph.test.ts
+++ b/packages/pg-delta/src/plan/graph.test.ts
@@ -19,7 +19,7 @@ function referenceSort(
   edges: Edge[],
   keyOf: (n: number) => string,
 ): number[] {
-  const indegree = new Array<number>(nodeCount).fill(0);
+  const indegree = Array.from({ length: nodeCount }, () => 0);
   const adjacency: number[][] = Array.from({ length: nodeCount }, () => []);
   const seen = new Set<string>();
   for (const [u, v] of edges) {

--- a/packages/pg-delta/src/plan/graph.test.ts
+++ b/packages/pg-delta/src/plan/graph.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit coverage for the deterministic heap-based Kahn sort (src/plan/graph.ts).
+ *
+ * `topoSort` memoizes the caller's tie-key function per node index, because the
+ * heap consults it inside every sift comparison. These tests pin that the
+ * memoization is transparent: the emitted order matches a naive reference sort
+ * (repeatedly take the lexicographically smallest ready node), and each node's
+ * key is computed exactly once.
+ */
+import { describe, expect, test } from "bun:test";
+import { topoSort } from "./graph.ts";
+
+type Edge = [before: number, after: number];
+
+/** Reference implementation: O(n^2) selection of the smallest ready key. No
+ *  heap, no memoization — the ground truth for "deterministic Kahn". */
+function referenceSort(
+  nodeCount: number,
+  edges: Edge[],
+  keyOf: (n: number) => string,
+): number[] {
+  const indegree = new Array<number>(nodeCount).fill(0);
+  const adjacency: number[][] = Array.from({ length: nodeCount }, () => []);
+  const seen = new Set<string>();
+  for (const [u, v] of edges) {
+    if (u === v) continue;
+    const k = `${u}>${v}`;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    adjacency[u]!.push(v);
+    indegree[v]! += 1;
+  }
+  const ready = new Set<number>();
+  for (let i = 0; i < nodeCount; i++) if (indegree[i] === 0) ready.add(i);
+  const order: number[] = [];
+  while (ready.size > 0) {
+    let best: number | undefined;
+    for (const n of ready) {
+      if (best === undefined || keyOf(n) < keyOf(best)) best = n;
+    }
+    ready.delete(best!);
+    order.push(best!);
+    for (const next of adjacency[best!]!) {
+      indegree[next]! -= 1;
+      if (indegree[next] === 0) ready.add(next);
+    }
+  }
+  return order;
+}
+
+/** Deterministic PRNG so a failure is reproducible. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** A random DAG: edges only ever point from a lower to a higher rank, so it is
+ *  acyclic by construction, while the NODE ids are shuffled so index order
+ *  carries no ordering information. */
+function randomDag(
+  seed: number,
+  nodeCount: number,
+  edgeCount: number,
+): { edges: Edge[]; keyOf: (n: number) => string } {
+  const rnd = mulberry32(seed);
+  const rank = Array.from({ length: nodeCount }, (_, i) => i);
+  for (let i = nodeCount - 1; i > 0; i--) {
+    const j = Math.floor(rnd() * (i + 1));
+    [rank[i], rank[j]] = [rank[j]!, rank[i]!];
+  }
+  const edges: Edge[] = [];
+  for (let e = 0; e < edgeCount; e++) {
+    const a = Math.floor(rnd() * nodeCount);
+    const b = Math.floor(rnd() * nodeCount);
+    if (rank[a]! === rank[b]!) continue;
+    edges.push(rank[a]! < rank[b]! ? [a, b] : [b, a]);
+  }
+  // Deliberately COLLIDING tie keys (a small alphabet) so equal-key nodes are
+  // common and the padded index suffix is what actually breaks the tie — the
+  // shape `actionTieKey` produces.
+  const keys = Array.from(
+    { length: nodeCount },
+    (_, i) =>
+      `${String(Math.floor(rnd() * 4))}|${"abc"[Math.floor(rnd() * 3)]}|${String(i).padStart(6, "0")}`,
+  );
+  return { edges, keyOf: (n) => keys[n]! };
+}
+
+describe("topoSort", () => {
+  test("respects edges and breaks ties by key on a simple graph", () => {
+    // 0 -> 2, 1 -> 2; keys make 1 sort before 0
+    const keys = ["b", "a", "c", "a0"];
+    const order = topoSort(
+      4,
+      [
+        [0, 2],
+        [1, 2],
+      ],
+      (n) => keys[n]!,
+      (n) => `node ${n}`,
+    );
+    expect(order).toEqual([1, 3, 0, 2]);
+  });
+
+  test("matches the naive reference sort on shuffled random DAGs", () => {
+    for (const seed of [1, 2, 3, 7, 42, 1337, 99991]) {
+      const { edges, keyOf } = randomDag(seed, 200, 600);
+      const got = topoSort(200, edges, keyOf, (n) => `node ${n}`);
+      expect(got).toEqual(referenceSort(200, edges, keyOf));
+      expect(got).toHaveLength(200);
+      expect(new Set(got).size).toBe(200);
+    }
+  });
+
+  test("computes each node's tie key exactly once", () => {
+    const { edges, keyOf } = randomDag(4711, 300, 900);
+    const calls = new Map<number, number>();
+    const counted = (n: number): string => {
+      calls.set(n, (calls.get(n) ?? 0) + 1);
+      return keyOf(n);
+    };
+    const order = topoSort(300, edges, counted, (n) => `node ${n}`);
+    expect(order).toEqual(referenceSort(300, edges, keyOf));
+    // No node is keyed twice — the memo property. (A node pushed onto an EMPTY
+    // heap, or popped as the only item, is never compared, so the total is
+    // nodeCount or slightly under; without the memo it is O(n log n).)
+    expect([...calls.values()].every((c) => c === 1)).toBe(true);
+    expect(calls.size).toBeLessThanOrEqual(300);
+    expect(calls.size).toBeGreaterThan(290);
+  });
+
+  test("reports a cycle instead of repairing it", () => {
+    expect(() =>
+      topoSort(
+        3,
+        [
+          [0, 1],
+          [1, 2],
+          [2, 0],
+        ],
+        (n) => `k${n}`,
+        (n) => `node ${n}`,
+      ),
+    ).toThrow(/dependency cycle among 3 actions/);
+  });
+
+  test("ignores self-edges and duplicate edges", () => {
+    const keys = ["a", "b"];
+    const order = topoSort(
+      2,
+      [
+        [0, 0],
+        [1, 0],
+        [1, 0],
+      ],
+      (n) => keys[n]!,
+      (n) => `node ${n}`,
+    );
+    expect(order).toEqual([1, 0]);
+  });
+});

--- a/packages/pg-delta/src/plan/graph.ts
+++ b/packages/pg-delta/src/plan/graph.ts
@@ -82,7 +82,22 @@ export function topoSort(
     indegree[v] = (indegree[v] as number) + 1;
   }
 
-  const heap = new MinHeap(tieKeyOf);
+  // `keyOf` is consulted inside EVERY heap sift comparison, so the heap asks for
+  // O(n log n) keys over only `nodeCount` distinct nodes. The caller's key is a
+  // pure function of the node index (see `actionTieKey` — it reads the fixed
+  // action list, rule resolver, subject-key override and evaluator set), so
+  // memoizing per index is transparent: the heap sees exactly the same keys, and
+  // therefore produces exactly the same order.
+  const tieKeys = new Array<string | undefined>(nodeCount);
+  const memoizedTieKeyOf = (node: number): string => {
+    const cached = tieKeys[node];
+    if (cached !== undefined) return cached;
+    const key = tieKeyOf(node);
+    tieKeys[node] = key;
+    return key;
+  };
+
+  const heap = new MinHeap(memoizedTieKeyOf);
   for (let i = 0; i < nodeCount; i++) if (indegree[i] === 0) heap.push(i);
 
   const order: number[] = [];

--- a/packages/pg-delta/src/plan/graph.ts
+++ b/packages/pg-delta/src/plan/graph.ts
@@ -88,7 +88,7 @@ export function topoSort(
   // action list, rule resolver, subject-key override and evaluator set), so
   // memoizing per index is transparent: the heap sees exactly the same keys, and
   // therefore produces exactly the same order.
-  const tieKeys = new Array<string | undefined>(nodeCount);
+  const tieKeys = Array.from<string | undefined>({ length: nodeCount });
   const memoizedTieKeyOf = (node: number): string => {
     const cached = tieKeys[node];
     if (cached !== undefined) return cached;

--- a/packages/pg-delta/src/plan/internal.test.ts
+++ b/packages/pg-delta/src/plan/internal.test.ts
@@ -384,7 +384,9 @@ describe("elideDefaultAclCreates", () => {
 
     test("without a capability, ANY role's ADP counts → kept", () => {
       expect(
-        publicUsageOnType([{ role: "someone_else", schema: null, objtype: "T" }]),
+        publicUsageOnType([
+          { role: "someone_else", schema: null, objtype: "T" },
+        ]),
       ).toBe(true);
     });
 
@@ -444,9 +446,9 @@ describe("elideDefaultAclCreates", () => {
     });
 
     test("schema-scoped ADP cannot apply to a schema target → elided", () => {
-      expect(ownerAclOnSchema({ role: "test", schema: "s", objtype: "n" })).toBe(
-        false,
-      );
+      expect(
+        ownerAclOnSchema({ role: "test", schema: "s", objtype: "n" }),
+      ).toBe(false);
     });
   });
 });

--- a/packages/pg-delta/src/plan/internal.test.ts
+++ b/packages/pg-delta/src/plan/internal.test.ts
@@ -285,6 +285,170 @@ describe("elideDefaultAclCreates", () => {
       "CREATE TABLE app.t ...",
     ]);
   });
+
+  // The ADP gate is served by a prebuilt objtype index (buildAdpIndex) instead of
+  // rescanning `desired.facts()` per acl-create. These pin every dimension the
+  // old inline predicate discriminated on: objtype, schema (null = cluster-wide
+  // vs schema-scoped), and the defaclrole/capability filter.
+  describe("ADP gate dimensions", () => {
+    type Adp = {
+      role: string;
+      schema: string | null;
+      objtype: string;
+    };
+
+    /** co-created `app.mood` type + its default PUBLIC USAGE grant (elidable on
+     *  its own), plus the ADP under test. */
+    function publicUsageOnType(
+      adps: Adp[],
+      capability?: ApplierCapability,
+    ): boolean {
+      const mood = typeId("mood");
+      const facts: Fact[] = [
+        { id: mood, payload: {} },
+        roleFact("test"),
+        aclFact(mood, "PUBLIC", ["USAGE"]),
+        ...adps.map((a) => ({
+          id: {
+            kind: "defaultPrivilege" as const,
+            role: a.role,
+            schema: a.schema,
+            objtype: a.objtype,
+            grantee: "PUBLIC",
+          },
+          payload: { privileges: [] },
+        })),
+      ];
+      const edges: DependencyEdge[] = [
+        { from: mood, to: roleId("test"), kind: "owner" },
+      ];
+      const actions: Action[] = [
+        mkAction({ sql: "CREATE TYPE app.mood ...", produces: [mood] }),
+        ...aclActions(mood, "PUBLIC"),
+      ];
+      const kept = elideDefaultAclCreates(
+        actions,
+        buildFactBase(facts, edges),
+        capability,
+      );
+      return kept.map((a) => a.sql).includes("GRANT ... TO PUBLIC");
+    }
+
+    test("no ADP at all → elided", () => {
+      expect(publicUsageOnType([])).toBe(false);
+    });
+
+    test("cluster-wide ADP on the same objtype → kept", () => {
+      expect(
+        publicUsageOnType([{ role: "test", schema: null, objtype: "T" }]),
+      ).toBe(true);
+    });
+
+    test("ADP scoped to the target's own schema → kept", () => {
+      expect(
+        publicUsageOnType([{ role: "test", schema: "app", objtype: "T" }]),
+      ).toBe(true);
+    });
+
+    test("ADP scoped to a DIFFERENT schema → elided", () => {
+      expect(
+        publicUsageOnType([{ role: "test", schema: "other", objtype: "T" }]),
+      ).toBe(false);
+    });
+
+    test("ADP on a different objtype → elided", () => {
+      expect(
+        publicUsageOnType([{ role: "test", schema: null, objtype: "r" }]),
+      ).toBe(false);
+    });
+
+    test("mixed ADPs: only the non-matching ones present → elided", () => {
+      expect(
+        publicUsageOnType([
+          { role: "test", schema: "other", objtype: "T" },
+          { role: "test", schema: null, objtype: "r" },
+          { role: "test", schema: "app", objtype: "S" },
+        ]),
+      ).toBe(false);
+    });
+
+    test("mixed ADPs: one matching among many → kept", () => {
+      expect(
+        publicUsageOnType([
+          { role: "test", schema: "other", objtype: "T" },
+          { role: "test", schema: null, objtype: "r" },
+          { role: "test", schema: "app", objtype: "T" },
+        ]),
+      ).toBe(true);
+    });
+
+    test("without a capability, ANY role's ADP counts → kept", () => {
+      expect(
+        publicUsageOnType([{ role: "someone_else", schema: null, objtype: "T" }]),
+      ).toBe(true);
+    });
+
+    test("with a capability, another role's ADP is ignored → elided", () => {
+      expect(
+        publicUsageOnType(
+          [{ role: "someone_else", schema: null, objtype: "T" }],
+          cap("test"),
+        ),
+      ).toBe(false);
+    });
+
+    test("with a capability, the applier's own ADP counts → kept", () => {
+      expect(
+        publicUsageOnType(
+          [{ role: "test", schema: null, objtype: "T" }],
+          cap("test"),
+        ),
+      ).toBe(true);
+    });
+
+    // A SCHEMA target has no schema of its own (targetSchema === null), so a
+    // schema-scoped ADP can never apply to it — only a cluster-wide one can.
+    function ownerAclOnSchema(adp: Adp): boolean {
+      const s = schemaId("s");
+      const ownerDefault = ["CREATE", "USAGE"];
+      const facts: Fact[] = [
+        { id: s, payload: {} },
+        roleFact("test"),
+        aclFact(s, "test", ownerDefault, [], ownerDefault),
+        {
+          id: {
+            kind: "defaultPrivilege" as const,
+            role: adp.role,
+            schema: adp.schema,
+            objtype: adp.objtype,
+            grantee: "test",
+          },
+          payload: { privileges: [] },
+        },
+      ];
+      const actions: Action[] = [
+        mkAction({ sql: `CREATE SCHEMA "s"`, produces: [s] }),
+        ...aclActions(s, "test"),
+      ];
+      const kept = elideDefaultAclCreates(
+        actions,
+        buildFactBase(facts, [{ from: s, to: roleId("test"), kind: "owner" }]),
+      );
+      return kept.map((a) => a.sql).includes("GRANT ... TO test");
+    }
+
+    test("cluster-wide ADP ON SCHEMAS gates a co-created schema → kept", () => {
+      expect(
+        ownerAclOnSchema({ role: "test", schema: null, objtype: "n" }),
+      ).toBe(true);
+    });
+
+    test("schema-scoped ADP cannot apply to a schema target → elided", () => {
+      expect(ownerAclOnSchema({ role: "test", schema: "s", objtype: "n" })).toBe(
+        false,
+      );
+    });
+  });
 });
 
 describe("foldCoCreateOwnership", () => {

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -781,25 +781,59 @@ function samePrivilegeSet(a: readonly string[], b: readonly string[]): boolean {
  * we filter to the applier's role, else (corpus/raw) consider any role's ADP
  * (conservative — at worst we keep a redundant REVOKE/GRANT).
  */
-function adpCustomizesObjtype(
+/**
+ * The `defaultPrivilege` facts of a desired state, folded by `objtype` so
+ * `adpCustomizesObjtype` is an O(1) lookup instead of a full fact scan.
+ * `allSchemas` records an ADP whose `schema` is null (cluster-wide for that
+ * role — matches ANY target schema); `schemas` the schema-scoped ones.
+ */
+type AdpIndex = ReadonlyMap<
+  string,
+  { allSchemas: boolean; schemas: ReadonlySet<string> }
+>;
+
+/** One pass over `desired`, applying the same role filter the predicate did:
+ *  ADP is keyed by the CREATING role, so with a known `capability` only that
+ *  role's ADP counts; without one (corpus/raw) any role's does. */
+function buildAdpIndex(
   desired: FactBase,
-  target: StableId,
   capability: ApplierCapability | undefined,
+): AdpIndex {
+  const index = new Map<
+    string,
+    { allSchemas: boolean; schemas: Set<string> }
+  >();
+  for (const fact of desired.facts()) {
+    if (fact.id.kind !== "defaultPrivilege") continue;
+    const d = fact.id;
+    if (capability !== undefined && d.role !== capability.role) continue;
+    let entry = index.get(d.objtype);
+    if (entry === undefined) {
+      entry = { allSchemas: false, schemas: new Set<string>() };
+      index.set(d.objtype, entry);
+    }
+    if (d.schema === null) entry.allSchemas = true;
+    else entry.schemas.add(d.schema);
+  }
+  return index;
+}
+
+function adpCustomizesObjtype(
+  adp: AdpIndex,
+  target: StableId,
 ): boolean {
   const objtype = ruleFlag(target.kind, "defaclObjtype");
   if (objtype === undefined) return false; // kind has no default-ACL mechanism
+  const entry = adp.get(objtype);
+  if (entry === undefined) return false;
+  if (entry.allSchemas) return true;
   const targetSchema =
     target.kind === "schema"
       ? null
       : ((target as { schema?: string }).schema ?? null);
-  return desired.facts().some((fact) => {
-    if (fact.id.kind !== "defaultPrivilege") return false;
-    const d = fact.id as Extract<StableId, { kind: "defaultPrivilege" }>;
-    if (d.objtype !== objtype) return false;
-    if (d.schema !== null && d.schema !== targetSchema) return false;
-    if (capability !== undefined && d.role !== capability.role) return false;
-    return true;
-  });
+  // a schema-scoped ADP never matches a schema-less target (the old predicate's
+  // `d.schema !== targetSchema` with targetSchema === null).
+  return targetSchema !== null && entry.schemas.has(targetSchema);
 }
 
 /**
@@ -835,6 +869,12 @@ export function elideDefaultAclCreates(
   desired: FactBase,
   capability?: ApplierCapability,
 ): Action[] {
+  // ADP lookup table, built ONCE. The predicate below used to re-scan
+  // `desired.facts()` (a freshly materialized array) per acl-create action,
+  // which is O(aclCreates x facts) — the dominant cost of a from-empty plan on a
+  // large catalog.
+  const adp = buildAdpIndex(desired, capability);
+
   // ids of the objects actually created in this plan (acl satellites excluded).
   const createdObjects = new Set<string>();
   for (const action of actions) {
@@ -870,7 +910,7 @@ export function elideDefaultAclCreates(
     // customizing this objtype breaks that assumption (the effective default
     // differs, and ADP-vs-CREATE order is not guaranteed in a from-empty plan),
     // so the explicit REVOKE/GRANT is load-bearing — keep it (review P2).
-    if (adpCustomizesObjtype(desired, aclId.target, capability)) continue;
+    if (adpCustomizesObjtype(adp, aclId.target)) continue;
 
     if (aclId.grantee === "PUBLIC") {
       const def = PUBLIC_DEFAULT_PRIVILEGE[aclId.target.kind];

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -818,10 +818,7 @@ function buildAdpIndex(
   return index;
 }
 
-function adpCustomizesObjtype(
-  adp: AdpIndex,
-  target: StableId,
-): boolean {
+function adpCustomizesObjtype(adp: AdpIndex, target: StableId): boolean {
   const objtype = ruleFlag(target.kind, "defaclObjtype");
   if (objtype === undefined) return false; // kind has no default-ACL mechanism
   const entry = adp.get(objtype);

--- a/packages/pg-delta/src/plan/phases/change-set.ts
+++ b/packages/pg-delta/src/plan/phases/change-set.ts
@@ -167,25 +167,35 @@ export function buildChangeSet(
       projectionSuppressions.push({ side: "desired", suppression }),
   });
 
-  // Rename proposals come from policy-kept deltas in physical identity space.
-  // This is intentionally a discovery pass: the actual plan is built from a
-  // second diff after accepted role identities have been canonicalized.
-  const discoveryAllDeltas = diff(physicalSource, physicalDesired);
-  const { kept: discoveryDeltas } = options?.policy
-    ? filterDeltas(
-        discoveryAllDeltas,
-        options.policy,
-        physicalSource,
-        physicalDesired,
-      )
-    : { kept: discoveryAllDeltas };
-  const { removed: discoveryRemoved, added: discoveryAdded } =
-    groupDeltas(discoveryDeltas);
-
   const renameMode: RenameMode = options?.renames ?? "off";
   const renameCandidates: RenameCandidate[] = [];
   const discoveredRenames: AcceptedRename[] = [];
   if (renameMode !== "off") {
+    // Rename proposals come from policy-kept deltas in physical identity space.
+    // This is intentionally a discovery pass: the actual plan is built from a
+    // second diff (below) after accepted role identities have been canonicalized.
+    //
+    // Gated on the rename mode because it is pure and its ONLY consumers are in
+    // this block. At `renames: "off"` (the production default) nothing reads
+    // `discoveryRemoved` / `discoveryAdded`, and `diff` / `filterDeltas` /
+    // `groupDeltas` are side-effect-free — they return fresh arrays/maps and
+    // never touch a FactBase, emit a diagnostic or write a suppression (the
+    // projection suppression sink hangs off `reconstructManagedView` above, not
+    // off this diff). So the whole pass was byte-identical duplicate work of the
+    // canonical pass below: with no discovered renames the role-rename map is
+    // empty and `normalizeRoleIdentities` hands the same FactBases straight back.
+    const discoveryAllDeltas = diff(physicalSource, physicalDesired);
+    const { kept: discoveryDeltas } = options?.policy
+      ? filterDeltas(
+          discoveryAllDeltas,
+          options.policy,
+          physicalSource,
+          physicalDesired,
+        )
+      : { kept: discoveryAllDeltas };
+    const { removed: discoveryRemoved, added: discoveryAdded } =
+      groupDeltas(discoveryDeltas);
+
     const candidates = matchRenameCandidates(
       discoveryRemoved,
       discoveryAdded,

--- a/packages/pg-delta/src/plan/plan.guard.test.ts
+++ b/packages/pg-delta/src/plan/plan.guard.test.ts
@@ -36,7 +36,10 @@ const KIND_LITERAL_BASELINE: Readonly<Record<string, number>> = {
   "identity-normalize.ts": 17,
   // 28 → 30: mergeCoTargetGrants (multi-grantee GRANT merge) discriminates acl
   // actions via the isAclId type guard — 2 deliberate literals (type + guard).
-  "internal.ts": 30,
+  // 30 → 29: the ADP gate's `desired.facts()` rescan became a prebuilt objtype
+  // index (buildAdpIndex), dropping the redundant `Extract<StableId, { kind:
+  // "defaultPrivilege" }>` cast — narrowing on the `!==` check suffices.
+  "internal.ts": 29,
   "locks.ts": 18,
   "phases/action-emitter.ts": 10,
   "phases/action-graph.ts": 1,

--- a/packages/pg-delta/src/policy/policy.test.ts
+++ b/packages/pg-delta/src/policy/policy.test.ts
@@ -1439,3 +1439,85 @@ describe("factMatches — partitionOf predicate", () => {
     expect(filtered).toEqual([addChild]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// describe: glob matching is memoized per pattern (perf) without changing
+// semantics. `globToRegex` caches its compiled RegExp; these pin the
+// translation against an uncached oracle and pin repeat-call stability (a
+// cached RegExp carrying /g or /y would advance `lastIndex` between calls).
+// ---------------------------------------------------------------------------
+
+describe("factMatches — glob translation is cache-invariant", () => {
+  /** The pre-cache implementation, kept here as an oracle. */
+  function oracle(pattern: string, value: string): boolean {
+    const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`^${escaped.replace(/\*/g, ".*")}$`).test(value);
+  }
+
+  const values = [
+    "public",
+    "auth",
+    "pg_temp_1",
+    "a.b",
+    "we[ird]",
+    "pa(ren)s",
+    "do$llar",
+    "plus+sign",
+    "que?mark",
+    "back\\slash",
+    "pipe|d",
+    "cur{ly}",
+    "car^et",
+    "star*inname",
+  ];
+  const patterns = [
+    "*",
+    "public",
+    "pub*",
+    "*lic",
+    "*ub*",
+    "a.b",
+    "a*b",
+    "we[ird]",
+    "pa(ren)s",
+    "do$llar",
+    "plus+sign",
+    "que?mark",
+    "back\\slash",
+    "pipe|d",
+    "cur{ly}",
+    "car^et",
+    "",
+    "star*inname",
+    "pg_temp_*",
+  ];
+
+  const schemaId = (name: string): StableId => ({ kind: "schema", name });
+  const fb = makeFactBase(
+    values.map((name) => ({ id: schemaId(name), payload: {} })),
+  );
+
+  test("matches the uncached oracle for every pattern x value pair", () => {
+    let checked = 0;
+    for (const pattern of patterns) {
+      for (const name of values) {
+        const fact = fb.get(schemaId(name))!;
+        expect(factMatches({ name: pattern }, fact, fb)).toBe(
+          oracle(pattern, name),
+        );
+        checked++;
+      }
+    }
+    expect(checked).toBe(patterns.length * values.length);
+  });
+
+  test("repeated evaluation of the same pattern is stable", () => {
+    const fact = fb.get(schemaId("public"))!;
+    for (const pattern of ["*", "pub*", "*lic", "nomatch*"]) {
+      const first = factMatches({ name: pattern }, fact, fb);
+      for (let i = 0; i < 5; i++) {
+        expect(factMatches({ name: pattern }, fact, fb)).toBe(first);
+      }
+    }
+  });
+});

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -315,14 +315,38 @@ export interface Policy {
 // Glob helpers (no regex library; implement ourselves)
 // ---------------------------------------------------------------------------
 
+/**
+ * Compiled-glob cache. The scope scan (`resolveView` → `factScopeExclusion`)
+ * evaluates every policy rule's matchers against every fact, so a 20k-fact
+ * catalog drives hundreds of thousands of `globMatch` calls per plan — but only
+ * over the handful of DISTINCT patterns the policy's rules spell out. Compiling
+ * the RegExp once per pattern instead of once per call is the whole win; the
+ * translation is a pure function of the pattern string, so the cache cannot
+ * change a result.
+ *
+ * Capped so a pathological caller (a policy synthesized from untrusted input,
+ * one rule per object) cannot grow it without bound: past the cap we simply
+ * stop memoizing and compile per call — the pre-cache behavior.
+ */
+const GLOB_REGEX_CACHE_MAX = 4096;
+const globRegexCache = new Map<string, RegExp>();
+
 /** Escape all regex meta-characters except `*`, then replace `*` with `.*`. */
 function globToRegex(pattern: string): RegExp {
+  const cached = globRegexCache.get(pattern);
+  if (cached !== undefined) return cached;
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
   const regexSource = escaped.replace(/\*/g, ".*");
-  return new RegExp(`^${regexSource}$`);
+  const compiled = new RegExp(`^${regexSource}$`);
+  if (globRegexCache.size < GLOB_REGEX_CACHE_MAX) {
+    globRegexCache.set(pattern, compiled);
+  }
+  return compiled;
 }
 
 function globMatch(pattern: string, value: string): boolean {
+  // `test` on a cached RegExp is only stateful for /g//y regexes; globToRegex
+  // never sets either flag, so lastIndex never advances and reuse is safe.
   return globToRegex(pattern).test(value);
 }
 

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -72,7 +72,9 @@ import { encodeId } from "../core/stable-id.ts";
 import { KNOWN_PARAMS, type PlanParams } from "../plan/rules.ts";
 import { subtractBaseline } from "./baseline.ts";
 import {
+  buildExclusion,
   collectRemovedSuppressions,
+  computeExclusion,
   excludeFactsAndDescendants,
   extensionMemberClosure,
   type ProjectionAuditClassification,
@@ -1203,8 +1205,37 @@ export function resolveView(
       policyRootAttribution.set(encodeId(fact.id), attribution);
     }
   }
-  const pruned = excludeFactsAndDescendants(base, hardRoots);
+  // The hard exclusion and the reference-only marks are ONE rebuild, not two.
+  // Both used to call `buildFactBase` over the same ~20k surviving facts (the
+  // exclusion built an intermediate that the reference-only pass then rebuilt
+  // verbatim, changing only the `referenceOnly` set), so a plan paid four full
+  // catalog re-indexes across its two sides. `computeExclusion` does the pruning
+  // walk without building; `pruned` below is materialized exactly once, with the
+  // final reference-only set already attached.
+  //
+  // Merge the reference-only sets (extension members + assumed-schema), keeping
+  // only facts that actually survived pruning. This is the SINGLE projection
+  // point for the managed view; `referenceOnly` is per-side deterministic (no
+  // cross-side dependency → fingerprint/proof stay consistent).
+  const exclusion = computeExclusion(base, hardRoots);
+  const surviving = exclusion.survives;
+  const referenceOnly = new Set<string>();
+  for (const key of memberRefOnly)
+    if (surviving.has(key)) referenceOnly.add(key);
+  for (const key of policyRefOnly)
+    if (surviving.has(key)) referenceOnly.add(key);
+  // Nothing to mark → this is plain `excludeFactsAndDescendants(base, hardRoots)`,
+  // including its by-reference no-op for an empty root set.
+  const pruned =
+    referenceOnly.size === 0
+      ? hardRoots.size === 0
+        ? base
+        : buildExclusion(base, exclusion)
+      : buildExclusion(base, exclusion, referenceOnly);
   if (collectSuppression !== undefined && hardRoots.size > 0) {
+    // `collectRemovedSuppressions` reads only `after.has()` / `after.edges`, both
+    // identical between the old intermediate and `pruned` (same facts, same
+    // edges — only `referenceOnly` differs), so the records are unchanged.
     collectRemovedSuppressions(
       base,
       pruned,
@@ -1212,18 +1243,6 @@ export function resolveView(
       collectSuppression,
     );
   }
-
-  // Merge the reference-only sets (extension members + assumed-schema), keeping
-  // only facts that actually survived pruning. This is the SINGLE projection
-  // point for the managed view; `referenceOnly` is per-side deterministic (no
-  // cross-side dependency → fingerprint/proof stay consistent).
-  if (memberRefOnly.size === 0 && policyRefOnly.size === 0) return pruned;
-  const surviving = new Set(pruned.facts().map((f) => encodeId(f.id)));
-  const referenceOnly = new Set<string>();
-  for (const key of memberRefOnly)
-    if (surviving.has(key)) referenceOnly.add(key);
-  for (const key of policyRefOnly)
-    if (surviving.has(key)) referenceOnly.add(key);
   if (referenceOnly.size === 0) return pruned;
   if (collectSuppression !== undefined) {
     const recordReferenceOnly = (
@@ -1282,20 +1301,15 @@ export function resolveView(
       });
     }
   }
-  // Rebuild to attach the reference-only marks. This runs whenever the view has
-  // extension members / assumed-schema facts — including when `resolveView` is
-  // re-invoked (via `plan()`) on an ALREADY scope-projected view (the export
-  // path), which carries retained dangling owner→role edges. Propagate the
-  // ownership carve-out so the rebuild does not silently re-prune them (a
-  // public-only, extension-free view returns early above and never reaches here,
-  // which is why the regression hid until an extension forced this rebuild).
-  return buildFactBase(
-    pruned.facts(),
-    [...pruned.edges],
-    pruned.source,
-    referenceOnly,
-    { allowDangling: retainOwnerRoleDangling },
-  );
+  // `pruned` was already built WITH the reference-only marks attached above. This
+  // runs whenever the view has extension members / assumed-schema facts —
+  // including when `resolveView` is re-invoked (via `plan()`) on an ALREADY
+  // scope-projected view (the export path), which carries retained dangling
+  // owner→role edges. `buildExclusion` propagates the ownership carve-out
+  // (`allowDangling: retainOwnerRoleDangling`) so those edges are not silently
+  // re-pruned (a public-only, extension-free view returns early above, which is
+  // why that regression hid until an extension forced the rebuild).
+  return pruned;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -66,7 +66,6 @@
 import type { Delta } from "../core/diff.ts";
 import type { DependencyEdge, EdgeKind, Fact, FactBase } from "../core/fact.ts";
 import { contentHash, type PayloadValue } from "../core/hash.ts";
-import { buildFactBase, retainOwnerRoleDangling } from "../core/fact.ts";
 import type { FactKind, StableId } from "../core/stable-id.ts";
 import { encodeId } from "../core/stable-id.ts";
 import { KNOWN_PARAMS, type PlanParams } from "../plan/rules.ts";

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -1216,6 +1216,19 @@ export function resolveView(
   // only facts that actually survived pruning. This is the SINGLE projection
   // point for the managed view; `referenceOnly` is per-side deterministic (no
   // cross-side dependency → fingerprint/proof stay consistent).
+  // Nothing to prune AND nothing to mark → the projection is the identity, as it
+  // was when `excludeFactsAndDescendants` short-circuited an empty root set and
+  // the reference-only rebuild was skipped. Keep that free path free: without it
+  // `computeExclusion` would walk every fact and filter every edge to prove it
+  // has nothing to do.
+  if (
+    hardRoots.size === 0 &&
+    memberRefOnly.size === 0 &&
+    policyRefOnly.size === 0
+  ) {
+    return base;
+  }
+
   const exclusion = computeExclusion(base, hardRoots);
   const surviving = exclusion.survives;
   const referenceOnly = new Set<string>();

--- a/packages/pg-delta/src/policy/view.ts
+++ b/packages/pg-delta/src/policy/view.ts
@@ -177,16 +177,29 @@ function resolveRemoval(
 }
 
 /**
- * Return a new FactBase with `rootIds` and their entire descendant subtrees
- * removed; edges with a removed endpoint are pruned. If `rootIds` is empty, `fb`
- * is returned unchanged (referential identity preserved for cheap no-ops).
+ * The exclusion of `rootIds` and their descendant subtrees, COMPUTED but not yet
+ * built into a FactBase.
+ *
+ * Split out so `resolveView` — which has to attach ADDITIONAL reference-only
+ * marks on top of this projection — can do the whole thing in ONE
+ * `buildFactBase` instead of building an intermediate it immediately discards.
+ * Indexing a ~20k-fact catalog is ~30ms, and resolveView runs per side per plan.
  */
-export function excludeFactsAndDescendants(
+export interface ComputedExclusion {
+  keptFacts: Fact[];
+  keptEdges: DependencyEdge[];
+  /** Encoded ids that survived the exclusion. */
+  survives: ReadonlySet<string>;
+  /** `fb.referenceOnly` carried forward, restricted to survivors. */
+  referenceOnly: Set<string>;
+}
+
+/** Compute (without building) the exclusion of `rootIds` + descendants. An empty
+ *  `rootIds` keeps every fact and every edge — the identity projection. */
+export function computeExclusion(
   fb: FactBase,
   rootIds: ReadonlySet<string>,
-): FactBase {
-  if (rootIds.size === 0) return fb;
-
+): ComputedExclusion {
   const removed = new Set<string>();
   const kept = new Set<string>();
   const keptFacts: Fact[] = fb
@@ -215,9 +228,36 @@ export function excludeFactsAndDescendants(
   const referenceOnly = new Set(
     [...fb.referenceOnly].filter((key) => survives.has(key)),
   );
-  return buildFactBase(keptFacts, keptEdges, fb.source, referenceOnly, {
-    allowDangling: retainOwnerRoleDangling,
-  });
+  return { keptFacts, keptEdges, survives, referenceOnly };
+}
+
+/** Build a `ComputedExclusion` into a FactBase, optionally REPLACING the
+ *  carried-forward reference-only set (resolveView's merged marks). */
+export function buildExclusion(
+  fb: FactBase,
+  exclusion: ComputedExclusion,
+  referenceOnly: ReadonlySet<string> = exclusion.referenceOnly,
+): FactBase {
+  return buildFactBase(
+    exclusion.keptFacts,
+    exclusion.keptEdges,
+    fb.source,
+    referenceOnly,
+    { allowDangling: retainOwnerRoleDangling },
+  );
+}
+
+/**
+ * Return a new FactBase with `rootIds` and their entire descendant subtrees
+ * removed; edges with a removed endpoint are pruned. If `rootIds` is empty, `fb`
+ * is returned unchanged (referential identity preserved for cheap no-ops).
+ */
+export function excludeFactsAndDescendants(
+  fb: FactBase,
+  rootIds: ReadonlySet<string>,
+): FactBase {
+  if (rootIds.size === 0) return fb;
+  return buildExclusion(fb, computeExclusion(fb, rootIds));
 }
 
 /** Management scope of a declarative apply (target-architecture §scope). */


### PR DESCRIPTION
## What

Six mechanical performance fixes to `plan()`, found by CPU-profiling a 21.9k-fact catalog diff (profiling session documented on #402). Planner output is byte-identical — each fix is a cache, an index, or the removal of provably duplicate work; no behavioral change.

| Fix | Commit | Change |
|---|---|---|
| Glob→RegExp cache | `578377d8` | `globToRegex` compiled a fresh RegExp per call — ~613k compiles per plan via the policy scope scan; now a capped module-level cache |
| Stable-id encode memo | `5414453f` (hardened: `cb9d2cc3`, `458ab336`) | FactBase lookups re-encoded ids per call; now a registration-only WeakMap — see "Review hardening" below |
| Default-ACL index | `5aa67571` | `adpCustomizesObjtype` rescanned all 21.9k facts per ACL-create action (O(aclCreates × facts)); replaced with a prebuilt objtype index |
| Topo-sort tie-key memo | `418d3931` | `actionTieKey` was recomputed inside every heap sift (O(n log n) recomputes); keys precomputed per node |
| Skip duplicate discovery diff | `032c1ccc` | with `renames: "off"` (the production default) the discovery diff pass is byte-identical to the canonical pass; now gated on rename mode (no-consumers verification in the commit body) |
| Single projection rebuild | `cf5ffb0c`+`467b642c` | `resolveView` built the FactBase twice; exclusion computation split so it builds once (identity short-circuit preserved) |

## Measured (remote 21.9k-fact fixture FactBases, production plan options, p50 of 12 reps, at final HEAD `458ab336`)

| Cell | main | This PR | Δ |
|---|---|---|---|
| Supabase profile, tiny delta (3 actions) | 603.9 ms | **277.6 ms** | **−54%** |
| Supabase profile, empty→large (10,534 actions) | 2455.3 ms | **506.7 ms** | **−79%** |
| Raw profile, tiny delta | 247.9 ms | **175.1 ms** | −29% |

Rendered plan SQL sha256-identical to main in all three cells (3 actions / 501 B, 10,534 actions / 1,875,611 B, 7 actions / 915 B).

## Review hardening (the encode memo's final shape)

Two review rounds correctly flagged that an object-identity cache must not be observable through public APIs whose inputs are structurally mutable. Final design:

- Public `encodeId` is pure/unmemoized (mutate-and-re-encode returns the fresh encoding; 3 regression tests).
- The WeakMap is **registration-only**: `buildFactBase`'s indexing pass is the sole writer (engine-owned, never-mutated ids — the same invariant `payloadHashes` relies on); all public FactBase lookups are read-only against the cache and pure-encode anything unregistered, so caller-provided query objects can never go stale (7 lookup-purity tests + a cross-FactBase hit test).
- Measured memo hit rate on the fixture plan: 100.0% (227,400 hits / 8 misses) — the safety redesign cost ≈0 (277.6 vs 272.5 ms).
- Both memo functions are internal-only (absent from all export barrels/subpaths; single calling module for the writer, grep-verified).

## Verification

- Unit suite: **1065/1065** (base 1032 + 33 new tests: glob oracle matrix, O(n²) reference sort over shuffled DAGs — RED-first, mutation-checked ACL-index matrix, encode purity + lookup purity suites).
- **Full corpus** (PG 17): 662/662, run twice — mandatory gate for planner changes.
- `check-types` / `format-and-lint` clean; knip clean for pg-delta.
- Changeset: patch.

## Notes

- Known remaining headroom (deliberately not attempted — design change, not a cache): the projection stages (baseline subtraction, managedBy, capability) each rebuild the FactBase; a fused single-pass projection would save more. Noted in `cf5ffb0c`'s body.
- Latent pre-existing observation (unchanged by this PR): `resolveView`'s reference-only rebuild re-derives rather than carries forward `fb.referenceOnly`; idempotent today because all current marks re-derive from edges/rules.
- Independent of #402 (extraction); no file overlap besides `.changeset/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
