### PR TITLE
fix(pg-delta): exempt platform-provisioned assumed-schema members from the requirement guard

### DIFF
--- a/.changeset/tidy-moons-repair.md
+++ b/.changeset/tidy-moons-repair.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix the planner's missing-requirement guard rejecting DB-webhook triggers (`CREATE TRIGGER … EXECUTE FUNCTION supabase_functions.http_request(...)`) when the target database has never had the webhooks infrastructure provisioned. A platform-provisioned member of an assumed schema — an object owned by a policy-declared assumed role other than the default owner, such as `supabase_functions.http_request()` (owned by `supabase_functions_admin`) — is now treated as present at apply time by the same platform guarantee that makes its schema assumed. User-created objects in assumed schemas (owned by the default owner or a user role) still fail fast at plan time when the target lacks them.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -856,3 +856,33 @@ excluded from provenance; descendant closure). One is **deferred by design**:
   kinds already have. Revisit only alongside the committed Supabase baseline
   (docs/roadmap/backlog.md), which is the mechanism that could seed platform
   objects into proof clones for all assumed kinds at once.
+
+Round-4 findings (loop capped here per the automated-review policy — both are
+contract re-litigation of the provenance heuristic under hypothetical setups,
+not defects reachable on the shipped policy):
+
+- **Deferred — explicit platform-owner designation instead of
+  `assumedRoles \ {policy.defaultOwner}` (Codex P1, round 4).** The heuristic
+  treats a policy-assumed role other than the policy's own declared default
+  owner as a platform object owner within assumed schemas. For the shipped
+  Supabase policy this is exact (`assumedRoles` = SUPABASE_SYSTEM_ROLES +
+  `postgres`, `defaultOwner: postgres`). A CUSTOM policy that added a user
+  role to `assumedRoles` would widen the exemption to that role's objects in
+  assumed schemas. No shipped or known custom policy does this; the clean fix
+  is a new `Policy` field (e.g. `platformObjectOwners`) — an API addition
+  disproportionate to this bug fix. Revisit when a custom-policy consumer
+  actually declares assumed user roles.
+
+- **Refuted for the shipped policy — descendant closure covering "user-added"
+  children of platform tables (Codex P1, round 4).** The claimed
+  counterexample (a user-added `auth.users.custom_flag` column) is not
+  creatable on Supabase: `ADD COLUMN` / `CREATE INDEX` / `ADD CONSTRAINT` /
+  `CREATE POLICY` all require table OWNERSHIP, which the user's `postgres`
+  lacks on system-role-owned tables. The one user-creatable child — a trigger,
+  via the grantable TRIGGER privilege — is deliberately MANAGED (policy
+  include rule 3), so the plan PRODUCES it and the requirement guard never
+  consults the exemption for it. Desired-only FILTERED descendants of a
+  platform root can therefore only be platform-made (image upgrade), which is
+  exactly what the exemption must cover. Revisit together with the explicit
+  platform-owner designation above if any platform grants users DDL on
+  platform-owned relations.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -831,3 +831,28 @@ oversized key past its advertised total-length budget. One further finding is
   exactly this divergence, so the failure is pre-announced. Revisit if a real
   profile hits it.
 
+
+## PR #407 review triage (Codex) — platform-provisioned assumed-schema members
+
+Context: PR #407 exempts platform-provisioned members of assumed schemas
+(system-role-owned, e.g. `supabase_functions.http_request()`) from the
+action-graph missing-requirement guard, so a DB-webhook trigger plans against
+a target that has never had webhooks provisioned (Sentry SUPABASE-API-8CX).
+Two round-2 findings were fixed in the PR (run-level `defaultOwner` override
+excluded from provenance; descendant closure). One is **deferred by design**:
+
+- **Deferred — the plan neither creates the platform object nor proves against
+  a target that lacks it ("materialize the dependency before bypassing the
+  guard", Codex P1).** Deliberate: the policy's managed view EXCLUDES platform
+  objects — a user plan must never `CREATE SCHEMA supabase_functions` /
+  `CREATE FUNCTION … http_request` (it may lack the privileges and would claim
+  platform state as user state). "Assumed present" is the same contract as
+  `assumedRoles`/`assumedSchemas`: a plan with `GRANT … TO anon` or
+  `CREATE EXTENSION … SCHEMA extensions` equally fails on a target where the
+  platform never provisioned those; the platform (mgmt-api / Supabase image
+  migrations) owns provisioning, outside the plan. Consequence, accepted: an
+  `apply()`/`provePlan()` run against a bare clone that lacks the webhooks
+  infra fails at the CREATE TRIGGER — the same failure mode the other assumed
+  kinds already have. Revisit only alongside the committed Supabase baseline
+  (docs/roadmap/backlog.md), which is the mechanism that could seed platform
+  objects into proof clones for all assumed kinds at once.

--- a/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
+++ b/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
@@ -263,6 +263,52 @@ describe("plan() — platform-provisioned members of assumed schemas", () => {
     expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(true);
   });
 
+  test("a desired-only descendant of a platform root present in BOTH states is still exempt", () => {
+    // The descendant walk must not share its visited set across the two raw
+    // fact bases: when the platform root (`supabase_functions.hooks`) exists on
+    // both sides, the source pass records the root first — the desired pass
+    // must still traverse the root's DESIRED-ONLY children (a new platform
+    // column shipped by a newer image), or a dependent on that column throws
+    // (Codex P2 round 3 on PR #407).
+    const hooks: StableId = {
+      kind: "table",
+      schema: "supabase_functions",
+      name: "hooks",
+    };
+    const newCol: StableId = {
+      kind: "column",
+      schema: "supabase_functions",
+      table: "hooks",
+      name: "added_in_new_image",
+    };
+    const owner: StableId = { kind: "role", name: "supabase_functions_admin" };
+    const platformFacts = (withNewCol: boolean) => [
+      f(publicSchema),
+      f(table, publicSchema, { persistence: "p" }),
+      f(owner),
+      f(functionsSchema),
+      f(hooks, functionsSchema, { persistence: "p" }),
+      ...(withNewCol
+        ? [f(newCol, hooks, { type: "bigint", notNull: false })]
+        : []),
+    ];
+    const source = buildFactBase(platformFacts(false), [
+      { from: hooks, to: owner, kind: "owner" },
+    ]);
+    const desired = buildFactBase(
+      [
+        ...platformFacts(true),
+        f(trigger, table, { def: triggerDef, enabled: "O" }),
+      ],
+      [
+        { from: hooks, to: owner, kind: "owner" },
+        { from: trigger, to: newCol, kind: "depends" },
+      ],
+    );
+    const p = plan(source, desired, { policy: supabasePolicy });
+    expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(true);
+  });
+
   test("supplemental options.assumedRoles (target roles under database scope) do not widen the exemption", () => {
     // The database-scoped schema-apply frontend passes EVERY role found on the
     // target through options.assumedRoles (schema-plan.ts) so grants/ownership

--- a/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
+++ b/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
@@ -19,8 +19,9 @@
 import { describe, expect, test } from "bun:test";
 import { buildFactBase, type Fact } from "../core/fact.ts";
 import type { StableId } from "../core/stable-id.ts";
+import { supabasePolicy } from "../policy/supabase.ts";
 import { buildActionGraph } from "./internal.ts";
-import type { Action } from "./plan.ts";
+import { type Action, plan } from "./plan.ts";
 
 const authUsers: StableId = { kind: "table", schema: "auth", name: "users" };
 
@@ -94,5 +95,109 @@ describe("missing-requirement guard: objects within assumed schemas", () => {
     const source = buildFactBase([], []);
     const desired = buildFactBase([], []);
     expect(() => run(source, desired, new Set(["auth"]))).not.toThrow();
+  });
+});
+
+// The Sentry SUPABASE-API-8CX regression: a DB-webhook trigger (`CREATE TRIGGER
+// … EXECUTE FUNCTION supabase_functions.http_request(...)`) depends on a
+// PLATFORM-provisioned member of an assumed schema. The desired side keeps the
+// function reference-only, and a target that has never had webhooks enabled
+// lacks it — but the platform provisions it, so the requirement guard must not
+// refuse the plan. The discriminator from the `auth.extra` fail-fast above is
+// OWNERSHIP: `http_request()` is owned by `supabase_functions_admin` (an
+// assumed system role), while a user-created object in an assumed schema is
+// owned by the default owner (`postgres`) or a user role.
+describe("plan() — platform-provisioned members of assumed schemas", () => {
+  const publicSchema: StableId = { kind: "schema", name: "public" };
+  const table: StableId = {
+    kind: "table",
+    schema: "public",
+    name: "deliverable",
+  };
+  const trigger: StableId = {
+    kind: "trigger",
+    schema: "public",
+    table: "deliverable",
+    name: "crud_sync",
+  };
+  const functionsSchema: StableId = {
+    kind: "schema",
+    name: "supabase_functions",
+  };
+  const httpRequest: StableId = {
+    kind: "function",
+    schema: "supabase_functions",
+    name: "http_request",
+    args: [],
+  };
+
+  const f = (
+    id: StableId,
+    parent?: StableId,
+    payload: Fact["payload"] = {},
+  ): Fact => (parent ? { id, parent, payload } : { id, payload });
+
+  const triggerDef =
+    "CREATE TRIGGER crud_sync AFTER INSERT ON public.deliverable FOR EACH ROW EXECUTE FUNCTION supabase_functions.http_request('https://example.com', 'POST')";
+
+  /** source: the table exists, webhooks were never provisioned. */
+  function sourceBase(): ReturnType<typeof buildFactBase> {
+    return buildFactBase(
+      [f(publicSchema), f(table, publicSchema, { persistence: "p" })],
+      [],
+    );
+  }
+
+  /** desired: the same table plus the webhook trigger, with the platform's
+   *  `supabase_functions` schema + `http_request()` present (reference-only
+   *  once the policy filters them) and the function owned by `ownerRole`. */
+  function desiredBase(ownerRole: string): ReturnType<typeof buildFactBase> {
+    const owner: StableId = { kind: "role", name: ownerRole };
+    return buildFactBase(
+      [
+        f(publicSchema),
+        f(table, publicSchema, { persistence: "p" }),
+        f(trigger, table, { def: triggerDef, enabled: "O" }),
+        f(owner),
+        f(functionsSchema),
+        f(httpRequest, functionsSchema, { kind: "f" }),
+      ],
+      [
+        { from: trigger, to: httpRequest, kind: "depends" },
+        { from: httpRequest, to: owner, kind: "owner" },
+      ],
+    );
+  }
+
+  test("a webhook trigger depending on a system-role-owned assumed-schema function plans (target lacks webhooks)", () => {
+    // RED before the fix: missing requirement — "depends on
+    // function:supabase_functions.http_request() … (a filter may be hiding its
+    // creation)". The platform guarantee that makes `supabase_functions`
+    // assumed extends to its system-owned members.
+    const p = plan(sourceBase(), desiredBase("supabase_functions_admin"), {
+      policy: supabasePolicy,
+    });
+    expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(true);
+    // the reference-only platform function is never created by the plan
+    expect(p.actions.some((a) => /http_request/i.test(a.sql) && /CREATE (OR REPLACE )?FUNCTION/i.test(a.sql))).toBe(false);
+  });
+
+  test("the fail-fast is preserved when the assumed-schema dependency is owned by the default owner", () => {
+    // A default-owner-owned (i.e. user-created) object in an assumed schema
+    // absent from the target still fails at plan time (PR #307 review P2) —
+    // nothing will provision it at apply time.
+    expect(() =>
+      plan(sourceBase(), desiredBase("postgres"), {
+        policy: supabasePolicy,
+      }),
+    ).toThrow(/missing requirement/);
+  });
+
+  test("the fail-fast is preserved when the assumed-schema dependency is owned by a user role", () => {
+    expect(() =>
+      plan(sourceBase(), desiredBase("app_admin"), {
+        policy: supabasePolicy,
+      }),
+    ).toThrow(/missing requirement/);
   });
 });

--- a/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
+++ b/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
@@ -13,8 +13,13 @@
  *    true → satisfied (the in-schema exemption never even runs);
  *  - external to the managed view (e.g. an extension member, hard-pruned from
  *    both sides) → not in `desired` → ambient, satisfied;
- *  - kept in `desired` (reference-only) but absent from `source` → the desired
- *    side wants something the target lacks → NOT exempt → throws.
+ *  - PLATFORM-PROVISIONED (owned by an assumed system role — `assumedPresentIds`,
+ *    computed by plan() from the raw owner edges) → ambient, satisfied even when
+ *    kept in `desired` and absent from `source` (e.g. Supabase's
+ *    `supabase_functions.http_request()`, Sentry SUPABASE-API-8CX);
+ *  - otherwise kept in `desired` (reference-only) but absent from `source` → the
+ *    desired side wants something the target lacks and nothing will provision →
+ *    NOT exempt → throws.
  */
 import { describe, expect, test } from "bun:test";
 import { buildFactBase, type Fact } from "../core/fact.ts";
@@ -179,7 +184,13 @@ describe("plan() — platform-provisioned members of assumed schemas", () => {
     });
     expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(true);
     // the reference-only platform function is never created by the plan
-    expect(p.actions.some((a) => /http_request/i.test(a.sql) && /CREATE (OR REPLACE )?FUNCTION/i.test(a.sql))).toBe(false);
+    expect(
+      p.actions.some(
+        (a) =>
+          /http_request/i.test(a.sql) &&
+          /CREATE (OR REPLACE )?FUNCTION/i.test(a.sql),
+      ),
+    ).toBe(false);
   });
 
   test("the fail-fast is preserved when the assumed-schema dependency is owned by the default owner", () => {

--- a/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
+++ b/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
@@ -212,6 +212,57 @@ describe("plan() — platform-provisioned members of assumed schemas", () => {
     ).toThrow(/missing requirement/);
   });
 
+  test("a custom options.defaultOwner does not turn default-owner-owned objects into platform ones", () => {
+    // A database-scope run may override the default owner (`--default-owner`).
+    // The PROVENANCE judgment must stay the policy's own: `postgres` is the
+    // supabase policy's declared default owner, so a postgres-owned object in
+    // an assumed schema is user-created no matter what the run-level default
+    // owner is — nothing will provision it (Codex P1 #2 on PR #407).
+    expect(() =>
+      plan(sourceBase(), desiredBase("postgres"), {
+        policy: supabasePolicy,
+        scope: "database",
+        defaultOwner: "custom_owner",
+      }),
+    ).toThrow(/missing requirement/);
+  });
+
+  test("the exemption covers descendants of a platform-provisioned object", () => {
+    // Extraction resolves relation subobjects to COLUMN ids, so a dependent's
+    // depends edge can point at a column of a system-role-owned table. The
+    // platform guarantee covers the whole subtree, not just the owner-bearing
+    // root (Codex P2 on PR #407).
+    const hooks: StableId = {
+      kind: "table",
+      schema: "supabase_functions",
+      name: "hooks",
+    };
+    const hooksCol: StableId = {
+      kind: "column",
+      schema: "supabase_functions",
+      table: "hooks",
+      name: "request_id",
+    };
+    const owner: StableId = { kind: "role", name: "supabase_functions_admin" };
+    const desired = buildFactBase(
+      [
+        f(publicSchema),
+        f(table, publicSchema, { persistence: "p" }),
+        f(trigger, table, { def: triggerDef, enabled: "O" }),
+        f(owner),
+        f(functionsSchema),
+        f(hooks, functionsSchema, { persistence: "p" }),
+        f(hooksCol, hooks, { type: "bigint", notNull: false }),
+      ],
+      [
+        { from: trigger, to: hooksCol, kind: "depends" },
+        { from: hooks, to: owner, kind: "owner" },
+      ],
+    );
+    const p = plan(sourceBase(), desired, { policy: supabasePolicy });
+    expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(true);
+  });
+
   test("supplemental options.assumedRoles (target roles under database scope) do not widen the exemption", () => {
     // The database-scoped schema-apply frontend passes EVERY role found on the
     // target through options.assumedRoles (schema-plan.ts) so grants/ownership

--- a/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
+++ b/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
@@ -211,4 +211,19 @@ describe("plan() — platform-provisioned members of assumed schemas", () => {
       }),
     ).toThrow(/missing requirement/);
   });
+
+  test("supplemental options.assumedRoles (target roles under database scope) do not widen the exemption", () => {
+    // The database-scoped schema-apply frontend passes EVERY role found on the
+    // target through options.assumedRoles (schema-plan.ts) so grants/ownership
+    // against filtered role objects resolve. That supplemental set must not
+    // feed the platform-provisioned discriminator: an assumed-schema object
+    // owned by a pre-existing USER role is still user-created, and nothing
+    // will provision it on the target (Codex P1 on PR #407).
+    expect(() =>
+      plan(sourceBase(), desiredBase("app_admin"), {
+        policy: supabasePolicy,
+        assumedRoles: ["app_admin"],
+      }),
+    ).toThrow(/missing requirement/);
+  });
 });

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -70,6 +70,17 @@ export function buildActionGraph(
   // `CREATE EXTENSION … SCHEMA <schema>` whose schema object is filtered out of
   // the view is a valid dependency target, not a stranded reference.
   assumedSchemaNames: ReadonlySet<string> = new Set(),
+  // encoded ids of PLATFORM-PROVISIONED members of assumed schemas — objects
+  // owned (in the raw extract, before the owner edge to the policy-excluded
+  // role is pruned) by an assumed role other than the resolved default owner,
+  // e.g. Supabase's `supabase_functions.http_request()` (the DB-webhook trigger
+  // function, owned by `supabase_functions_admin`). The platform guarantee that
+  // makes their schema assumed extends to them, so a kept dependent (a user
+  // webhook trigger) is valid even when the target lacks the object — unlike a
+  // USER-created object in an assumed schema, which stays a plan-time failure
+  // (see `isAmbient`). Computed by plan() (plan.ts); affects ONLY whether the
+  // missing-requirement guard fires, never ordering/edges.
+  assumedPresentIds: ReadonlySet<string> = new Set(),
   // OUT-param (optional): collects the indices of EVALUATOR actions — actions
   // that make PostgreSQL RUN a user expression while the statement applies.
   //
@@ -210,12 +221,19 @@ export function buildActionGraph(
     }
     const schema = (id as { schema?: string }).schema;
     if (schema === undefined || !assumedSchemaNames.has(schema)) return false;
-    // An object in an assumed schema is ambient only when it is genuinely
+    // A PLATFORM-PROVISIONED member of an assumed schema (system-role-owned,
+    // e.g. `supabase_functions.http_request()`) is present at apply time by the
+    // same guarantee that makes its schema assumed — even when the desired view
+    // keeps it reference-only and the target lacks it (the platform provisions
+    // webhooks infra outside the plan). See the parameter doc above.
+    if (assumedPresentIds.has(encodeId(id))) return true;
+    // Any OTHER object in an assumed schema is ambient only when it is genuinely
     // external to the managed view (e.g. an extension member, hard-pruned from
     // both sides). If the DESIRED view KEEPS it (reference-only) yet it is absent
     // from the target (`!source.has`, checked by the caller), the desired side is
-    // referencing something the target lacks — fail at plan time instead of
-    // exempting it and letting apply fail against a missing relation (review P2).
+    // referencing something the target lacks — a user-created object nothing will
+    // provision — so fail at plan time instead of exempting it and letting apply
+    // fail against a missing relation (review P2).
     return !desired.has(id);
   };
 

--- a/packages/pg-delta/src/plan/phases/action-graph.ts
+++ b/packages/pg-delta/src/plan/phases/action-graph.ts
@@ -47,6 +47,12 @@ export interface FinalizeInput {
    *  `extensions`) — exempt from the missing-requirement guard like the assumed
    *  roles. Empty under the raw/no-policy path. */
   assumedSchemaNames: ReadonlySet<string>;
+  /** encoded ids of platform-provisioned members of assumed schemas (system-
+   *  role-owned, e.g. `supabase_functions.http_request()`) — exempt from the
+   *  missing-requirement guard even when kept reference-only on the desired
+   *  side and absent from the target. Computed by plan() from the RAW fact
+   *  bases; empty under the raw/no-policy path. */
+  assumedPresentIds: ReadonlySet<string>;
   /** applier capability (move 6) — needed by the co-create compaction passes:
    *  the owner-ALTER no-op elision and the REVOKE-before-GRANT superset guard key
    *  off `capability.role`. Undefined under the unrestricted (superuser/CI/raw)
@@ -86,6 +92,7 @@ export function finalizeActions(input: FinalizeInput): FinalizeOutput {
     acceptsFolds,
     assumedRoleNames,
     assumedSchemaNames,
+    assumedPresentIds,
     capability,
     compact,
     foldConstraints,
@@ -108,6 +115,7 @@ export function finalizeActions(input: FinalizeInput): FinalizeOutput {
     renameActionIndices,
     assumedRoleNames,
     assumedSchemaNames,
+    assumedPresentIds,
     evaluatorActions,
   );
 

--- a/packages/pg-delta/src/plan/plan.guard.test.ts
+++ b/packages/pg-delta/src/plan/plan.guard.test.ts
@@ -45,7 +45,10 @@ const KIND_LITERAL_BASELINE: Readonly<Record<string, number>> = {
   "phases/action-graph.ts": 1,
   "phases/change-set.ts": 4,
   "phases/replacement-expansion.ts": 0,
-  "plan.ts": 7,
+  // 7 → 8: the platform-provisioned assumed-schema-member scan discriminates
+  // owner edges to role facts in the RAW extracts (`e.to.kind === "role"`) —
+  // 1 deliberate literal, same shape as the dangling-owner auto-add loop.
+  "plan.ts": 8,
   // preamble.ts classifies actions into "routine-family or not" for the
   // cosmetic check_function_bodies compaction; the routine kinds themselves
   // come from core ROUTINE_KINDS, leaving only the two extension literals.

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -474,12 +474,6 @@ export function plan(
     ...(options?.policy ? flattenPolicy(options.policy).assumedRoles : []),
     ...(options?.assumedRoles ?? []),
   ]);
-  // Snapshot of the DECLARED assumed roles (policy + explicit options), taken
-  // before the dangling-owner auto-add below widens `assumedRoleNames`: the
-  // platform-provisioned discriminator further down must key off the policy's
-  // own role list, not off every role that merely owns something under
-  // database scope.
-  const declaredAssumedRoleNames = new Set(assumedRoleNames);
 
   // Database-scope projection RETAINS `owner` edges to scope-projected roles as
   // dangling assumed references (view.ts), so a kept `ALTER … OWNER TO <role>`
@@ -519,18 +513,30 @@ export function plan(
   // Threaded into the action-graph requirement guard only — never
   // ordering/edges. Empty under the raw/no-policy path and for callers that
   // pass an already-resolved view (its owner edges to excluded roles are gone).
+  //
+  // The owner must be a role the POLICY declares assumed — NOT one merely
+  // supplemented via `options.assumedRoles`, and NOT one auto-assumed from a
+  // dangling owner edge: the database-scoped apply frontend passes EVERY role
+  // found on the target through `options.assumedRoles` (schema-plan.ts), so
+  // keying off the combined set would mark a user-role-owned object in an
+  // assumed schema as platform-provisioned and silence the fail-fast (Codex P1
+  // on PR #407). Only the policy's own list carries the platform-provenance
+  // judgment.
+  const policyAssumedRoleNames = new Set(
+    options?.policy ? flattenPolicy(options.policy).assumedRoles : [],
+  );
   const resolvedDefaultOwner =
     options?.defaultOwner ??
     (options?.policy ? flattenPolicy(options.policy).defaultOwner : undefined);
   const assumedPresentIds = new Set<string>();
-  if (declaredAssumedRoleNames.size > 0) {
+  if (policyAssumedRoleNames.size > 0) {
     for (const fb of [rawSource, rawDesired]) {
       for (const e of fb.edges) {
         if (e.kind !== "owner" || e.to.kind !== "role") continue;
         const schema = (e.from as { schema?: string }).schema;
         if (schema === undefined || !assumedSchemaNames.has(schema)) continue;
         const owner = (e.to as { name: string }).name;
-        if (!declaredAssumedRoleNames.has(owner)) continue;
+        if (!policyAssumedRoleNames.has(owner)) continue;
         if (owner === resolvedDefaultOwner) continue;
         assumedPresentIds.add(encodeId(e.from));
       }

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -5,7 +5,7 @@
 import { INTENT_UNKEYED, USER_MAPPING_UNREADABLE } from "../core/diagnostic.ts";
 import { subjectOf, type Delta } from "../core/diff.ts";
 import type { FactBase } from "../core/fact.ts";
-import { encodeId, type StableId } from "../core/stable-id.ts";
+import { encodeId, isSatelliteId, type StableId } from "../core/stable-id.ts";
 import { flattenPolicy, type Policy } from "../policy/policy.ts";
 import type { ApplierCapability } from "../policy/capability.ts";
 import {
@@ -514,20 +514,29 @@ export function plan(
   // ordering/edges. Empty under the raw/no-policy path and for callers that
   // pass an already-resolved view (its owner edges to excluded roles are gone).
   //
-  // The owner must be a role the POLICY declares assumed — NOT one merely
-  // supplemented via `options.assumedRoles`, and NOT one auto-assumed from a
-  // dangling owner edge: the database-scoped apply frontend passes EVERY role
-  // found on the target through `options.assumedRoles` (schema-plan.ts), so
-  // keying off the combined set would mark a user-role-owned object in an
-  // assumed schema as platform-provisioned and silence the fail-fast (Codex P1
-  // on PR #407). Only the policy's own list carries the platform-provenance
-  // judgment.
-  const policyAssumedRoleNames = new Set(
-    options?.policy ? flattenPolicy(options.policy).assumedRoles : [],
-  );
-  const resolvedDefaultOwner =
-    options?.defaultOwner ??
-    (options?.policy ? flattenPolicy(options.policy).defaultOwner : undefined);
+  // The provenance judgment is derived from the POLICY alone — its declared
+  // `assumedRoles` minus its own declared `defaultOwner`:
+  //  - NOT `options.assumedRoles`: the database-scoped apply frontend passes
+  //    EVERY role found on the target through it (schema-plan.ts), so the
+  //    combined set would mark a user-role-owned object in an assumed schema
+  //    as platform-provisioned and silence the fail-fast (Codex P1 #1,
+  //    PR #407);
+  //  - NOT the run-level `options.defaultOwner` override: the policy declares
+  //    `postgres` assumed only so ownership/grant references resolve — objects
+  //    it owns are the USER's, and a custom `--default-owner` must not
+  //    reclassify them as platform-provisioned (Codex P1 #2, PR #407).
+  // The exemption then covers the owner-bearing root AND its non-satellite
+  // descendants: extraction resolves relation subobjects to COLUMN ids
+  // (extract/dependencies.ts), so a dependent's `depends` edge can point at a
+  // column of a platform table — the platform guarantee covers the subtree
+  // (Codex P2, PR #407). Satellites are excluded like extensionMemberClosure
+  // does: a user GRANT/COMMENT on a platform object is user state, never a
+  // depends target.
+  const flatPolicy = options?.policy
+    ? flattenPolicy(options.policy)
+    : undefined;
+  const policyAssumedRoleNames = new Set(flatPolicy?.assumedRoles ?? []);
+  const policyDefaultOwner = flatPolicy?.defaultOwner;
   const assumedPresentIds = new Set<string>();
   if (policyAssumedRoleNames.size > 0) {
     for (const fb of [rawSource, rawDesired]) {
@@ -537,8 +546,18 @@ export function plan(
         if (schema === undefined || !assumedSchemaNames.has(schema)) continue;
         const owner = (e.to as { name: string }).name;
         if (!policyAssumedRoleNames.has(owner)) continue;
-        if (owner === resolvedDefaultOwner) continue;
-        assumedPresentIds.add(encodeId(e.from));
+        if (owner === policyDefaultOwner) continue;
+        const stack: StableId[] = [e.from];
+        while (stack.length > 0) {
+          const id = stack.pop() as StableId;
+          const key = encodeId(id);
+          if (assumedPresentIds.has(key)) continue;
+          assumedPresentIds.add(key);
+          for (const child of fb.childrenOf(id)) {
+            if (isSatelliteId(child.id)) continue;
+            stack.push(child.id);
+          }
+        }
       }
     }
   }

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -540,6 +540,12 @@ export function plan(
   const assumedPresentIds = new Set<string>();
   if (policyAssumedRoleNames.size > 0) {
     for (const fb of [rawSource, rawDesired]) {
+      // The traversal guard is PER FACT BASE, not the shared result set: a
+      // platform root present on BOTH sides is recorded by the source pass
+      // first, but the desired pass must still walk it — its DESIRED-ONLY
+      // descendants (a platform column added by a newer image) would otherwise
+      // never be traversed (Codex P2 round 3, PR #407).
+      const visited = new Set<string>();
       for (const e of fb.edges) {
         if (e.kind !== "owner" || e.to.kind !== "role") continue;
         const schema = (e.from as { schema?: string }).schema;
@@ -551,7 +557,8 @@ export function plan(
         while (stack.length > 0) {
           const id = stack.pop() as StableId;
           const key = encodeId(id);
-          if (assumedPresentIds.has(key)) continue;
+          if (visited.has(key)) continue;
+          visited.add(key);
           assumedPresentIds.add(key);
           for (const child of fb.childrenOf(id)) {
             if (isSatelliteId(child.id)) continue;

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -474,6 +474,12 @@ export function plan(
     ...(options?.policy ? flattenPolicy(options.policy).assumedRoles : []),
     ...(options?.assumedRoles ?? []),
   ]);
+  // Snapshot of the DECLARED assumed roles (policy + explicit options), taken
+  // before the dangling-owner auto-add below widens `assumedRoleNames`: the
+  // platform-provisioned discriminator further down must key off the policy's
+  // own role list, not off every role that merely owns something under
+  // database scope.
+  const declaredAssumedRoleNames = new Set(assumedRoleNames);
 
   // Database-scope projection RETAINS `owner` edges to scope-projected roles as
   // dangling assumed references (view.ts), so a kept `ALTER … OWNER TO <role>`
@@ -497,6 +503,39 @@ export function plan(
     ...(options?.policy ? flattenPolicy(options.policy).assumedSchemas : []),
     ...(options?.assumedSchemas ?? []),
   ]);
+
+  // PLATFORM-PROVISIONED members of assumed schemas (e.g. Supabase's
+  // `supabase_functions.http_request()`, the DB-webhook trigger function): an
+  // object inside an assumed schema whose owner — read from the RAW extracts,
+  // where the owner edge to the policy-excluded role still exists (resolveView
+  // prunes it together with the role fact) — is a DECLARED assumed role other
+  // than the resolved default owner. The default owner is the role the
+  // platform hands the user, so objects it owns (and objects owned by user
+  // roles) are USER-created: for those the requirement guard keeps the
+  // PR #307 review-P2 fail-fast when the target lacks them. A system-role-owned
+  // member is covered by the same platform guarantee that makes its schema
+  // assumed, so a kept dependent (a user webhook trigger) must plan even when
+  // the target has not had the infra provisioned yet (Sentry SUPABASE-API-8CX).
+  // Threaded into the action-graph requirement guard only — never
+  // ordering/edges. Empty under the raw/no-policy path and for callers that
+  // pass an already-resolved view (its owner edges to excluded roles are gone).
+  const resolvedDefaultOwner =
+    options?.defaultOwner ??
+    (options?.policy ? flattenPolicy(options.policy).defaultOwner : undefined);
+  const assumedPresentIds = new Set<string>();
+  if (declaredAssumedRoleNames.size > 0) {
+    for (const fb of [rawSource, rawDesired]) {
+      for (const e of fb.edges) {
+        if (e.kind !== "owner" || e.to.kind !== "role") continue;
+        const schema = (e.from as { schema?: string }).schema;
+        if (schema === undefined || !assumedSchemaNames.has(schema)) continue;
+        const owner = (e.to as { name: string }).name;
+        if (!declaredAssumedRoleNames.has(owner)) continue;
+        if (owner === resolvedDefaultOwner) continue;
+        assumedPresentIds.add(encodeId(e.from));
+      }
+    }
+  }
 
   // ── phase 2: replacement expansion + drop-root suppression ────────────
   // Classify set-deltas (alter vs replace), expand the forced dependent
@@ -555,6 +594,7 @@ export function plan(
     acceptsFolds,
     assumedRoleNames,
     assumedSchemaNames,
+    assumedPresentIds,
     capability: options?.capability,
     compact: options?.compact !== false,
     foldConstraints: options?.foldConstraints,

--- a/packages/pg-delta/tests/assumed-schema-requirement.test.ts
+++ b/packages/pg-delta/tests/assumed-schema-requirement.test.ts
@@ -9,6 +9,14 @@
  * other filtered-away requirement. An existing assumed-schema object
  * (`auth.users`-style, present on the target) stays satisfied via `source.has`.
  *
+ * The fail-fast must NOT cover PLATFORM-provisioned members of assumed schemas
+ * (Sentry SUPABASE-API-8CX): a DB-webhook trigger depends on
+ * `supabase_functions.http_request()`, which is owned by
+ * `supabase_functions_admin` (an assumed system role) and provisioned by the
+ * platform — a target that has never had webhooks enabled lacks it, yet the
+ * plan must go through. Ownership by an assumed role other than the default
+ * owner is the discriminator (user objects are owned by `postgres`/user roles).
+ *
  * Docker required.
  */
 import { afterAll, describe, expect, test } from "bun:test";
@@ -52,5 +60,59 @@ describe("assumed-schema requirement guard", () => {
         policy: supabasePolicy,
       }),
     ).toThrow(/missing requirement[\s\S]*auth.*extra/);
+  }, 120_000);
+
+  test("a DB-webhook trigger plans when the target lacks the platform's supabase_functions infra", async () => {
+    const cluster = await sharedCluster();
+    const source = await cluster.createDb("webhook_req_src");
+    const desired = await cluster.createDb("webhook_req_dst");
+    dbs.push(source, desired);
+
+    // The system role is cluster-global on the shared test cluster.
+    await source.pool.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_functions_admin') THEN
+          CREATE ROLE supabase_functions_admin;
+        END IF;
+      END $$;
+    `);
+
+    // target: the table exists, webhooks were never provisioned.
+    await source.pool.query(`CREATE TABLE public.deliverable (id integer)`);
+    // desired: the platform provisioned the webhooks infra (schema + function
+    // owned by the system role, as the Supabase image ships it) and the user
+    // added a DB-webhook trigger.
+    await desired.pool.query(`
+      CREATE TABLE public.deliverable (id integer);
+      CREATE SCHEMA supabase_functions;
+      CREATE FUNCTION supabase_functions.http_request() RETURNS trigger
+        LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$;
+      ALTER FUNCTION supabase_functions.http_request() OWNER TO supabase_functions_admin;
+      CREATE TRIGGER "CRUD Deliverables sync out"
+        AFTER INSERT OR UPDATE ON public.deliverable FOR EACH ROW
+        EXECUTE FUNCTION supabase_functions.http_request('https://example.com/webhook', 'POST');
+    `);
+
+    const [sourceState, desiredState] = await Promise.all([
+      extract(source.pool),
+      extract(desired.pool),
+    ]);
+
+    // RED before the fix (Sentry SUPABASE-API-8CX): missing requirement —
+    // "depends on function:supabase_functions.http_request() … (a filter may
+    // be hiding its creation)". The system-role-owned platform function is
+    // present at apply time by platform guarantee.
+    const thePlan = plan(sourceState.factBase, desiredState.factBase, {
+      policy: supabasePolicy,
+    });
+    expect(
+      thePlan.actions.some((a) =>
+        /CREATE TRIGGER "CRUD Deliverables sync out"/.test(a.sql),
+      ),
+    ).toBe(true);
+    // the plan never tries to create the platform function itself
+    expect(
+      thePlan.actions.some((a) => /CREATE (OR REPLACE )?FUNCTION/i.test(a.sql)),
+    ).toBe(false);
   }, 120_000);
 });


### PR DESCRIPTION
## Summary

Fixes the planner&#39;s missing-requirement guard incorrectly rejecting DB-webhook triggers that depend on platform-provisioned functions in assumed schemas (Sentry SUPABASE-API-8CX).

When a database has never had webhooks enabled, the target lacks `supabase_functions.http_request()` and related infrastructure. However, the platform guarantees these objects are provisioned at apply time. The planner was treating this system-role-owned function the same as user-created objects in assumed schemas, causing it to fail with &#34;missing requirement&#34; even though the dependency would be satisfied.

The fix discriminates between:
- **Platform-provisioned members** of assumed schemas: objects owned by a policy-declared assumed role *other than* the policy&#39;s own default owner (e.g., `supabase_functions.http_request()` owned by `supabase_functions_admin`), plus their non-satellite descendant closure. These are treated as ambient/present at apply time by the same guarantee that makes their schema assumed.
- **User-created objects** in assumed schemas: owned by the default owner or user roles. These still fail fast at plan time when the target lacks them (PR #307 review P2).

The discriminator is computed from the RAW fact bases (before policy filtering prunes owner edges to excluded roles) by scanning for objects in assumed schemas whose owner is a policy-declared assumed role other than the policy&#39;s declared default owner. Review hardening (Codex rounds 1–3): supplemental `options.assumedRoles` (target roles under database scope) and the run-level `options.defaultOwner` override are excluded from the provenance judgment, and the descendant walk uses a per-fact-base traversal guard.

## Changes

- **plan.ts**: Compute `assumedPresentIds` set from raw extracts, capturing platform-provisioned members of assumed schemas (system-role-owned objects in assumed schemas) and their non-satellite descendants.
- **internal.ts**: Thread `assumedPresentIds` into `buildActionGraph` and update `isAmbient` logic to treat these objects as present even when kept reference-only and absent from target.
- **action-graph.ts**: Pass `assumedPresentIds` through the finalization pipeline.
- **assumed-schema-requirement.test.ts**: Add unit tests covering the webhook trigger scenario with system-role vs. default-owner vs. user-role ownership, supplemental assumedRoles, custom defaultOwner, and descendant closure (including desired-only descendants of roots present on both sides).
- **tests/assumed-schema-requirement.test.ts**: Add integration test with actual Postgres demonstrating the fix (requires Docker).
- **plan.guard.test.ts**: Update literal count baseline.
- **docs/roadmap/pg-delta-next-follow-ups.md**: PR #407 review triage — one Codex finding deferred by design.
- **Changeset**: Document the fix.

## Linked issue

Fixes CLI-2172
Sentry: [SUPABASE-API-8CX](https://supabase.sentry.io/issues/7665828836/?project=6060713)

## Checklist

- [x] Tests added for the change (unit + integration)
- [x] Changeset added
- [x] `bun run format-and-lint` and `bun run check-types` pass

https://claude.ai/code/session_01BVN92BteeP3trxRPrQscW1