### PR TITLE
fix(pg-delta): witness source-referenced roles in the missing-requirement guard

### DIFF
--- a/.changeset/lucky-donuts-repeat.md
+++ b/.changeset/lucky-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix: the action-graph missing-requirement guard no longer rejects a plan whose action consumes a role that is absent from the managed view but witnessed by the source side (Sentry SUPABASE-API-8CX, pattern B). The `database` scope projects every `role` fact out of both views, and only roles referenced via `owner` edges (or a caller-supplied `assumedRoles` list) were exempted — so a database-scoped DB↔DB diff tearing down a grant to a role that owns nothing threw `missing requirement: … consumes role:<name>` even though the role provably exists on the apply target. plan() now treats any role referenced by a fact kept in the SOURCE view — an ACL grantee, a default-privilege FOR-role/grantee, a membership endpoint, a user-mapping role, an RLS policy TO-role — as present at apply time: the source view is the target's own extract, and PostgreSQL cannot record such a fact for a nonexistent role. Desired-side references with no source witness still fail loudly at plan time.

--- a/packages/pg-delta/src/plan/plan.guard.test.ts
+++ b/packages/pg-delta/src/plan/plan.guard.test.ts
@@ -48,7 +48,10 @@ const KIND_LITERAL_BASELINE: Readonly<Record<string, number>> = {
   // 7 → 8: the platform-provisioned assumed-schema-member scan discriminates
   // owner edges to role facts in the RAW extracts (`e.to.kind === "role"`) —
   // 1 deliberate literal, same shape as the dangling-owner auto-add loop.
-  "plan.ts": 8,
+  // 8 → 9: the source-witnessed role scan probes `source.has({ kind: "role",
+  // name })` for each reference `roleReferencesOf` (rules/helpers.ts) returns —
+  // 1 deliberate literal; the per-kind reference knowledge lives in the rules.
+  "plan.ts": 9,
   // preamble.ts classifies actions into "routine-family or not" for the
   // cosmetic check_function_bodies compaction; the routine kinds themselves
   // come from core ROUTINE_KINDS, leaving only the two extension literals.

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -26,6 +26,7 @@ import {
   KNOWN_PARAMS,
   type PlanParams,
 } from "./rules.ts";
+import { roleReferencesOf } from "./rules/helpers.ts";
 
 /** Engine version stamped into plan artifacts; apply refuses artifacts
  *  from an engine it does not understand (stage 6 deliverable 1). */
@@ -486,6 +487,26 @@ export function plan(
       if (e.kind === "owner" && e.to.kind === "role" && !fb.has(e.to)) {
         assumedRoleNames.add((e.to as { kind: "role"; name: string }).name);
       }
+    }
+  }
+
+  // A role referenced by a fact KEPT in the SOURCE view is WITNESSED to exist
+  // on the apply target even when its role OBJECT is absent from the view (the
+  // database scope projects every role fact out; a policy exclusion can do the
+  // same): the source view is the target's own extract, and PostgreSQL cannot
+  // record an ACL, default privilege, membership, user mapping, or RLS policy
+  // for a role that does not exist. Without the witness, a teardown `REVOKE …
+  // FROM <role>` consumes a role id the guard can't resolve — a grantee-only
+  // role (it owns nothing) is invisible to the owner-edge auto-add above, and
+  // a DB↔DB caller supplies no `assumedRoles` list (Sentry SUPABASE-API-8CX,
+  // pattern B). SOURCE-side only, deliberately: a DESIRED-side reference with
+  // no witness stays a loud plan-time failure — the role may not exist on the
+  // target at all, or a filter may be hiding its creation. `roleReferencesOf`
+  // (rules/helpers.ts) enumerates exactly the references the rule table turns
+  // into role `consumes`.
+  for (const fact of source.facts()) {
+    for (const name of roleReferencesOf(fact)) {
+      if (!source.has({ kind: "role", name })) assumedRoleNames.add(name);
     }
   }
 

--- a/packages/pg-delta/src/plan/revoke-requirement.test.ts
+++ b/packages/pg-delta/src/plan/revoke-requirement.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Missing-requirement guard vs roles WITNESSED by the source view (Sentry
+ * SUPABASE-API-8CX, pattern B).
+ *
+ * Under `scope: "database"` every `role` fact is projected out of both views
+ * (roles are cluster-global), and plan() compensates only for roles referenced
+ * via `owner` edges plus whatever the caller passes as `assumedRoles`. A role
+ * referenced ONLY as an ACL grantee (or a default-privilege FOR-role/grantee, a
+ * membership endpoint, a user-mapping role, an RLS policy TO-role) got neither,
+ * so a teardown `REVOKE … ON … FROM <role>` consumed a role id that "neither
+ * exists on the target nor is produced by this plan" and the action-graph
+ * requirement guard threw — even though the source view IS the target's
+ * extract, and PostgreSQL cannot record a grant for a role that does not exist
+ * on that target.
+ *
+ * The witness must stay SOURCE-side only: a DESIRED-side grant to a role with
+ * no source witness is still a stranded reference (the role may not exist on
+ * the target at all) and must keep failing loudly at plan time.
+ *
+ * No Docker required — synthetic fact bases exercise the planner wiring.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import type { StableId } from "../core/stable-id.ts";
+import { plan } from "./plan.ts";
+
+const appSchema: StableId = { kind: "schema", name: "app" };
+const table: StableId = { kind: "table", schema: "app", name: "t" };
+const role: StableId = { kind: "role", name: "lambda_service_role" };
+
+const f = (
+  id: StableId,
+  parent?: StableId,
+  payload: Fact["payload"] = {},
+): Fact => (parent ? { id, parent, payload } : { id, payload });
+
+const aclTo = (grantee: string, privileges: string[]): Fact =>
+  f({ kind: "acl", target: table, grantee }, table, {
+    privileges,
+    grantable: [],
+  });
+
+describe("plan() — source-witnessed role requirement (SUPABASE-API-8CX pattern B)", () => {
+  test("a REVOKE from a grantee-only role plans under database scope", () => {
+    // target (source side): the table plus a grant to a role that owns nothing —
+    // the role fact itself is projected out by the database scope.
+    const source = buildFactBase(
+      [
+        f(appSchema),
+        f(table, appSchema, { persistence: "p" }),
+        f(role),
+        aclTo("lambda_service_role", ["SELECT"]),
+      ],
+      [],
+    );
+    // desired: the grant is gone → the plan must REVOKE it on the target.
+    const desired = buildFactBase(
+      [f(appSchema), f(table, appSchema, { persistence: "p" })],
+      [],
+    );
+
+    // RED before the fix: missing requirement — the REVOKE consumes
+    // role:lambda_service_role, which the scope projection removed from the
+    // view and nothing witnesses. GREEN: the source-side grant IS the witness
+    // that the role exists on the target, so the REVOKE plans.
+    const thePlan = plan(source, desired, { scope: "database" });
+    expect(
+      thePlan.actions.some((a) =>
+        /REVOKE ALL ON TABLE "app"\."t" FROM "lambda_service_role"/.test(a.sql),
+      ),
+    ).toBe(true);
+  });
+
+  test("a desired-side GRANT to a role the source side witnesses plans", () => {
+    // the grant exists on the target and the desired state widens it: the
+    // replace's REVOKE+GRANT both consume the role, witnessed by the
+    // source-side acl fact.
+    const source = buildFactBase(
+      [
+        f(appSchema),
+        f(table, appSchema, { persistence: "p" }),
+        f(role),
+        aclTo("lambda_service_role", ["SELECT"]),
+      ],
+      [],
+    );
+    const desired = buildFactBase(
+      [
+        f(appSchema),
+        f(table, appSchema, { persistence: "p" }),
+        aclTo("lambda_service_role", ["SELECT", "UPDATE"]),
+      ],
+      [],
+    );
+
+    const thePlan = plan(source, desired, { scope: "database" });
+    expect(
+      thePlan.actions.some((a) =>
+        /GRANT SELECT, UPDATE ON TABLE "app"\."t" TO "lambda_service_role"/.test(
+          a.sql,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("a default-privilege teardown's FOR-role and grantee are witnessed", () => {
+    const adp: Fact = {
+      id: {
+        kind: "defaultPrivilege",
+        role: "deployer",
+        schema: "app",
+        objtype: "r",
+        grantee: "lambda_service_role",
+      },
+      payload: { privileges: ["SELECT"], grantable: [] },
+    };
+    const source = buildFactBase([f(appSchema), adp], []);
+    const desired = buildFactBase([f(appSchema)], []);
+
+    // RED before the fix: the ADP drop consumes role:deployer and
+    // role:lambda_service_role, both projected out by the database scope.
+    const thePlan = plan(source, desired, { scope: "database" });
+    expect(
+      thePlan.actions.some((a) =>
+        /ALTER DEFAULT PRIVILEGES FOR ROLE "deployer"/.test(a.sql),
+      ),
+    ).toBe(true);
+  });
+
+  test("a desired-side GRANT to a role with NO source witness still fails loudly", () => {
+    const source = buildFactBase(
+      [f(appSchema), f(table, appSchema, { persistence: "p" })],
+      [],
+    );
+    // nothing on the source side ever mentions `ghost` — the role may not
+    // exist on the target at all, so the stranded-reference fail-fast stands.
+    const desired = buildFactBase(
+      [
+        f(appSchema),
+        f(table, appSchema, { persistence: "p" }),
+        aclTo("ghost", ["SELECT"]),
+      ],
+      [],
+    );
+
+    expect(() => plan(source, desired, { scope: "database" })).toThrow(
+      /missing requirement[\s\S]*role:ghost/,
+    );
+  });
+});

--- a/packages/pg-delta/src/plan/rules/helpers.ts
+++ b/packages/pg-delta/src/plan/rules/helpers.ts
@@ -745,6 +745,43 @@ export function defaultPrivConsumes(id: {
 }
 
 /**
+ * Role names a fact REFERENCES without owning: an ACL grantee, a
+ * default-privilege FOR-role/grantee, the membership endpoints, a
+ * user-mapping role, an RLS policy's TO-roles — exactly the references the
+ * rules in this directory turn into `consumes: [{ kind: "role", … }]`
+ * (grantActions / defaultPrivConsumes / membership / userMapping / policy).
+ * plan() reads these off the SOURCE view to WITNESS that a role exists on the
+ * apply target even when the role OBJECT is projected or filtered out of the
+ * view: PostgreSQL cannot record any of these for a nonexistent role.
+ * `PUBLIC` is a pseudo-role, never an object — excluded, like the consumes
+ * builders do.
+ */
+export function roleReferencesOf(fact: Fact): string[] {
+  const id = fact.id;
+  const names: string[] = [];
+  switch (id.kind) {
+    case "acl":
+      names.push(id.grantee);
+      break;
+    case "defaultPrivilege":
+      names.push(id.role, id.grantee);
+      break;
+    case "membership":
+      names.push(id.role, id.member);
+      break;
+    case "userMapping":
+      names.push(id.role);
+      break;
+    case "policy":
+      names.push(...((fact.payload as { roles?: string[] }).roles ?? []));
+      break;
+    default:
+      break;
+  }
+  return names.filter((name) => name !== "PUBLIC");
+}
+
+/**
  * A `defaultPrivilege` fact with EMPTY `privileges` is a synthesized marker for
  * a REVOKED built-in default (e.g. `ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON
  * FUNCTIONS FROM PUBLIC`): the grantee's built-in default was taken away. Its

--- a/packages/pg-delta/tests/scope-grantee-role-requirement.test.ts
+++ b/packages/pg-delta/tests/scope-grantee-role-requirement.test.ts
@@ -1,0 +1,87 @@
+/**
+ * A database-scoped DB↔DB diff must plan a `REVOKE … FROM <role>` even when the
+ * role is referenced ONLY as an ACL grantee (Sentry SUPABASE-API-8CX, pattern
+ * B). The `database` scope projects every `role` fact out of both views, and
+ * plan() compensated only for roles referenced via `owner` edges — so a
+ * grantee-only role (it owns nothing, no caller-supplied `assumedRoles`)
+ * stranded the action-graph requirement guard: "consumes role:…, which neither
+ * exists on the target nor is produced by this plan". The source view is the
+ * target's own extract, and PostgreSQL cannot record a grant for a nonexistent
+ * role, so the grant itself witnesses that the role exists at apply time.
+ *
+ * Mirrors the production shape (the branch-diff service plans between two live
+ * databases with `scope: "database"` and no assumed-role list). Docker
+ * required; plain alpine.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { extract } from "../src/extract/extract.ts";
+import { plan } from "../src/plan/plan.ts";
+import { sharedCluster, type TestDb } from "./containers.ts";
+
+const dbs: TestDb[] = [];
+const roles: Array<{ cluster: TestDb["cluster"]; name: string }> = [];
+afterAll(async () => {
+  await Promise.all(dbs.map((d) => d.drop().catch(() => {})));
+  await Promise.all(
+    roles.map(({ cluster, name }) =>
+      cluster.adminPool.query(`DROP ROLE IF EXISTS "${name}"`).catch(() => {}),
+    ),
+  );
+});
+
+describe("database-scope requirement guard: grantee-only role", () => {
+  test("a grant torn down FROM a grantee-only role plans and applies", async () => {
+    const cluster = await sharedCluster();
+    const source = await cluster.createDb("grantee_only_src");
+    const desired = await cluster.createDb("grantee_only_dst");
+    dbs.push(source, desired);
+    // cluster-global on the shared test cluster — unique per run.
+    const role = `lambda_service_role_${source.name}`;
+    roles.push({ cluster, name: role });
+    await cluster.adminPool.query(`CREATE ROLE "${role}"`);
+
+    // target: the table plus a grant to the role; the role OWNS nothing, so no
+    // owner edge ever names it. desired: the grant (and the role) are gone.
+    await source.pool.query(`
+      CREATE TABLE public.campaign_credit_usage (id integer);
+      GRANT SELECT ON public.campaign_credit_usage TO "${role}";
+    `);
+    await desired.pool.query(
+      `CREATE TABLE public.campaign_credit_usage (id integer)`,
+    );
+
+    const [sourceState, desiredState] = await Promise.all([
+      extract(source.pool),
+      extract(desired.pool),
+    ]);
+
+    // RED before the fix: plan() throws `missing requirement: action "REVOKE
+    // ALL ON TABLE "public"."campaign_credit_usage" FROM "<role>"" consumes
+    // role:<role>, which neither exists on the target nor is produced by this
+    // plan`. GREEN: the source-side grant witnesses the role.
+    const thePlan = plan(sourceState.factBase, desiredState.factBase, {
+      scope: "database",
+    });
+    const revoke = thePlan.actions.find((a) =>
+      new RegExp(
+        `REVOKE ALL ON TABLE "public"\\."campaign_credit_usage" FROM "${role}"`,
+      ).test(a.sql),
+    );
+    expect(revoke).toBeDefined();
+
+    // the plan is appliable on the target: the role exists there, so the
+    // REVOKE (and every other action) executes.
+    for (const action of thePlan.actions) {
+      await source.pool.query(action.sql);
+    }
+    const acl = await source.pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n
+         FROM information_schema.role_table_grants
+        WHERE table_schema = 'public'
+          AND table_name = 'campaign_credit_usage'
+          AND grantee = $1`,
+      [role],
+    );
+    expect(acl.rows[0]?.n).toBe("0");
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary

The action-graph missing-requirement guard now correctly handles roles that are referenced (as ACL grantees, default-privilege FOR/grantee roles, membership endpoints, user-mapping roles, or RLS policy TO-roles) but absent from the managed view. When the `database` scope projects all `role` facts out of both views, a teardown action like `REVOKE ALL ON TABLE "public"."campaign_credit_usage" FROM "lambda_service_role"` would fail the requirement guard even though the role provably exists on the apply target — because the source view is the target's own extract, and PostgreSQL cannot record any of these references for a nonexistent role.

The fix adds a source-side witness mechanism: any role referenced by a fact kept in the SOURCE view is now treated as existing on the apply target, exempting it from the missing-requirement check. This is deliberately SOURCE-side only — a DESIRED-side reference with no source witness remains a loud plan-time failure, as the role may not exist on the target at all (or a filter may be hiding its creation).

Fixes [CLI-2175](https://linear.app/supabase/issue/CLI-2175) — Sentry [SUPABASE-API-8CX](https://supabase.sentry.io/issues/7665828836/?project=6060713), pattern B (database-scoped DB↔DB branch diff with a grantee-only role). Sibling of #407, which fixed pattern A (the `depends` branch of the same guard).

## Changes

- **`src/plan/rules/helpers.ts`**: Added `roleReferencesOf()` — enumerates all role names a fact references (ACL grantee, default-privilege FOR-role/grantee, membership endpoints, user-mapping role, RLS policy TO-roles), excluding the pseudo-role `PUBLIC`. Mirrors exactly the references the rule table turns into role `consumes`.
- **`src/plan/plan.ts`**: Source-side witness scan — every role name `roleReferencesOf` returns for a kept SOURCE fact whose role object is absent from the view is added to `assumedRoleNames`. Feeds only the missing-requirement guard; no ordering/edges/SQL change.
- **`src/plan/plan.guard.test.ts`**: FactKind literal ratchet baseline 8 → 9 (documented; the per-kind knowledge lives in plan/rules).

## Tests (RED → GREEN)

At the first commit (tests only), the new tests fail with the production error:

```
error: missing requirement: action "REVOKE ALL ON TABLE "app"."t" FROM
"lambda_service_role"" consumes role:lambda_service_role, which neither
exists on the target nor is produced by this plan
```

- **`src/plan/revoke-requirement.test.ts`** (new, no Docker): REVOKE from a grantee-only role under database scope; desired-side GRANT witnessed by a source ACL; default-privilege teardown (FOR-role + grantee); pins that a desired-side GRANT to an **unwitnessed** role still fails loudly.
- **`tests/scope-grantee-role-requirement.test.ts`** (new, Docker): production shape end-to-end — two live databases, `scope: "database"`, no assumed-role list; plans the REVOKE and applies it.

## Validation

- [x] New tests RED at the test-only commit, GREEN at the fix commit
- [x] Full pg-delta unit suite (1109 tests)
- [x] Related guard integration tests (`assumed-schema-requirement`, `apply-scope-owner-exclusion`)
- [x] Full corpus on `postgres:17-alpine`: **662/662 pass, 0 failures** (every scenario, both directions, state + data proofs)
- [x] `bun run format-and-lint`, `check-types`, `knip`
- [x] Changeset added (`.changeset/lucky-donuts-repeat.md`, patch)

## Known follow-up (tracked in CLI-2175)

The **create-side** gap is deliberately not covered: a branch introducing a NEW role + grants still fails loudly under database scope (no source witness). Whether that needs cluster-scope diffs, an additive role mode, or platform-side role propagation is a product decision under research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sp7GmjExaKQf1RAndzkyHf