### PR TITLE
fix(pg-delta): resolve action-graph cycle on non-relocatable extension replace

### DIFF
--- a/.changeset/pgnet-extension-replace-cycle.md
+++ b/.changeset/pgnet-extension-replace-cycle.md
@@ -1,0 +1,10 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix the planner dependency cycle when a non-relocatable extension is replaced
+(e.g. pg_net installed in different schemas on the two sides). The forced
+dependent rebuild no longer promotes reference-only extension members into
+standalone DROP/CREATE actions, and actions that consume an extension member
+now order against exactly one side of the replace (teardown before the DROP,
+build-up after the re-CREATE) instead of impossibly against both.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -969,3 +969,28 @@ not defects reachable on the shipped policy):
   exactly what the exemption must cover. Revisit together with the explicit
   platform-owner designation above if any platform grants users DDL on
   platform-owned relations.
+
+## PR #410 review triage (Codex) — extension-replace member handling
+
+Rounds 1–2 were real defects in the PR's own changes and were fixed in-PR
+with RED-first regressions (member-satellite removal cycle, traverse-through
+for member dependents, member-satellite replay, vanish-gate scoped to
+`memberOfExtension` edges into destroyed extensions). Round 3 re-litigates a
+pre-existing contract corner; loop capped here per the automated-review
+policy.
+
+- **Deferred — renamed dependents escape the forced-rebuild walk (Codex P1,
+  round 3).** With `renames: "auto"`, `expandReplacements`' dependent check
+  (`desired.has(edge.from)`) sees only the dependent's NEW id, so a dependent
+  being renamed in the same plan is never rebuilt around a destroyed
+  dependency — e.g. renaming a table whose column uses an extension-owned
+  type while that extension is replaced yields `ALTER TABLE … RENAME` +
+  `DROP EXTENSION` and PostgreSQL rejects the drop. This gap PREDATES PR
+  #410 and is not extension-specific: the same shape exists for a rename
+  crossing an enum/type replace (the walk has never carried the
+  accepted-rename identity mapping). The clean fix is to thread
+  `acceptedRenames` into `ReplacementExpansionInput` and translate ids during
+  the walk — or to refuse the plan when a renamed dependent would need a
+  rebuild (rename + rebuild of the same object in one plan is currently
+  unexpressible). Disproportionate to the pg_net cycle fix; needs its own
+  RED coverage for the rename × forced-rebuild matrix.

--- a/packages/pg-delta/src/plan/extension-replace-member-cycle.test.ts
+++ b/packages/pg-delta/src/plan/extension-replace-member-cycle.test.ts
@@ -1,0 +1,161 @@
+/**
+ * A NON-relocatable extension whose `schema` changes is planned as DROP +
+ * CREATE (replace). Its members are reference-only — they vanish with the DROP
+ * and re-materialize with the CREATE — so the replace must never emit
+ * standalone member DROP/CREATE actions, and actions that consume a member id
+ * (a satellite customization, a user object living in an extension-owned
+ * schema) must order against ONE side of the replace, not both.
+ *
+ * Production shape (Sentry event 06bb0a36, pg-delta-next): a pg_net
+ * `extnamespace` drift planned DROP/CREATE EXTENSION pg_net plus DROP/CREATE
+ * for every `net.*` member function, and topoSort threw "dependency cycle
+ * among 21 actions". Two rule bugs cooperated:
+ *
+ *  1. the forced dependent rebuild followed `memberOfExtension` edges, pulling
+ *     reference-only members into `replaceIds` (replacement-expansion.ts);
+ *  2. the extension↔member ordering edges demanded every member-consuming
+ *     action run both AFTER `CREATE EXTENSION` and BEFORE `DROP EXTENSION`,
+ *     which is unsatisfiable across a replace (internal.ts).
+ *
+ * No Docker required — synthetic fact bases exercise the planner wiring.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import type { StableId } from "../core/stable-id.ts";
+import { plan } from "./plan.ts";
+
+const publicSchema: StableId = { kind: "schema", name: "public" };
+const extensionsSchema: StableId = { kind: "schema", name: "extensions" };
+const pgNet: StableId = { kind: "extension", name: "pg_net" };
+const netSchema: StableId = { kind: "schema", name: "net" };
+const httpGet: StableId = {
+  kind: "function",
+  schema: "net",
+  name: "http_get",
+  args: ["text"],
+};
+
+const f = (id: StableId, payload: Fact["payload"] = {}): Fact => ({
+  id,
+  payload,
+});
+
+/** pg_net-shaped facts: the extension owns schema `net` AND a function inside
+ *  it (both carry `memberOfExtension` edges), plus extra user-side facts. */
+const pgNetBase = (
+  extSchema: string,
+  extraFacts: Fact[] = [],
+  extraEdges: Parameters<typeof buildFactBase>[1] = [],
+) =>
+  buildFactBase(
+    [
+      f(publicSchema),
+      f(extensionsSchema),
+      f(pgNet, { schema: extSchema, relocatable: false }),
+      f(netSchema),
+      {
+        id: httpGet,
+        parent: netSchema,
+        payload: {
+          def: `CREATE OR REPLACE FUNCTION net.http_get(url text) RETURNS bigint LANGUAGE sql AS $$ SELECT 1::bigint $$`,
+        },
+      },
+      ...extraFacts,
+    ],
+    [
+      { from: netSchema, to: pgNet, kind: "memberOfExtension" },
+      { from: httpGet, to: pgNet, kind: "memberOfExtension" },
+      { from: httpGet, to: netSchema, kind: "depends" },
+      ...extraEdges,
+    ],
+  );
+
+describe("plan() — non-relocatable extension replace with member-owned schema", () => {
+  test("the replace never emits standalone member DROP/CREATE and sorts DROP before CREATE", () => {
+    const source = pgNetBase("public");
+    const desired = pgNetBase("extensions");
+
+    const thePlan = plan(source, desired);
+    const sqls = thePlan.actions.map((a) => a.sql);
+
+    const dropAt = sqls.findIndex((s) => s === `DROP EXTENSION "pg_net"`);
+    const createAt = sqls.findIndex(
+      (s) => s === `CREATE EXTENSION "pg_net" SCHEMA "extensions"`,
+    );
+    expect(dropAt).toBeGreaterThanOrEqual(0);
+    expect(createAt).toBeGreaterThan(dropAt);
+    // the member function converges VIA the extension — never its own action
+    expect(sqls.some((s) => /FUNCTION "?net"?\./i.test(s))).toBe(false);
+    expect(thePlan.actions).toHaveLength(2);
+  });
+
+  test("a user function inside the extension-owned schema replans around the replace", () => {
+    const report: StableId = {
+      kind: "function",
+      schema: "net",
+      name: "report",
+      args: [],
+    };
+    const userFn = (returnType: string): Fact => ({
+      id: report,
+      parent: netSchema,
+      payload: {
+        def: `CREATE OR REPLACE FUNCTION net.report() RETURNS ${returnType} LANGUAGE sql AS $$ SELECT 1 $$`,
+        returnType,
+      },
+    });
+    const source = pgNetBase(
+      "public",
+      [userFn("bigint")],
+      [{ from: report, to: netSchema, kind: "depends" }],
+    );
+    // returnType change forces the user function's own replace
+    const desired = pgNetBase(
+      "extensions",
+      [userFn("integer")],
+      [{ from: report, to: netSchema, kind: "depends" }],
+    );
+
+    const thePlan = plan(source, desired);
+    const sqls = thePlan.actions.map((a) => a.sql);
+
+    const dropFnAt = sqls.findIndex(
+      (s) => s === `DROP FUNCTION "net"."report"()`,
+    );
+    const dropExtAt = sqls.findIndex((s) => s === `DROP EXTENSION "pg_net"`);
+    const createExtAt = sqls.findIndex(
+      (s) => s === `CREATE EXTENSION "pg_net" SCHEMA "extensions"`,
+    );
+    const createFnAt = sqls.findIndex((s) =>
+      s.includes("FUNCTION net.report() RETURNS integer"),
+    );
+    // teardown belongs to the OLD incarnation, build-up to the NEW one:
+    // DROP FN → DROP EXT → CREATE EXT → CREATE FN
+    expect(dropFnAt).toBeGreaterThanOrEqual(0);
+    expect(dropExtAt).toBeGreaterThan(dropFnAt);
+    expect(createExtAt).toBeGreaterThan(dropExtAt);
+    expect(createFnAt).toBeGreaterThan(createExtAt);
+  });
+
+  test("a satellite customization added on a member orders after the re-CREATE", () => {
+    const comment: StableId = { kind: "comment", target: httpGet };
+    const source = pgNetBase("public");
+    const desired = pgNetBase("extensions", [
+      { id: comment, parent: httpGet, payload: { text: "customized" } },
+    ]);
+
+    const thePlan = plan(source, desired);
+    const sqls = thePlan.actions.map((a) => a.sql);
+
+    const createExtAt = sqls.findIndex(
+      (s) => s === `CREATE EXTENSION "pg_net" SCHEMA "extensions"`,
+    );
+    const commentAt = sqls.findIndex((s) =>
+      s.startsWith(`COMMENT ON FUNCTION "net"."http_get"`),
+    );
+    // the customization targets the NEW incarnation (the member re-materializes
+    // with CREATE EXTENSION), so it must follow the re-create — and must not be
+    // dragged BEFORE the DROP by the source-side member edge.
+    expect(commentAt).toBeGreaterThan(createExtAt);
+  });
+});

--- a/packages/pg-delta/src/plan/extension-replace-member-cycle.test.ts
+++ b/packages/pg-delta/src/plan/extension-replace-member-cycle.test.ts
@@ -185,6 +185,33 @@ describe("plan() — non-relocatable extension replace with member-owned schema"
     expect(commentAt).toBeGreaterThan(createExtAt);
   });
 
+  // An UNCHANGED member customization (same COMMENT/GRANT on both sides) has
+  // no delta — but the replace destroys it with the member and CREATE EXTENSION
+  // restores only installation defaults. The plan must replay the desired-side
+  // satellite after the re-CREATE, or the apply leaves immediate drift.
+  test("an unchanged member customization is replayed after the re-CREATE", () => {
+    const comment: StableId = { kind: "comment", target: httpGet };
+    const commentFact: Fact = {
+      id: comment,
+      parent: httpGet,
+      payload: { text: "kept" },
+    };
+    const source = pgNetBase("public", [commentFact]);
+    const desired = pgNetBase("extensions", [commentFact]);
+
+    const thePlan = plan(source, desired);
+    const sqls = thePlan.actions.map((a) => a.sql);
+
+    const createExtAt = sqls.findIndex(
+      (s) => s === `CREATE EXTENSION "pg_net" SCHEMA "extensions"`,
+    );
+    const commentAt = sqls.findIndex((s) =>
+      s.startsWith(`COMMENT ON FUNCTION "net"."http_get"`),
+    );
+    expect(createExtAt).toBeGreaterThanOrEqual(0);
+    expect(commentAt).toBeGreaterThan(createExtAt);
+  });
+
   // An UNCHANGED user object that depends on a member (not on the member's
   // schema) is a real casualty of the replace: the member vanishes with
   // DROP EXTENSION, so the dependent must be rebuilt around it. The rebuild

--- a/packages/pg-delta/src/plan/extension-replace-member-cycle.test.ts
+++ b/packages/pg-delta/src/plan/extension-replace-member-cycle.test.ts
@@ -158,4 +158,76 @@ describe("plan() — non-relocatable extension replace with member-owned schema"
     // dragged BEFORE the DROP by the source-side member edge.
     expect(commentAt).toBeGreaterThan(createExtAt);
   });
+
+  // The mirror of the previous case: the satellite exists only on the SOURCE
+  // (a customization the desired state removes). Its removal action destroys
+  // only metadata, so it targets the NEW incarnation too — the re-created
+  // member may re-materialize script state the desired side doesn't want. The
+  // child-teardown rule must not pin it before DROP EXTENSION (its consumes
+  // orders it after the re-CREATE → the pair would be a cycle).
+  test("a satellite customization removed from a member orders after the re-CREATE", () => {
+    const comment: StableId = { kind: "comment", target: httpGet };
+    const source = pgNetBase("public", [
+      { id: comment, parent: httpGet, payload: { text: "old note" } },
+    ]);
+    const desired = pgNetBase("extensions");
+
+    const thePlan = plan(source, desired);
+    const sqls = thePlan.actions.map((a) => a.sql);
+
+    const createExtAt = sqls.findIndex(
+      (s) => s === `CREATE EXTENSION "pg_net" SCHEMA "extensions"`,
+    );
+    const commentAt = sqls.findIndex((s) =>
+      s.startsWith(`COMMENT ON FUNCTION "net"."http_get"`),
+    );
+    expect(createExtAt).toBeGreaterThanOrEqual(0);
+    expect(commentAt).toBeGreaterThan(createExtAt);
+  });
+
+  // An UNCHANGED user object that depends on a member (not on the member's
+  // schema) is a real casualty of the replace: the member vanishes with
+  // DROP EXTENSION, so the dependent must be rebuilt around it. The rebuild
+  // walk keeps members out of replaceIds but must still traverse THROUGH them
+  // to reach such dependents — otherwise the plan refuses with a
+  // missing-requirement error ("survives but depends on … which this plan
+  // drops without recreating").
+  test("an unchanged user function depending on a member rebuilds around the replace", () => {
+    const wrapper: StableId = {
+      kind: "function",
+      schema: "public",
+      name: "wrapper",
+      args: [],
+    };
+    const wrapperFact: Fact = {
+      id: wrapper,
+      parent: publicSchema,
+      payload: {
+        def: `CREATE OR REPLACE FUNCTION public.wrapper() RETURNS bigint LANGUAGE plpgsql AS $$ begin return net.http_get('x'); end $$`,
+      },
+    };
+    const wrapperEdges: Parameters<typeof buildFactBase>[1] = [
+      { from: wrapper, to: httpGet, kind: "depends" },
+    ];
+    const source = pgNetBase("public", [wrapperFact], wrapperEdges);
+    const desired = pgNetBase("extensions", [wrapperFact], wrapperEdges);
+
+    const thePlan = plan(source, desired);
+    const sqls = thePlan.actions.map((a) => a.sql);
+
+    const dropWrapperAt = sqls.findIndex(
+      (s) => s === `DROP FUNCTION "public"."wrapper"()`,
+    );
+    const dropExtAt = sqls.findIndex((s) => s === `DROP EXTENSION "pg_net"`);
+    const createExtAt = sqls.findIndex(
+      (s) => s === `CREATE EXTENSION "pg_net" SCHEMA "extensions"`,
+    );
+    const createWrapperAt = sqls.findIndex((s) =>
+      s.includes("FUNCTION public.wrapper()"),
+    );
+    expect(dropWrapperAt).toBeGreaterThanOrEqual(0);
+    expect(dropExtAt).toBeGreaterThan(dropWrapperAt);
+    expect(createExtAt).toBeGreaterThan(dropExtAt);
+    expect(createWrapperAt).toBeGreaterThan(createExtAt);
+  });
 });

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -487,9 +487,20 @@ export function buildActionGraph(
       // child teardown precedes parent teardown
       const fact = source.get(id);
       if (fact?.parent !== undefined) {
-        const parentDestroyer = destroyerOf.get(remember(fact.parent));
+        const parentKey = remember(fact.parent);
+        const parentDestroyer = destroyerOf.get(parentKey);
         if (parentDestroyer !== undefined && parentDestroyer !== index) {
-          edges.push([index, parentDestroyer]);
+          // a metadata satellite whose parent MEMBER an extension replace
+          // re-materializes: the removal targets the NEW incarnation (its
+          // consumes order it after the re-CREATE), so pinning it before the
+          // parent's DROP would close the replace cycle. The old satellite
+          // needs no explicit teardown — it dies with DROP EXTENSION.
+          const parentReproduced =
+            isMetadataKind(id.kind) &&
+            (desiredMemberClosure.get(parentKey) ?? []).some((ext) =>
+              producerOf.has(encodeId(ext)),
+            );
+          if (!parentReproduced) edges.push([index, parentDestroyer]);
         }
       }
     }

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -22,7 +22,7 @@ import {
 import { type ApplierCapability, canSetOwner } from "../policy/capability.ts";
 import { extensionMemberClosure } from "../policy/view.ts";
 import type { Action, SafetyReport } from "./plan.ts";
-import { ruleFlag } from "./rule-flags.ts";
+import { isMetadataKind, ruleFlag } from "./rule-flags.ts";
 import { defaultRulesForId, type FoldHint, type RulesForId } from "./rules.ts";
 import { renderGrantSql } from "./rules/helpers.ts";
 import { schemaCreateSql } from "./rules/schemas.ts";
@@ -276,6 +276,15 @@ export function buildActionGraph(
         edges.push([index, destroyer]);
       }
     }
+    // When a member's extension is REPLACED (both produced and destroyed in
+    // this plan, DROP ordered before CREATE), a member-consuming action can
+    // order against only ONE side — demanding both is unsatisfiable (the
+    // pg_net member cycle, guardrail 4). An action that tears down a real
+    // (non-metadata) object belongs to the OLD incarnation and must precede
+    // the DROP; everything else (creates, alters, metadata satellite changes
+    // — REVOKE / COMMENT are idempotent) targets the NEW incarnation the
+    // re-CREATE materializes.
+    const isTeardown = action.destroys.some((d) => !isMetadataKind(d.kind));
     for (const id of action.consumes) {
       const key = remember(id);
       const producer = producerOf.get(key);
@@ -283,13 +292,22 @@ export function buildActionGraph(
         edges.push([producer, index]);
       const destroyer = destroyerOf.get(key);
       // consumer-before-destroyer applies only when the id is NOT being
-      // re-produced; consumers of a replaced fact use the new one
+      // re-produced; consumers of a replaced fact use the new one. A consumed
+      // extension MEMBER of a replaced extension IS re-produced — by the
+      // CREATE EXTENSION (`producerOf` never tracks members) — so a build-up
+      // consumer uses the new incarnation and must not be pinned before the
+      // DROP (unsatisfiable with its member-closure producer edge below).
       if (
         destroyer !== undefined &&
         destroyer !== index &&
         producer === undefined
       ) {
-        edges.push([index, destroyer]);
+        const memberReproduced =
+          !isTeardown &&
+          (desiredMemberClosure.get(key) ?? []).some((ext) =>
+            producerOf.has(encodeId(ext)),
+          );
+        if (!memberReproduced) edges.push([index, destroyer]);
       }
       // A consumed EXTENSION MEMBER is reference-only (its object is never a
       // create/drop action — CREATE/DROP EXTENSION materializes/removes it). A
@@ -299,14 +317,20 @@ export function buildActionGraph(
       // BEFORE `DROP EXTENSION` (the member vanishes with it — REVOKE it while it
       // still exists).
       for (const ext of desiredMemberClosure.get(key) ?? []) {
-        const extProducer = producerOf.get(encodeId(ext));
-        if (extProducer !== undefined && extProducer !== index)
-          edges.push([extProducer, index]);
+        const extKey = encodeId(ext);
+        const extProducer = producerOf.get(extKey);
+        if (extProducer === undefined || extProducer === index) continue;
+        // replace: a teardown action orders against the DROP, not the CREATE
+        if (isTeardown && destroyerOf.has(extKey)) continue;
+        edges.push([extProducer, index]);
       }
       for (const ext of sourceMemberClosure.get(key) ?? []) {
-        const extDestroyer = destroyerOf.get(encodeId(ext));
-        if (extDestroyer !== undefined && extDestroyer !== index)
-          edges.push([index, extDestroyer]);
+        const extKey = encodeId(ext);
+        const extDestroyer = destroyerOf.get(extKey);
+        if (extDestroyer === undefined || extDestroyer === index) continue;
+        // replace: a build-up action orders against the CREATE, not the DROP
+        if (!isTeardown && producerOf.has(extKey)) continue;
+        edges.push([index, extDestroyer]);
       }
       // the id must exist on the target before apply (source) or be
       // produced by this plan; "it's in the desired state" is not enough —

--- a/packages/pg-delta/src/plan/phases/action-emitter.ts
+++ b/packages/pg-delta/src/plan/phases/action-emitter.ts
@@ -16,6 +16,7 @@ import {
   type ApplierCapability,
 } from "../../policy/capability.ts";
 import { factMatches, type SerializeRule } from "../../policy/policy.ts";
+import { extensionMemberClosure } from "../../policy/view.ts";
 import { lockClassFor } from "../locks.ts";
 import type { Action } from "../plan.ts";
 import { grantTarget, qid } from "../render.ts";
@@ -188,6 +189,14 @@ export function emitActions(input: ActionEmitterInput): ActionEmitterOutput {
     );
   }
 
+  // Desired-side member closure, computed lazily — only an extension REPLACE
+  // needs it (see the satellite replay below).
+  let desiredMemberClosureMemo: Map<string, StableId[]> | undefined;
+  const desiredMemberClosureOf = (): Map<string, StableId[]> => {
+    desiredMemberClosureMemo ??= extensionMemberClosure(projectedDesired);
+    return desiredMemberClosureMemo;
+  };
+
   // replaces: drop old + create new (+ recreate unchanged descendants).
   // Emitted BEFORE the added-creates loop so a replaced parent's CREATE registers
   // its inlined delta-set children (publication members, etc.) in `producerOf`
@@ -256,6 +265,26 @@ export function emitActions(input: ActionEmitterInput): ActionEmitterOutput {
       }
     };
     recreate(newFact.id);
+    // A replaced EXTENSION re-materializes its members with installation
+    // defaults. The members themselves are reference-only (never standalone
+    // actions), but their desired-side SATELLITES (a user COMMENT/GRANT on a
+    // member) die with the DROP — and when the customization is identical on
+    // both sides there is no delta to re-emit it. Replay them from the
+    // projected target; the member consume orders them after the re-CREATE.
+    // (The closure maps members to their owning EXTENSIONS only, so a
+    // non-extension replace key simply matches no members — no kind check.)
+    for (const [memberKey, exts] of desiredMemberClosureOf()) {
+      if (!exts.some((ext) => encodeId(ext) === key)) continue;
+      const member = projectedDesired.getByEncoded(memberKey);
+      if (!member) continue;
+      for (const child of projectedDesired.childrenOf(member.id)) {
+        if (ruleFlag(child.id.kind, "metadata") !== true) continue;
+        const childKey = encodeId(child.id);
+        if (added.has(childKey) || producerOf.has(childKey)) continue;
+        recreatedByReplace.add(childKey);
+        emitCreate(child, projectedDesired);
+      }
+    }
   }
 
   // creates — parents first, so a parent's delta-set inlining (e.g. a

--- a/packages/pg-delta/src/plan/phases/replacement-expansion.ts
+++ b/packages/pg-delta/src/plan/phases/replacement-expansion.ts
@@ -109,8 +109,15 @@ export function expandReplacements(
         // replace, wedges the action graph (the pg_net member cycle,
         // guardrail 4). Reached via its `memberOfExtension` edge when the
         // extension itself is replaced, or via a `depends` edge into any other
-        // destroyed fact.
-        if (source.isReferenceOnly(edge.from)) continue;
+        // destroyed fact. The walk still traverses THROUGH the member: its
+        // non-member dependents are real casualties of the replace and must
+        // rebuild (an unchanged user function calling a member function).
+        if (source.isReferenceOnly(edge.from)) {
+          fullDestroy.add(fromKey);
+          targets.add(fromKey);
+          worklist.push(fromKey);
+          continue;
+        }
         if (!isRebuildable(dependent.id.kind)) continue;
         // reached only via a kind-restricted seed: honor the allowed kinds
         if (!fullDestroy.has(toKey)) {

--- a/packages/pg-delta/src/plan/phases/replacement-expansion.ts
+++ b/packages/pg-delta/src/plan/phases/replacement-expansion.ts
@@ -101,6 +101,16 @@ export function expandReplacements(
         if (targets.has(fromKey)) continue;
         const dependent = source.get(edge.from);
         if (!dependent || !desired.has(edge.from)) continue;
+        // A REFERENCE-ONLY dependent (an extension member, or a non-satellite
+        // descendant of one) is never a standalone action: it vanishes with its
+        // extension's DROP (`alsoDestroys`) and re-materializes with the
+        // CREATE. Promoting it into `replaceIds` emits member DROP/CREATE
+        // statements PostgreSQL rejects outright — and, across an extension
+        // replace, wedges the action graph (the pg_net member cycle,
+        // guardrail 4). Reached via its `memberOfExtension` edge when the
+        // extension itself is replaced, or via a `depends` edge into any other
+        // destroyed fact.
+        if (source.isReferenceOnly(edge.from)) continue;
         if (!isRebuildable(dependent.id.kind)) continue;
         // reached only via a kind-restricted seed: honor the allowed kinds
         if (!fullDestroy.has(toKey)) {

--- a/packages/pg-delta/src/plan/phases/replacement-expansion.ts
+++ b/packages/pg-delta/src/plan/phases/replacement-expansion.ts
@@ -101,18 +101,25 @@ export function expandReplacements(
         if (targets.has(fromKey)) continue;
         const dependent = source.get(edge.from);
         if (!dependent || !desired.has(edge.from)) continue;
-        // A REFERENCE-ONLY dependent (an extension member, or a non-satellite
-        // descendant of one) is never a standalone action: it vanishes with its
+        // An extension MEMBER whose owning extension this plan DESTROYS (drop
+        // or replace) is never a standalone action: it vanishes with the
         // extension's DROP (`alsoDestroys`) and re-materializes with the
         // CREATE. Promoting it into `replaceIds` emits member DROP/CREATE
         // statements PostgreSQL rejects outright — and, across an extension
         // replace, wedges the action graph (the pg_net member cycle,
-        // guardrail 4). Reached via its `memberOfExtension` edge when the
-        // extension itself is replaced, or via a `depends` edge into any other
-        // destroyed fact. The walk still traverses THROUGH the member: its
+        // guardrail 4). The walk still traverses THROUGH the member: its
         // non-member dependents are real casualties of the replace and must
         // rebuild (an unchanged user function calling a member function).
-        if (source.isReferenceOnly(edge.from)) {
+        // Scoped to members of a destroyed extension — a reference-only fact
+        // kept by a POLICY (an assumed-schema platform object) does not
+        // vanish, so it keeps the pre-existing rebuild path below.
+        const vanishesWithExtension = source
+          .outgoingEdges(dependent.id)
+          .some(
+            (e) =>
+              e.kind === "memberOfExtension" && fullDestroy.has(encodeId(e.to)),
+          );
+        if (vanishesWithExtension) {
           fullDestroy.add(fromKey);
           targets.add(fromKey);
           worklist.push(fromKey);

--- a/packages/pg-delta/src/plan/rule-flags.ts
+++ b/packages/pg-delta/src/plan/rule-flags.ts
@@ -31,3 +31,6 @@ export const cascadesToChildren = (kind: string): boolean =>
 
 export const isRebuildable = (kind: string): boolean =>
   ruleFlag(kind, "rebuildable") === true;
+
+export const isMetadataKind = (kind: string): boolean =>
+  ruleFlag(kind, "metadata") === true;

--- a/packages/pg-delta/tests/supabase-integration.test.ts
+++ b/packages/pg-delta/tests/supabase-integration.test.ts
@@ -315,6 +315,66 @@ describe.skipIf(!runSupabaseBareTests)(
       }
     }, 240_000);
 
+    // RAW-profile variant of the drift test, pinning member-customization
+    // replay: an IDENTICAL customization on a member (COMMENT on the member
+    // schema `net`, same on both sides) has no delta, yet dies with the
+    // replace — the plan must replay it after the re-CREATE or the apply
+    // leaves immediate drift. The supabase profile can't see this (Rule 10
+    // excludes satellites targeting the `net` system schema), so this runs
+    // raw; the Supabase IMAGE is still required for pg_net itself.
+    test("pg_net extnamespace drift replays unchanged member customizations (raw profile)", async () => {
+      const cluster = await supabaseCluster();
+      const main = await cluster.createDb("supa_pgnet_raw_main");
+      const branch = await cluster.createDb("supa_pgnet_raw_branch");
+      try {
+        await main.pool.query(
+          `CREATE SCHEMA IF NOT EXISTS extensions;\n` +
+            `CREATE EXTENSION pg_net;\n` +
+            `COMMENT ON SCHEMA net IS 'pinned by pgdelta test';`,
+        );
+        await branch.pool.query(
+          `CREATE SCHEMA IF NOT EXISTS extensions;\n` +
+            `CREATE EXTENSION pg_net SCHEMA extensions;\n` +
+            `COMMENT ON SCHEMA net IS 'pinned by pgdelta test';`,
+        );
+
+        const [s, d] = await Promise.all([
+          extract(main.pool),
+          extract(branch.pool),
+        ]);
+        const thePlan = plan(s.factBase, d.factBase, { compact: true });
+        const sqls = thePlan.actions.map((a) => a.sql);
+        const createExtAt = sqls.findIndex((sql) =>
+          sql.includes(`CREATE EXTENSION "pg_net" SCHEMA "extensions"`),
+        );
+        const commentAt = sqls.findIndex((sql) =>
+          sql.startsWith(`COMMENT ON SCHEMA "net"`),
+        );
+        expect(createExtAt).toBeGreaterThanOrEqual(0);
+        expect(commentAt).toBeGreaterThan(createExtAt);
+
+        const report = await apply(thePlan, main.pool, {
+          fingerprintGate: false,
+        });
+        if (report.status !== "applied") {
+          throw new Error(
+            `apply failed at action ${report.error?.actionIndex ?? "?"}: ${report.error?.message ?? report.status}\nSQL: ${report.error?.sql ?? "(none)"}`,
+          );
+        }
+
+        const after = await extract(main.pool);
+        const drift = plan(after.factBase, d.factBase);
+        if (drift.actions.length > 0) {
+          throw new Error(
+            `${drift.actions.length} drift action(s) after apply:\n${drift.actions.map((a) => a.sql).join("\n")}`,
+          );
+        }
+        expect(drift.actions).toEqual([]);
+      } finally {
+        await Promise.all([main.drop(), branch.drop()]);
+      }
+    }, 240_000);
+
     // Export-as-source-of-truth on the heavy image, through the FULL CLI
     // pipeline (schema export → schema apply), for a realistic middleware shape:
     // a real extension (pgmq), cross-schema mutual FKs, and multi-role ADP

--- a/packages/pg-delta/tests/supabase-integration.test.ts
+++ b/packages/pg-delta/tests/supabase-integration.test.ts
@@ -243,6 +243,78 @@ describe.skipIf(!runSupabaseBareTests)(
       }
     }, 240_000);
 
+    // pg_net `extnamespace` DRIFT (the extension installed into different
+    // schemas on the two sides). pg_net is non-relocatable, so the planner must
+    // replace it — and pg_net owns schema `net` plus every `net.*` function
+    // (deptype 'e'), the shape that made the replace emit standalone member
+    // DROP/CREATE actions and cycle in production ("dependency cycle among 21
+    // actions", Sentry event 06bb0a36). The plan must be a clean
+    // DROP EXTENSION → CREATE EXTENSION with no `net.*` member actions, and it
+    // must apply and converge.
+    test("pg_net extnamespace drift replans as a clean extension replace (no member cycle)", async () => {
+      const cluster = await supabaseCluster();
+      const main = await cluster.createDb("supa_pgnet_drift_main");
+      const branch = await cluster.createDb("supa_pgnet_drift_branch");
+      try {
+        // main: pg_net at its CREATE-time default home (`public`); branch: the
+        // Supabase baseline home (`extensions`). Members live in `net` either way.
+        await main.pool.query(
+          `CREATE SCHEMA IF NOT EXISTS extensions;\n` +
+            `CREATE EXTENSION pg_net;`,
+        );
+        await branch.pool.query(
+          `CREATE SCHEMA IF NOT EXISTS extensions;\n` +
+            `CREATE EXTENSION pg_net SCHEMA extensions;`,
+        );
+
+        const ctx = await resolveCliProfile(main.pool, "supabase");
+        const extractFn = ctx.extract ?? extract;
+        const [s, d] = await Promise.all([
+          extractFn(main.pool),
+          extractFn(branch.pool),
+        ]);
+
+        const thePlan = plan(s.factBase, d.factBase, {
+          compact: true,
+          ...ctx.planOptions,
+        });
+        const sqls = thePlan.actions.map((a) => a.sql);
+        const dropAt = sqls.findIndex((sql) =>
+          sql.includes(`DROP EXTENSION "pg_net"`),
+        );
+        const createAt = sqls.findIndex((sql) =>
+          sql.includes(`CREATE EXTENSION "pg_net" SCHEMA "extensions"`),
+        );
+        expect(dropAt).toBeGreaterThanOrEqual(0);
+        expect(createAt).toBeGreaterThan(dropAt);
+        // members converge via the extension — never their own DROP/CREATE
+        expect(sqls.filter((sql) => /FUNCTION "?net"?\./.test(sql))).toEqual(
+          [],
+        );
+
+        const report = await apply(thePlan, main.pool, {
+          fingerprintGate: false,
+          ...ctx.applyOptions,
+        });
+        if (report.status !== "applied") {
+          throw new Error(
+            `apply failed at action ${report.error?.actionIndex ?? "?"}: ${report.error?.message ?? report.status}\nSQL: ${report.error?.sql ?? "(none)"}`,
+          );
+        }
+
+        const after = await extractFn(main.pool);
+        const drift = plan(after.factBase, d.factBase, ctx.planOptions);
+        if (drift.actions.length > 0) {
+          throw new Error(
+            `${drift.actions.length} drift action(s) after apply:\n${drift.actions.map((a) => a.sql).join("\n")}`,
+          );
+        }
+        expect(drift.actions).toEqual([]);
+      } finally {
+        await Promise.all([main.drop(), branch.drop()]);
+      }
+    }, 240_000);
+
     // Export-as-source-of-truth on the heavy image, through the FULL CLI
     // pipeline (schema export → schema apply), for a realistic middleware shape:
     // a real extension (pgmq), cross-schema mutual FKs, and multi-role ADP


### PR DESCRIPTION
## Summary

Fixes a critical planner bug that caused dependency cycles when a non-relocatable extension (like `pg_net`) is replaced due to schema drift. The issue manifested as "dependency cycle among 21 actions — this is a rule/emission bug, fix the rule (guardrail 4)" in production (Sentry event 06bb0a36, pg-delta-next, thrown from `topoSort` on a pg_net extnamespace drift).

The root causes were:

1. **Forced dependent rebuild promoted reference-only members**: The replacement expansion logic followed `memberOfExtension` edges and pulled extension members (which are reference-only — they vanish with DROP and re-materialize with CREATE) into standalone DROP/CREATE actions. PostgreSQL rejects these statements outright.

2. **Unsatisfiable ordering constraints**: The action graph builder demanded that member-consuming actions run both AFTER `CREATE EXTENSION` and BEFORE `DROP EXTENSION`, which is impossible across a replace operation (DROP is ordered before CREATE).

### Changes

- **`replacement-expansion.ts`**: Skip promoting reference-only dependents (extension members and their descendants) into `replaceIds`. These objects never warrant standalone actions since they're materialized/removed by the extension itself.

- **`internal.ts`**: Refine member-consuming action ordering to respect the replace boundary:
  - Teardown actions (those destroying real objects) order against the DROP side only
  - Build-up actions (creates, alters, metadata changes) order against the CREATE side only
  - The generic consumer-before-destroyer edge gets the same treatment: `DROP EXTENSION` is the `alsoDestroys`-destroyer of every member, and members are never in `producerOf`, so build-up consumers of a member of a replaced extension are no longer pinned before the DROP

- **`rule-flags.ts`**: Export `isMetadataKind()` helper to distinguish metadata-only changes (COMMENT, REVOKE) from real object teardowns.

### Testing

RED → GREEN split across the two commits — the test commit is checkoutable and fails with the production error (`dependency cycle among 41 actions` with real pg_net on the Supabase image).

- Added plan-level unit suite (`extension-replace-member-cycle.test.ts`, no Docker) covering:
  - Clean replace with no member actions and correct DROP→CREATE ordering
  - User functions inside extension-owned schemas replanning around the replace (`DROP FN → DROP EXT → CREATE EXT → CREATE FN`)
  - Satellite customizations (comments) ordering after re-CREATE
- Added Supabase-image integration test (`supabase-integration.test.ts`) verifying pg_net extnamespace drift plans as a clean extension replace, applies, and converges (empty re-plan)
- Full corpus on `postgres:17-alpine`: 662 pass / 0 fail

## Linked issue

No GitHub issue — production failure tracked via Sentry event 06bb0a36 (pg-delta-next, 2026-08-12; the `8CX` issue group).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature
- [x] `bun run format-and-lint` and `bun run check-types` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5BwyHpZNN6etyxyeV7oWx