### PR TITLE
feat(pg-delta): export a pure SQL-file classification helper

### DIFF
--- a/.changeset/export-file-classification.md
+++ b/.changeset/export-file-classification.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Export `classifySqlFiles` / `classifySqlContent`, a pure helper that classifies a proposed declarative export against an existing tree (`created` / `updated` / `unchanged` / `removed` / `unmanaged`) without writing or deleting files. The Supabase CLI can compose this for `schema pull`; `pgdelta schema export` keeps staging, unmanaged-file refusal, and install.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -18,6 +18,10 @@ performance, then DX.
   format decision).
 - **[ephemeral-shadow-design.md](ephemeral-shadow-design.md)** — full design for
   auto-provisioning an ephemeral shadow database (deferred).
+- **[schema-first-cli-enablement.md](schema-first-cli-enablement.md)** — what
+  pg-delta must export so the Supabase CLI can build the schema-first workflow
+  (`schema pull / diff / generate / apply / push`). WP3a (export-file
+  classification) is in progress; remaining WPs are sequenced there.
 
 ## How the engine got here
 

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -77,6 +77,16 @@ one unsplittable query that caps the ceiling). Deferred.
 
 ## Milestone B — DX
 
+### 🟡 Schema-first CLI enablement
+Promote engine primitives the RFC's `PgDeltaSchemaEngine` adapter needs onto
+the exported library surface (stable `planId`, `HazardKind` codes, file
+classification, segments, coverage/data-loss helpers, named loader options).
+Most of the RFC's integration boundary is already satisfied; the work is
+targeted additions plus moving CLI-only logic out of `src/cli/**`. Full plan
+and WP sequencing: [schema-first-cli-enablement.md](schema-first-cli-enablement.md).
+WP3a (pure `classifySqlFiles` helper) ships with this change. Linear: the
+RFC plus CLI-1459–1464 (WP2).
+
 ### 🟡 Risk classification 2.0
 The engine already computes proof-verified per-action safety (`dataLoss`,
 `rewriteRisk`, `lockClass`, `transactionality`). Derive stable `HazardKind` codes

--- a/docs/roadmap/schema-first-cli-enablement.md
+++ b/docs/roadmap/schema-first-cli-enablement.md
@@ -1,0 +1,139 @@
+# Schema-first CLI enablement
+
+- **Status**: In progress — WP3a shipping; remaining WPs sequenced below.
+- **Date**: 2026-08-13
+- **Source**: RFC *Schema-First Database Development* (Linear
+  `rfc-schema-first-database-development-532de5a122d5`, 2026-08-12, **revised
+  2026-08-13**).
+
+What `@supabase/pg-delta` must add so the Supabase CLI can build the
+schema-first workflow (`schema pull / diff / generate / apply / push`).
+pg-delta is the schema compiler; the CLI owns the workflow layer.
+
+The 2026-08-13 revision: `schema extract` → `schema pull` (V1), `--replace` →
+`--force`, semantic reconciliation dropped for the `_custom/` escape hatch,
+checkpoint records the extracted catalog snapshot as a forward-compatible
+base. Observed provenance (WP6) is deferred.
+
+| Symbol | Meaning |
+|---|---|
+| ✅ | Already provided by the engine |
+| 🟠 | Net-new engineering |
+| 🟡 | Substrate exists; build the consumer/surface |
+| ⚪ | Deliberate deferral |
+
+---
+
+## Already provided ✅
+
+No new engine work — these must survive the CLI adapter without being
+flattened to rendered SQL:
+
+- Typed `Plan.actions` with `sql`, `verb`, dependency edges, `dataLoss`,
+  `rewriteRisk`, `lockClass`, `transactionality`, plus `SafetyReport`.
+- `Plan.source.fingerprint` / `Plan.target.fingerprint`.
+- `Plan.renameCandidates`, `PlanOptions.renames`, `acceptRenames`.
+- Fingerprint-gated `apply()` with `ApplyReport.actionStatuses` and
+  `ApplyEvent` streaming.
+- `renderPlanFiles()` — one logical change, multiple physical files at
+  transaction boundaries.
+- `loadSqlFiles()` DML detection (`data_statement`); `strictDataStatements:
+  true` makes it fatal.
+- Coverage diagnostics: `unmodeled_kind`, `unmodeled_drift`,
+  `unresolved_security_label`.
+- `planSchemaFiles()` — load + extract + plan + coverage-drift probe.
+- `serializeSnapshot` / `deserializeSnapshot` / `saveSnapshot` /
+  `loadSnapshot` — version-stamped, fail-closed.
+- `_custom/` preservation (exporter never writes/prunes/claims it) and
+  `ExportManifest.files` ownership list.
+
+**Inventory corrections vs the RFC text:**
+
+- Plan artifacts already stamp `formatVersion` + `engineVersion`; `parsePlan`
+  and `apply()` refuse a mismatch. WP1's remaining work is `Plan.planId`.
+- `segmentActions()` is already exported from `@supabase/pg-delta/apply`. WP3
+  still needs the `Segment` type, a `planSegments(plan)` helper, and
+  root/`frontends` re-exports, plus `renderApplyScript`.
+
+---
+
+## WP1 — 🟠 Stable plan identifier
+
+Add `Plan.planId`: a content hash over source fingerprint, desired
+fingerprint, accepted renames, an action-list digest, profile/scope/policy,
+and engine + artifact format version. `parsePlan` verifies it. Version
+fail-closed is already there.
+
+---
+
+## WP2 — 🟡 Hazard classification 2.0
+
+Derive per-action `HazardKind[]` from existing proof-verified safety fields
+plus coverage diagnostics. Export stable codes and a plan-level hazard
+report. Policy (which hazards block which target class) stays in the
+Supabase CLI. Linear: CLI-1459–1464.
+
+---
+
+## WP3 — 🟡 Promote CLI-only logic into exported library frontends
+
+Library frontends accept pools and SQL files; they return typed data. No
+`supabase/` paths, prompts, or CLI JSON. `pgdelta` stays a thin consumer.
+
+| Slice | Status | Notes |
+|---|---|---|
+| **WP3a** export file classification | **this change** | Pure `classifySqlFiles` / `classifySqlContent`. Does **not** export `writeExportFiles` (writes, scaffolds `_custom/README.md`, refuses unmanaged). |
+| **WP3b** | next | Re-export `pruneStaleSqlFiles`, `renderApplyScript`, `probeUnmodeledIdentitiesPinned`. |
+| **WP3c** | | Export `Segment` + `planSegments(plan)` from root/`frontends`. |
+| **WP3d** | | Move `STRICT_COVERAGE_CODES` + `hasBlockingDiagnostics` into a frontend; leave `printDiagnostics` / `exitIfBlocking` in the CLI. |
+| **WP3e** | | Move `dataLossActions` into a frontend; leave `assertDataLossAllowed` in the CLI. |
+| **WP3f** | | Export `SourceDatabaseIdentity` + `src/database-identity.ts` helpers (not URL parsing). |
+
+---
+
+## WP4 — 🟠 Loader contract polish
+
+Name and export `LoadSqlFilesOptions`. Library default for
+`strictDataStatements` stays permissive (warning); the Supabase CLI adapter
+**must** pass `strictDataStatements: true`. Flipping the library default is
+a breaking change with no engine benefit.
+
+---
+
+## WP5 — Supporting tracks (not V1 blockers)
+
+Extension-intent Phase B, Supabase baseline snapshots, ephemeral auto-shadow,
+coverage waves / outside-observer verification. See [backlog.md](backlog.md).
+
+---
+
+## WP6 — ⚪ Observed provenance
+
+Deferred. The RFC revision dropped semantic reconciliation; the checkpoint
+catalog snapshot is the only forward-compatibility hook, and the engine
+already provides it. Reopen only if an opt-in `schema pull --merge` is
+designed, or if diff-UX demand justifies Tier 1 on its own.
+
+---
+
+## Sequencing
+
+WP3a → WP3b/c (pull's file summary + segments) → WP1 → WP2 → WP3d/e/f → WP4.
+
+RFC phase mapping: Phase 0 needs WP2 + WP3d; Phase 1 needs WP1 + WP3a–c;
+Phase 2 consumes `planId` + hazard codes; Phases 3–4 need nothing new on
+the pg-delta side.
+
+---
+
+## Boundary (binding on every WP)
+
+- pg-delta does not learn about `supabase/database`, `supabase/migrations`,
+  linked projects, branch protection, prompts, or CLI JSON.
+- The Supabase CLI owns staging, `--force`, unmanaged-file /
+  `--prune-unmanaged` policy, install/recovery, target/branch policy,
+  checkpoints, draft journals, and migration history.
+- pg-delta owns classification, planning, safety metadata, rendering,
+  fingerprints, apply, and proof.
+- Persisted plan artifacts are diagnostic and version-bound; stale artifacts
+  are re-planned, never silently upgraded.

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -129,6 +129,10 @@ import type {
   ExportGroupingPattern,
 } from "../../frontends/export-sql-files.ts";
 import type { SqlFormatOptions } from "../../frontends/sql-format/index.ts";
+import {
+  classifySqlContent,
+  type SqlFileChange,
+} from "../../frontends/classify-sql-files.ts";
 import { pruneStaleSqlFiles } from "../../frontends/prune-sql-files.ts";
 import {
   CUSTOM_DIR_NAME,
@@ -337,26 +341,24 @@ export function writeExportFiles(
         `export: refusing to write outside ${outRoot}: ${file.name}`,
       );
     }
-    // Classify against the file already on disk: absent → created; same
-    // bytes → unchanged (skip the write, keeping the mtime stable for build
-    // tools); anything else → updated. A size mismatch alone proves the
+    // Classify against the file already on disk via the shared helper
+    // (frontends/classify-sql-files.ts). A size mismatch alone proves the
     // content differs, so the old content is only buffered for a plausible
     // match. Only ENOENT means "created" — any other stat/read error is
     // surfaced rather than silently reclassified as absence (PR #405 review).
-    let status: "created" | "updated" | "unchanged";
+    let status: SqlFileChange;
     try {
       status =
-        statSync(full).size === Buffer.byteLength(file.sql, "utf8") &&
-        readFileSync(full, "utf8") === file.sql
-          ? "unchanged"
-          : "updated";
+        statSync(full).size !== Buffer.byteLength(file.sql, "utf8")
+          ? "updated"
+          : classifySqlContent(readFileSync(full, "utf8"), file.sql);
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
         throw new Error(
           `export: cannot read existing file ${full} to classify it: ${e instanceof Error ? e.message : String(e)}`,
         );
       }
-      status = "created";
+      status = classifySqlContent(undefined, file.sql);
     }
     if (status === "unchanged") {
       unchanged.push(full);

--- a/packages/pg-delta/src/frontends/classify-sql-files.test.ts
+++ b/packages/pg-delta/src/frontends/classify-sql-files.test.ts
@@ -75,6 +75,31 @@ describe("classifySqlFiles", () => {
     expect(result.updated).toEqual([]);
   });
 
+  test("a ./ -prefixed existing key matches the same proposed path", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "./schemas/app/t.sql": "CREATE TABLE app.t ();\n",
+      }),
+    });
+    expect(result.unchanged).toEqual(["schemas/app/t.sql"]);
+    expect(result.created).toEqual([]);
+    expect(result.unmanaged).toEqual([]);
+  });
+
+  test("./_custom/ is invisible, matching the reserved-folder invariant", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "schemas/app/t.sql": "CREATE TABLE app.t ();\n",
+        "./_custom/x.sql": "-- custom\n",
+      }),
+    });
+    expect(result.unchanged).toEqual(["schemas/app/t.sql"]);
+    expect(result.unmanaged).toEqual([]);
+    expect(result.removed).toEqual([]);
+  });
+
   test("a previously-owned file missing from proposed is removed", () => {
     const result = classifySqlFiles({
       proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],

--- a/packages/pg-delta/src/frontends/classify-sql-files.test.ts
+++ b/packages/pg-delta/src/frontends/classify-sql-files.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Pure export-file classification (schema-first CLI enablement WP3a).
+ *
+ * Compares a proposed `SqlFile[]` against an in-memory existing tree and the
+ * previous export's owned-file list. No filesystem mutation: staging, prune
+ * authorization, and install stay with the caller (pgdelta CLI / Supabase CLI).
+ */
+import { describe, expect, test } from "bun:test";
+import { classifySqlContent, classifySqlFiles } from "./classify-sql-files.ts";
+import type { SqlFile } from "./load-sql-files.ts";
+
+const file = (name: string, sql: string): SqlFile => ({ name, sql });
+
+function existing(entries: Record<string, string>): Map<string, string> {
+  return new Map(Object.entries(entries));
+}
+
+describe("classifySqlContent", () => {
+  test("absent existing content is created", () => {
+    expect(classifySqlContent(undefined, "CREATE TABLE app.t ();\n")).toBe(
+      "created",
+    );
+  });
+
+  test("byte-identical content is unchanged", () => {
+    expect(classifySqlContent("-- a\n", "-- a\n")).toBe("unchanged");
+  });
+
+  test("different content is updated", () => {
+    expect(classifySqlContent("-- a v1\n", "-- a v2\n")).toBe("updated");
+  });
+});
+
+describe("classifySqlFiles", () => {
+  test("classifies created / updated / unchanged across a re-export-shaped input", () => {
+    const first = classifySqlFiles({
+      proposed: [
+        file("schemas/app/a.sql", "-- a v1\n"),
+        file("schemas/app/b.sql", "-- b v1\n"),
+      ],
+      existing: existing({}),
+    });
+    expect(first.created).toEqual(["schemas/app/a.sql", "schemas/app/b.sql"]);
+    expect(first.updated).toEqual([]);
+    expect(first.unchanged).toEqual([]);
+    expect(first.removed).toEqual([]);
+    expect(first.unmanaged).toEqual([]);
+
+    const second = classifySqlFiles({
+      proposed: [
+        file("schemas/app/a.sql", "-- a v1\n"),
+        file("schemas/app/b.sql", "-- b v2\n"),
+        file("schemas/app/c.sql", "-- c\n"),
+      ],
+      existing: existing({
+        "schemas/app/a.sql": "-- a v1\n",
+        "schemas/app/b.sql": "-- b v1\n",
+      }),
+      previouslyOwned: new Set(["schemas/app/a.sql", "schemas/app/b.sql"]),
+    });
+    expect(second.created).toEqual(["schemas/app/c.sql"]);
+    expect(second.updated).toEqual(["schemas/app/b.sql"]);
+    expect(second.unchanged).toEqual(["schemas/app/a.sql"]);
+  });
+
+  test("normalizes separators so Windows-style proposed names match POSIX existing keys", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas\\app\\t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "schemas/app/t.sql": "CREATE TABLE app.t ();\n",
+      }),
+    });
+    expect(result.unchanged).toEqual(["schemas/app/t.sql"]);
+    expect(result.created).toEqual([]);
+    expect(result.updated).toEqual([]);
+  });
+
+  test("a previously-owned file missing from proposed is removed", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "schemas/app/t.sql": "CREATE TABLE app.t ();\n",
+        "schemas/app/gone.sql": "-- gone\n",
+      }),
+      previouslyOwned: new Set(["schemas/app/t.sql", "schemas/app/gone.sql"]),
+    });
+    expect(result.removed).toEqual(["schemas/app/gone.sql"]);
+    expect(result.unmanaged).toEqual([]);
+    expect(result.unchanged).toEqual(["schemas/app/t.sql"]);
+  });
+
+  test("a never-owned extra .sql is unmanaged (not removed)", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "schemas/app/handwritten.sql": "-- hand-authored\n",
+      }),
+      previouslyOwned: new Set(),
+    });
+    expect(result.removed).toEqual([]);
+    expect(result.unmanaged).toEqual(["schemas/app/handwritten.sql"]);
+  });
+
+  test("absent previouslyOwned treats every extra .sql as unmanaged (pre-feature dir)", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "schemas/app/t.sql": "CREATE TABLE app.t ();\n",
+        "legacy.sql": "-- leftover\n",
+      }),
+    });
+    expect(result.removed).toEqual([]);
+    expect(result.unmanaged).toEqual(["legacy.sql"]);
+    expect(result.unchanged).toEqual(["schemas/app/t.sql"]);
+  });
+
+  test("a previously-owned path not present in existing is not removed", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "schemas/app/t.sql": "CREATE TABLE app.t ();\n",
+      }),
+      previouslyOwned: new Set([
+        "schemas/app/t.sql",
+        "schemas/app/already-gone.sql",
+      ]),
+    });
+    expect(result.removed).toEqual([]);
+    expect(result.unmanaged).toEqual([]);
+  });
+
+  test("_custom/** is neither removed nor unmanaged", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "schemas/app/t.sql": "CREATE TABLE app.t ();\n",
+        "_custom/text-search.sql": "-- custom\n",
+        "_custom/nested/seed.sql": "-- seed\n",
+      }),
+      previouslyOwned: new Set([
+        "schemas/app/t.sql",
+        "_custom/text-search.sql",
+      ]),
+    });
+    expect(result.removed).toEqual([]);
+    expect(result.unmanaged).toEqual([]);
+    expect(result.unchanged).toEqual(["schemas/app/t.sql"]);
+  });
+
+  test("a proposed _custom/ path is ignored (exporter never claims the reserved folder)", () => {
+    const result = classifySqlFiles({
+      proposed: [
+        file("_custom/t.sql", "CREATE TABLE app.t ();\n"),
+        file("schemas/app/t.sql", "CREATE TABLE app.t ();\n"),
+      ],
+      existing: existing({}),
+    });
+    expect(result.created).toEqual(["schemas/app/t.sql"]);
+    expect(result.updated).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+  });
+
+  test("a nested schemas/app/_custom/ path is ordinary managed space", () => {
+    const result = classifySqlFiles({
+      proposed: [],
+      existing: existing({
+        "schemas/app/_custom/x.sql": "-- nested\n",
+      }),
+    });
+    expect(result.unmanaged).toEqual(["schemas/app/_custom/x.sql"]);
+    expect(result.removed).toEqual([]);
+  });
+
+  test("non-.sql existing entries are ignored", () => {
+    const result = classifySqlFiles({
+      proposed: [file("schemas/app/t.sql", "CREATE TABLE app.t ();\n")],
+      existing: existing({
+        "README.md": "# notes\n",
+        ".pgdelta-export.json": "{}\n",
+      }),
+    });
+    expect(result.unmanaged).toEqual([]);
+    expect(result.removed).toEqual([]);
+    expect(result.created).toEqual(["schemas/app/t.sql"]);
+  });
+
+  test("empty proposed against an empty tree is a no-op classification", () => {
+    expect(classifySqlFiles({ proposed: [], existing: existing({}) })).toEqual({
+      created: [],
+      updated: [],
+      unchanged: [],
+      removed: [],
+      unmanaged: [],
+    });
+  });
+});

--- a/packages/pg-delta/src/frontends/classify-sql-files.ts
+++ b/packages/pg-delta/src/frontends/classify-sql-files.ts
@@ -24,7 +24,8 @@ export interface ClassifySqlFilesInput {
    *  are POSIX-relative. */
   proposed: readonly SqlFile[];
   /** Existing `.sql` file bodies keyed by path relative to the export root.
-   *  Either separator is accepted. Non-`.sql` keys and `_custom/**` are ignored. */
+   *  Either separator is accepted; `.` segments are dropped. Non-`.sql` keys
+   *  and `_custom/**` are ignored. `..` is caller-owned (left as-is). */
   existing: ReadonlyMap<string, string>;
   /** POSIX-relative paths the previous export owned (`ExportManifest.files`).
    *  Absent (pre-feature / hand-authored dir) → every extra `.sql` is
@@ -43,11 +44,14 @@ export interface SqlFileClassification {
   unmanaged: string[];
 }
 
-/** Normalize a relative path to POSIX (`/` separators, no empty segments). */
+/** Normalize a relative path to POSIX (`/` separators, no empty or `.`
+ *  segments). `..` is left as-is — callers must not pass parent-directory
+ *  segments; this helper is pure, so `..` is a mismatch hazard, not a
+ *  traversal one. */
 function posixRelPath(relPath: string): string {
   return relPath
     .split(/[\\/]/)
-    .filter((segment) => segment !== "")
+    .filter((segment) => segment !== "" && segment !== ".")
     .join("/");
 }
 

--- a/packages/pg-delta/src/frontends/classify-sql-files.ts
+++ b/packages/pg-delta/src/frontends/classify-sql-files.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure export-file classification for declarative schema trees.
+ *
+ * Compares a proposed `SqlFile[]` (what an export would write) against an
+ * in-memory existing tree and the previous export's owned-file list
+ * (`.pgdelta-export.json` `files`). Returns created / updated / unchanged /
+ * removed / unmanaged as POSIX-relative paths. No filesystem mutation: the
+ * caller owns staging, `--force` / `--prune-unmanaged` authorization, and
+ * install (schema-first CLI enablement WP3a; the RFC's "reusable typed file
+ * classification helper").
+ *
+ * `_custom/` is invisible here, matching the exporter reservation
+ * (`custom-dir.ts`): nothing under the root-level folder is created, updated,
+ * unchanged, removed, or unmanaged. Nested `schemas/app/_custom/` is ordinary
+ * managed space.
+ */
+import type { SqlFile } from "./load-sql-files.ts";
+import { isCustomPath } from "./custom-dir.ts";
+
+export type SqlFileChange = "created" | "updated" | "unchanged";
+
+export interface ClassifySqlFilesInput {
+  /** Files the export would write. Names may use either separator; results
+   *  are POSIX-relative. */
+  proposed: readonly SqlFile[];
+  /** Existing `.sql` file bodies keyed by path relative to the export root.
+   *  Either separator is accepted. Non-`.sql` keys and `_custom/**` are ignored. */
+  existing: ReadonlyMap<string, string>;
+  /** POSIX-relative paths the previous export owned (`ExportManifest.files`).
+   *  Absent (pre-feature / hand-authored dir) → every extra `.sql` is
+   *  unmanaged; none are removed. */
+  previouslyOwned?: ReadonlySet<string>;
+}
+
+export interface SqlFileClassification {
+  created: string[];
+  updated: string[];
+  unchanged: string[];
+  /** Previously owned `.sql` present in `existing` but not in `proposed`. */
+  removed: string[];
+  /** `.sql` present in `existing` that the previous export did not own and
+   *  `proposed` does not claim. */
+  unmanaged: string[];
+}
+
+/** Normalize a relative path to POSIX (`/` separators, no empty segments). */
+function posixRelPath(relPath: string): string {
+  return relPath
+    .split(/[\\/]/)
+    .filter((segment) => segment !== "")
+    .join("/");
+}
+
+function isManagedSqlPath(path: string): boolean {
+  return path.endsWith(".sql") && !isCustomPath(path);
+}
+
+/** Classify one proposed body against the bytes already at that path. */
+export function classifySqlContent(
+  existing: string | undefined,
+  proposed: string,
+): SqlFileChange {
+  if (existing === undefined) return "created";
+  return existing === proposed ? "unchanged" : "updated";
+}
+
+/**
+ * Classify a proposed export against an existing tree without writing or
+ * deleting anything. Paths in the result are POSIX-relative.
+ *
+ * `created` / `updated` / `unchanged` follow `proposed` order (first
+ * occurrence). `removed` / `unmanaged` are sorted.
+ */
+export function classifySqlFiles(
+  input: ClassifySqlFilesInput,
+): SqlFileClassification {
+  const proposedByPath = new Map<string, string>();
+  for (const file of input.proposed) {
+    const path = posixRelPath(file.name);
+    if (!isManagedSqlPath(path)) continue;
+    proposedByPath.set(path, file.sql);
+  }
+
+  const existingByPath = new Map<string, string>();
+  for (const [raw, content] of input.existing) {
+    const path = posixRelPath(raw);
+    if (!isManagedSqlPath(path)) continue;
+    existingByPath.set(path, content);
+  }
+
+  const previouslyOwned =
+    input.previouslyOwned === undefined
+      ? undefined
+      : new Set(
+          [...input.previouslyOwned].map(posixRelPath).filter(isManagedSqlPath),
+        );
+
+  const created: string[] = [];
+  const updated: string[] = [];
+  const unchanged: string[] = [];
+  for (const [path, sql] of proposedByPath) {
+    const change = classifySqlContent(existingByPath.get(path), sql);
+    if (change === "created") created.push(path);
+    else if (change === "updated") updated.push(path);
+    else unchanged.push(path);
+  }
+
+  const removed: string[] = [];
+  const unmanaged: string[] = [];
+  for (const path of existingByPath.keys()) {
+    if (proposedByPath.has(path)) continue;
+    if (previouslyOwned?.has(path) === true) removed.push(path);
+    else unmanaged.push(path);
+  }
+  removed.sort();
+  unmanaged.sort();
+
+  return { created, updated, unchanged, removed, unmanaged };
+}

--- a/packages/pg-delta/src/frontends/index.ts
+++ b/packages/pg-delta/src/frontends/index.ts
@@ -28,6 +28,14 @@ export {
 } from "./export-manifest.ts";
 
 export {
+  classifySqlContent,
+  classifySqlFiles,
+  type ClassifySqlFilesInput,
+  type SqlFileChange,
+  type SqlFileClassification,
+} from "./classify-sql-files.ts";
+
+export {
   buildSchemaExport,
   type BuildSchemaExportOptions,
   type SchemaExportResult,

--- a/packages/pg-delta/src/index.ts
+++ b/packages/pg-delta/src/index.ts
@@ -94,6 +94,13 @@ export {
   type ExportManifest,
 } from "./frontends/export-manifest.ts";
 export {
+  classifySqlContent,
+  classifySqlFiles,
+  type ClassifySqlFilesInput,
+  type SqlFileChange,
+  type SqlFileClassification,
+} from "./frontends/classify-sql-files.ts";
+export {
   buildSchemaExport,
   type BuildSchemaExportOptions,
   type SchemaExportResult,

--- a/packages/pg-delta/src/public-api.test.ts
+++ b/packages/pg-delta/src/public-api.test.ts
@@ -22,6 +22,11 @@ describe("public API surface", () => {
     expect(root.rawProfile.id).toBe("raw");
   });
 
+  test("root re-exports the export-file classification helper", () => {
+    expect(typeof root.classifySqlFiles).toBe("function");
+    expect(typeof root.classifySqlContent).toBe("function");
+  });
+
   test("the integrations subpath exposes the full profile surface", () => {
     expect(typeof integrations.resolveProfile).toBe("function");
     expect(integrations.supabaseProfile.id).toBe("supabase");


### PR DESCRIPTION
## Summary

- First slice of [schema-first CLI enablement](docs/roadmap/schema-first-cli-enablement.md) (WP3a): export `classifySqlFiles` / `classifySqlContent` so the Supabase CLI can compose `schema pull` without reimplementing created/updated/unchanged/removed/unmanaged.
- Classification is **pure** (in-memory proposed files vs existing tree vs the previous export's owned-file list). `_custom/` stays invisible, matching the exporter reservation.
- `writeExportFiles` is **not** exported — staging, unmanaged-file refusal, `_custom/README.md` scaffolding, and install stay with `pgdelta` / the CLI adapter. `schema export` now uses `classifySqlContent` for the byte-compare path.

## Test plan

- [x] RED: `bun test src/frontends/classify-sql-files.test.ts` failed with `Cannot find module './classify-sql-files.ts'`
- [x] GREEN: 14 classification unit tests pass (created/updated/unchanged, removed vs unmanaged, `_custom/` reservation, separator normalization)
- [x] Existing `writeExportFiles` cases in `collect-sql-files.test.ts` still pass
- [x] `public-api.test.ts` pins the root re-export
- [x] `bun run format-and-lint && bun run check-types`

Follow-ups (not this PR): WP3b re-exports (`pruneStaleSqlFiles`, `renderApplyScript`, `probeUnmodeledIdentitiesPinned`), then WP3c segments, WP1 `planId`, WP2 hazards.