### PR TITLE
feat(pg-delta): export prune, apply-script, and unmodeled-drift helpers

### DIFF
--- a/.changeset/schema-first-cli-frontend-reexports.md
+++ b/.changeset/schema-first-cli-frontend-reexports.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Export `pruneStaleSqlFiles`, `renderApplyScript`, and `probeUnmodeledIdentitiesPinned` from the package root and `@supabase/pg-delta/frontends` so library consumers can prune stale schema files, render a dry-run apply script, and probe unmodeled drift without importing `src/cli/**` or unexported frontend modules. `pgdelta` already used them internally.

--- a/.changeset/schema-first-cli-frontend-reexports.md
+++ b/.changeset/schema-first-cli-frontend-reexports.md
@@ -3,3 +3,5 @@
 ---
 
 Export `pruneStaleSqlFiles`, `renderApplyScript`, and `probeUnmodeledIdentitiesPinned` from the package root and `@supabase/pg-delta/frontends` so library consumers can prune stale schema files, render a dry-run apply script, and probe unmodeled drift without importing `src/cli/**` or unexported frontend modules. `pgdelta` already used them internally.
+
+`pruneStaleSqlFiles` now resolves relative `keep`/`previouslyOwned` entries against `outRoot` (absolute entries are unchanged), so a consumer passing outRoot-relative paths cannot misread kept files as out-of-set — which under `pruneUnmanaged` would have deleted them.

--- a/packages/pg-delta/src/frontends/index.ts
+++ b/packages/pg-delta/src/frontends/index.ts
@@ -49,6 +49,13 @@ export {
   type ReconciledSchemaOptions,
 } from "./schema-plan.ts";
 
+// Schema-first CLI helpers: prune owned stale .sql, dry-run apply SQL, unmodeled-drift probe.
+export { pruneStaleSqlFiles } from "./prune-sql-files.ts";
+export { renderApplyScript } from "./render-apply-script.ts";
+export { probeUnmodeledIdentitiesPinned } from "./schema-plan.ts";
+export type { ApplyTimeoutOptions } from "../apply/apply-preamble.ts";
+export type { UnmodeledIdentities } from "../extract/unmodeled.ts";
+
 export {
   renderPlanFiles,
   isDestructiveAction,

--- a/packages/pg-delta/src/frontends/prune-sql-files.test.ts
+++ b/packages/pg-delta/src/frontends/prune-sql-files.test.ts
@@ -212,6 +212,42 @@ describe("pruneStaleSqlFiles", () => {
     },
   );
 
+  test("keep and previouslyOwned entries may be relative to outRoot", () => {
+    // Public-API hardening: the manifest and internal callers use absolute
+    // paths, but a library consumer passing outRoot-relative entries must get
+    // the same semantics — not have every file misread as out-of-set.
+    const kept = write("schemas/app/tables/kept.sql");
+    const stale = write("schemas/app/tables/dropped.sql");
+    const { removed, unmanaged } = pruneStaleSqlFiles(
+      root,
+      new Set(["schemas/app/tables/kept.sql"]),
+      new Set([
+        "schemas/app/tables/kept.sql",
+        "schemas/app/tables/dropped.sql",
+      ]),
+      false,
+    );
+    expect(removed).toEqual([stale]);
+    expect(unmanaged).toEqual([]);
+    expect(existsSync(kept)).toBe(true);
+    expect(existsSync(stale)).toBe(false);
+  });
+
+  test("pruneUnmanaged with relative keep entries must not delete kept files", () => {
+    // The sharp edge that motivated the normalization: a relative keep set plus
+    // pruneUnmanaged=true previously matched nothing and deleted the whole tree.
+    const kept = write("kept.sql");
+    const { removed, unmanaged } = pruneStaleSqlFiles(
+      root,
+      new Set(["kept.sql"]),
+      undefined,
+      true,
+    );
+    expect(removed).toEqual([]);
+    expect(unmanaged).toEqual([]);
+    expect(existsSync(kept)).toBe(true);
+  });
+
   test("a NESTED _custom/ directory is ordinary managed space", () => {
     // only the ROOT-level `_custom` is reserved (one auditable location).
     const nestedCustom = write("schemas/app/_custom/x.sql");

--- a/packages/pg-delta/src/frontends/prune-sql-files.ts
+++ b/packages/pg-delta/src/frontends/prune-sql-files.ts
@@ -78,7 +78,11 @@ function collectSqlCandidates(
  * A file present in `previouslyOwned` is a stale owned file and is DELETED
  * (returned under `removed`); any other `.sql` is `unmanaged` and left on disk
  * unless `pruneUnmanaged` is true (then it is deleted too and moved to
- * `removed`, and `unmanaged` comes back empty). `previouslyOwned` is `undefined`
+ * `removed`, and `unmanaged` comes back empty). Entries in `keep` and
+ * `previouslyOwned` may be absolute or relative; relative entries are resolved
+ * against `outRoot` (a relative entry that never matched would silently misread
+ * kept files as out-of-set — and delete them under `pruneUnmanaged`).
+ * `previouslyOwned` is `undefined`
  * when the previous manifest is absent or recorded no `files` list — then every
  * out-of-set `.sql` is unmanaged. A missing `outRoot` (first export) scans
  * nothing; any OTHER scan failure (EACCES, EIO) is raised rather than reported as
@@ -92,6 +96,18 @@ export function pruneStaleSqlFiles(
   previouslyOwned: ReadonlySet<string> | undefined,
   pruneUnmanaged: boolean,
 ): { removed: string[]; unmanaged: string[] } {
+  // Anchor everything to one absolute frame before comparing: scan paths are
+  // resolved against outRoot, so keep/previouslyOwned entries must live in the
+  // same frame or membership tests are meaningless (resolve() leaves absolute
+  // entries untouched).
+  outRoot = resolve(outRoot);
+  const keepResolved = new Set(
+    Array.from(keep, (path) => resolve(outRoot, path)),
+  );
+  const ownedResolved =
+    previouslyOwned === undefined
+      ? undefined
+      : new Set(Array.from(previouslyOwned, (path) => resolve(outRoot, path)));
   // The reserved subtree is never even walked, so a manifest that (impossibly —
   // writeExportFiles guards the write) claims a `_custom/` path still cannot turn
   // the pruner into a deleter in there.
@@ -101,14 +117,14 @@ export function pruneStaleSqlFiles(
   const unmanaged: string[] = [];
   for (const entry of entries) {
     const full = resolve(outRoot, entry);
-    if (keep.has(full)) continue;
+    if (keepResolved.has(full)) continue;
     try {
       if (!statSync(full).isFile()) continue;
     } catch (error) {
       if (isMissing(error)) continue; // vanished between readdir and stat, or a dangling symlink
       throw error;
     }
-    if (previouslyOwned?.has(full)) {
+    if (ownedResolved?.has(full)) {
       rmSync(full);
       removed.push(full);
     } else if (pruneUnmanaged) {

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -63,6 +63,12 @@ import {
  * its path for exactly this reason; the drift probe must match it, via a
  * short, dedicated transaction so the pool's OTHER borrowers keep their own
  * default path (`SET LOCAL` is discarded on COMMIT/ROLLBACK).
+ *
+ * @param major - The server's PostgreSQL major version (e.g. `17`); it selects
+ * which version-gated probes run. `ExtractResult.pgVersion` /
+ * `LoadResult.pgVersion` carry `server_version`, so
+ * `Number.parseInt(result.pgVersion, 10)` is the usual source (handles
+ * `"17.5"` and `"18beta1"` alike).
  */
 export async function probeUnmodeledIdentitiesPinned(
   pool: Pool,

--- a/packages/pg-delta/src/index.ts
+++ b/packages/pg-delta/src/index.ts
@@ -109,6 +109,12 @@ export {
   type PlanSchemaFilesResult,
   type PreparedSchemaFiles,
 } from "./frontends/schema-plan.ts";
+// Schema-first CLI helpers: prune owned stale .sql, dry-run apply SQL, unmodeled-drift probe.
+export { pruneStaleSqlFiles } from "./frontends/prune-sql-files.ts";
+export { renderApplyScript } from "./frontends/render-apply-script.ts";
+export { probeUnmodeledIdentitiesPinned } from "./frontends/schema-plan.ts";
+export type { ApplyTimeoutOptions } from "./apply/apply-preamble.ts";
+export type { UnmodeledIdentities } from "./extract/unmodeled.ts";
 export {
   renderPlanFiles,
   isDestructiveAction,

--- a/packages/pg-delta/src/public-api.test.ts
+++ b/packages/pg-delta/src/public-api.test.ts
@@ -12,8 +12,12 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 import * as root from "./index.ts";
+import * as frontends from "./frontends/index.ts";
 import * as integrations from "./integrations/index.ts";
 import * as planSubpath from "./plan/plan.ts";
+import { pruneStaleSqlFiles } from "./frontends/prune-sql-files.ts";
+import { renderApplyScript } from "./frontends/render-apply-script.ts";
+import { probeUnmodeledIdentitiesPinned } from "./frontends/schema-plan.ts";
 
 describe("public API surface", () => {
   test("root re-exports the headline profile API", () => {
@@ -67,6 +71,25 @@ describe("public API surface", () => {
     expect(entry?.bun).toBe("./src/integrations/index.ts");
     expect(entry?.import).toBe("./dist/integrations/index.js");
     expect(entry?.types).toBe("./dist/integrations/index.d.ts");
+  });
+
+  test("root and frontends re-export schema-first CLI helpers", () => {
+    expect(typeof root.pruneStaleSqlFiles).toBe("function");
+    expect(typeof root.renderApplyScript).toBe("function");
+    expect(typeof root.probeUnmodeledIdentitiesPinned).toBe("function");
+    expect(root.pruneStaleSqlFiles).toBe(pruneStaleSqlFiles);
+    expect(root.renderApplyScript).toBe(renderApplyScript);
+    expect(root.probeUnmodeledIdentitiesPinned).toBe(
+      probeUnmodeledIdentitiesPinned,
+    );
+    expect(typeof frontends.pruneStaleSqlFiles).toBe("function");
+    expect(typeof frontends.renderApplyScript).toBe("function");
+    expect(typeof frontends.probeUnmodeledIdentitiesPinned).toBe("function");
+    expect(frontends.pruneStaleSqlFiles).toBe(pruneStaleSqlFiles);
+    expect(frontends.renderApplyScript).toBe(renderApplyScript);
+    expect(frontends.probeUnmodeledIdentitiesPinned).toBe(
+      probeUnmodeledIdentitiesPinned,
+    );
   });
 
   // The build is ESM-only (package `type: module`, NodeNext output). A `require`


### PR DESCRIPTION
## Summary

- Schema-first CLI enablement **WP3b** ([plan](docs/roadmap/schema-first-cli-enablement.md)): re-export `pruneStaleSqlFiles`, `renderApplyScript`, and `probeUnmodeledIdentitiesPinned` from the package root and `@supabase/pg-delta/frontends`.
- Also export `ApplyTimeoutOptions` and `UnmodeledIdentities` so callers can type those signatures. `pgdelta` already used the helpers internally; this is the library surface the Supabase CLI needs for schema pull prune/summary, dry-run apply SQL, and unmodeled-drift probing.
- Follows #414 (WP3a classification). Does **not** export `writeExportFiles` (staging / unmanaged policy stay CLI-owned).

## Test plan

- [x] RED: `bun test src/public-api.test.ts` — `typeof root.pruneStaleSqlFiles` was `"undefined"`
- [x] GREEN: same test plus `prune-sql-files.test.ts` / `render-apply-script.test.ts` (23 pass)
- [x] Re-ran `public-api.test.ts` after merging `main` (#414) — 8 pass
- [ ] CI on this PR

Follow-up (not this PR): WP3c `Segment` + `planSegments(plan)`.