### PR TITLE
feat(pg-delta): require a stable planId content hash on every plan

### DIFF
--- a/.changeset/plan-id-content-hash.md
+++ b/.changeset/plan-id-content-hash.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Require `Plan.planId`, a SHA-256 content hash over the plan-bound approval ingredients (format/engine version, source/target fingerprints, accepted renames, the ordered action list, and profile/scope/policy). `plan()` stamps it; `parsePlan` and `apply()` refuse a missing or mismatching digest. Stale artifacts without `planId` must be re-planned — they are never silently upgraded.

--- a/.changeset/plan-id-content-hash.md
+++ b/.changeset/plan-id-content-hash.md
@@ -2,4 +2,4 @@
 "@supabase/pg-delta": minor
 ---
 
-Require `Plan.planId`, a SHA-256 content hash over the plan-bound approval ingredients (format/engine version, source/target fingerprints, accepted renames, the ordered action list, and profile/scope/policy). `plan()` stamps it; `parsePlan` and `apply()` refuse a missing or mismatching digest. Stale artifacts without `planId` must be re-planned — they are never silently upgraded.
+Require `Plan.planId`, a SHA-256 content hash over the plan-bound approval ingredients (format/engine version, source/target fingerprints, the preamble, accepted renames, the ordered action list, and profile/scope/policy). `plan()` stamps it; `parsePlan` and `apply()` refuse a missing or mismatching digest. Stale artifacts without `planId` must be re-planned — they are never silently upgraded.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1021,3 +1021,44 @@ policy.
   rebuild (rename + rebuild of the same object in one plan is currently
   unexpressible). Disproportionate to the pg_net cycle fix; needs its own
   RED coverage for the rename × forced-rebuild matrix.
+
+## PR #418 review triage (Codex) — planId content hash
+
+Context: PR #418 adds required `Plan.planId` (WP1). Threat model: planId is an
+**integrity check against accidental divergence** (stale/hand-edited artifacts
+drifting from what was approved), NOT a security boundary — `computePlanId` is
+a public export, so a deliberate artifact editor can always re-stamp. Findings
+whose only failure scenario is a malicious editor gain nothing from hashing.
+
+Fixed in the PR (rounds 1–3): preamble bound into the digest (it is executed
+per segment — run content); `ENGINE_VERSION` bumped to 0.3.0 so pre-planId
+executors fail closed on stamped artifacts; `assertPlanId` preflight added to
+`provePlan()` so every public execution path validates before clone work.
+
+- **Deferred — bind `projectionAudit` into planId (Codex P1, round 2).** The
+  audit is gate INPUT under `prove --strict-audit`, so it is the one remaining
+  field that neither fails loud nor is reporting-only. Not hashed yet because
+  (a) the only exploit path is a deliberate editor (re-stampable → no
+  adversarial gain), and (b) `parsePlan` runs `normalizeProjectionAudit`
+  BEFORE the digest check, so inclusion requires proving normalize-stability
+  between `plan()` output and re-parsed artifacts — a false "re-plan" reject
+  is the worst failure mode this feature can have. If revisited: hash the
+  NORMALIZED form on both sides and extend the round-trip suite with
+  audit-bearing plans.
+- **Declined — bind `source.endpointHash`/`source.identity` into planId
+  (Codex P1, round 2).** These are transport stamps the CLI attaches AFTER
+  `plan()` precisely so planId stays a transport-independent content
+  identity (same plan against two replicas must share an id). They defend
+  against accidental endpoint mixups (`prove --clone "$SOURCE_URL"`), which
+  do not involve artifact editing; the described bypass requires a deliberate
+  editor, who re-stamps.
+- **Declined — bind `baseline.digest` into planId (Codex P2, round 2).**
+  Baseline already fails loud on accidental drift: apply/prove reconcile the
+  live-resolved baseline against the stamped digest (even under `--force`).
+  The described bypass needs a deliberate two-step edit — re-stampable.
+- **Declined — `major` changeset (Codex P1, round 1).** The package is on a
+  0.x pre/alpha train (every bump releases as `-alpha.N`); the repo has never
+  queued a `major`, and doing so would promote pg-delta to 1.0.0 the day
+  `changeset pre exit` runs — a release-train side effect worse than the
+  labeling nit. Breaking-in-alpha ships as `minor` here by established
+  practice.

--- a/docs/roadmap/schema-first-cli-enablement.md
+++ b/docs/roadmap/schema-first-cli-enablement.md
@@ -1,6 +1,6 @@
 # Schema-first CLI enablement
 
-- **Status**: In progress — WP3a shipping; remaining WPs sequenced below.
+- **Status**: In progress — WP1 shipping; remaining WPs sequenced below.
 - **Date**: 2026-08-13
 - **Source**: RFC *Schema-First Database Development* (Linear
   `rfc-schema-first-database-development-532de5a122d5`, 2026-08-12, **revised
@@ -50,19 +50,22 @@ flattened to rendered SQL:
 **Inventory corrections vs the RFC text:**
 
 - Plan artifacts already stamp `formatVersion` + `engineVersion`; `parsePlan`
-  and `apply()` refuse a mismatch. WP1's remaining work is `Plan.planId`.
+  and `apply()` refuse a mismatch. WP1 adds required `Plan.planId` (this change).
 - `segmentActions()` is already exported from `@supabase/pg-delta/apply`. WP3
   still needs the `Segment` type, a `planSegments(plan)` helper, and
   root/`frontends` re-exports, plus `renderApplyScript`.
 
 ---
 
-## WP1 — 🟠 Stable plan identifier
+## WP1 — **this change** Stable plan identifier
 
-Add `Plan.planId`: a content hash over source fingerprint, desired
-fingerprint, accepted renames, an action-list digest, profile/scope/policy,
-and engine + artifact format version. `parsePlan` verifies it. Version
-fail-closed is already there.
+`Plan.planId` is a required SHA-256 content hash over `formatVersion`,
+`engineVersion`, source/target fingerprints, `acceptedRenames`, the ordered
+action list, and `profile`/`scope`/`policy`. `plan()` stamps it via
+`stampPlanId`; `parsePlan` and `apply()` refuse a missing or mismatching
+digest (`re-plan` — never silently upgrade). Version fail-closed for
+`formatVersion`/`engineVersion` was already in place. Stale artifacts
+without `planId` must be re-planned.
 
 ---
 
@@ -82,7 +85,7 @@ Library frontends accept pools and SQL files; they return typed data. No
 
 | Slice | Status | Notes |
 |---|---|---|
-| **WP3a** export file classification | **this change** | Pure `classifySqlFiles` / `classifySqlContent`. Does **not** export `writeExportFiles` (writes, scaffolds `_custom/README.md`, refuses unmanaged). |
+| **WP3a** export file classification | shipped (#414) | Pure `classifySqlFiles` / `classifySqlContent`. Does **not** export `writeExportFiles` (writes, scaffolds `_custom/README.md`, refuses unmanaged). |
 | **WP3b** | next | Re-export `pruneStaleSqlFiles`, `renderApplyScript`, `probeUnmodeledIdentitiesPinned`. |
 | **WP3c** | | Export `Segment` + `planSegments(plan)` from root/`frontends`. |
 | **WP3d** | | Move `STRICT_COVERAGE_CODES` + `hasBlockingDiagnostics` into a frontend; leave `printDiagnostics` / `exitIfBlocking` in the CLI. |

--- a/docs/roadmap/schema-first-cli-enablement.md
+++ b/docs/roadmap/schema-first-cli-enablement.md
@@ -60,8 +60,9 @@ flattened to rendered SQL:
 ## WP1 — **this change** Stable plan identifier
 
 `Plan.planId` is a required SHA-256 content hash over `formatVersion`,
-`engineVersion`, source/target fingerprints, `acceptedRenames`, the ordered
-action list, and `profile`/`scope`/`policy`. `plan()` stamps it via
+`engineVersion`, source/target fingerprints, the `preamble` (executed per
+segment by apply — run content, like the action list), `acceptedRenames`,
+the ordered action list, and `profile`/`scope`/`policy`. `plan()` stamps it via
 `stampPlanId`; `parsePlan` and `apply()` refuse a missing or mismatching
 digest (`re-plan` — never silently upgrade). Version fail-closed for
 `formatVersion`/`engineVersion` was already in place. Stale artifacts

--- a/packages/pg-delta/src/apply/apply.test.ts
+++ b/packages/pg-delta/src/apply/apply.test.ts
@@ -192,7 +192,7 @@ function planWithPreamble(
   transactionality: Action["transactionality"],
   preamble: Plan["preamble"],
 ): Plan {
-  return { ...planWithAction(transactionality), preamble };
+  return stampPlanId({ ...planWithAction(transactionality), preamble });
 }
 
 function segmentOutcomes(events: ApplyEvent[]): string[] {

--- a/packages/pg-delta/src/apply/apply.test.ts
+++ b/packages/pg-delta/src/apply/apply.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import type { Pool } from "pg";
 import type { Action, Plan } from "../plan/plan.ts";
-import { ENGINE_VERSION } from "../plan/plan.ts";
+import { ENGINE_VERSION, stampPlanId } from "../plan/plan.ts";
 import { apply, type ApplyEvent, segmentActions } from "./apply.ts";
 
 const txn = (newSegmentBefore = false) => ({
@@ -69,7 +69,7 @@ describe("segmentActions", () => {
 });
 
 function planWithAction(transactionality: Action["transactionality"]): Plan {
-  return {
+  return stampPlanId({
     formatVersion: 1,
     engineVersion: ENGINE_VERSION,
     source: { fingerprint: "source" },
@@ -99,7 +99,7 @@ function planWithAction(transactionality: Action["transactionality"]): Plan {
       nonTransactionalActions: transactionality === "nonTransactional" ? 1 : 0,
       lockClasses: {},
     },
-  } as Plan;
+  });
 }
 
 async function expectObserverLatencyExcluded(
@@ -444,7 +444,7 @@ describe("apply plan integrity", () => {
         throw new Error("must not connect");
       },
     } as unknown as Pool;
-    const thePlan = {
+    const thePlan = stampPlanId({
       formatVersion: 1,
       engineVersion: ENGINE_VERSION,
       source: { fingerprint: "a".repeat(64) },
@@ -474,7 +474,7 @@ describe("apply plan integrity", () => {
         nonTransactionalActions: 0,
         lockClasses: { accessExclusive: 1 },
       },
-    } satisfies Plan;
+    });
 
     let error: unknown;
     try {
@@ -486,6 +486,99 @@ describe("apply plan integrity", () => {
     expect((error as Error).message).toMatch(
       /destroys.*table:app\.t.*dataLoss:none/,
     );
+    expect(connected).toBe(false);
+  });
+
+  test("rejects a missing planId before connecting or mutating", async () => {
+    let connected = false;
+    const target = {
+      connect: async () => {
+        connected = true;
+        throw new Error("must not connect");
+      },
+    } as unknown as Pool;
+    const stamped = stampPlanId({
+      formatVersion: 1,
+      engineVersion: ENGINE_VERSION,
+      source: { fingerprint: "a".repeat(64) },
+      target: { fingerprint: "b".repeat(64) },
+      preamble: [],
+      deltas: [],
+      filteredDeltas: [],
+      renameCandidates: [],
+      actions: [],
+      safetyReport: {
+        destructiveActions: 0,
+        rewriteRiskActions: 0,
+        nonTransactionalActions: 0,
+        lockClasses: {},
+      },
+    });
+    const missing = { ...stamped, planId: undefined } as unknown as Plan;
+    let error: unknown;
+    try {
+      await apply(missing, target, { fingerprintGate: false });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/planId/);
+    expect((error as Error).message).toMatch(/re-plan/);
+    expect(connected).toBe(false);
+  });
+
+  test("rejects a mismatching planId before connecting or mutating", async () => {
+    let connected = false;
+    const target = {
+      connect: async () => {
+        connected = true;
+        throw new Error("must not connect");
+      },
+    } as unknown as Pool;
+    const stamped = stampPlanId({
+      formatVersion: 1,
+      engineVersion: ENGINE_VERSION,
+      source: { fingerprint: "a".repeat(64) },
+      target: { fingerprint: "b".repeat(64) },
+      preamble: [],
+      deltas: [],
+      filteredDeltas: [],
+      renameCandidates: [],
+      actions: [],
+      safetyReport: {
+        destructiveActions: 0,
+        rewriteRiskActions: 0,
+        nonTransactionalActions: 0,
+        lockClasses: {},
+      },
+    });
+    const tampered: Plan = {
+      ...stamped,
+      actions: [
+        {
+          sql: "SELECT 1",
+          verb: "create",
+          produces: [],
+          consumes: [],
+          destroys: [],
+          releases: [],
+          transactionality: "transactional",
+          lockClass: "none",
+          newSegmentBefore: false,
+          dataLoss: "none",
+          rewriteRisk: false,
+        },
+      ],
+    };
+    let error: unknown;
+    try {
+      await apply(tampered, target, { fingerprintGate: false });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/planId/);
+    expect((error as Error).message).toMatch(/re-plan/);
     expect(connected).toBe(false);
   });
 });

--- a/packages/pg-delta/src/apply/apply.ts
+++ b/packages/pg-delta/src/apply/apply.ts
@@ -15,7 +15,7 @@
 import type { Pool } from "pg";
 import type { FactBase } from "../core/fact.ts";
 import { extract } from "../extract/extract.ts";
-import { ENGINE_VERSION, type Plan } from "../plan/plan.ts";
+import { ENGINE_VERSION, computePlanId, type Plan } from "../plan/plan.ts";
 import { assertDestructionMetadataIntegrity } from "../plan/safety.ts";
 import { reconstructManagedView } from "../policy/reconstruct.ts";
 import { buildApplyPreamble } from "./apply-preamble.ts";
@@ -200,6 +200,15 @@ export async function apply(
     throw new Error(
       `apply: plan was produced by engine ${thePlan.engineVersion}, this engine is ${ENGINE_VERSION} — re-plan`,
     );
+  }
+  if (
+    typeof thePlan.planId !== "string" ||
+    !/^[0-9a-f]{64}$/.test(thePlan.planId)
+  ) {
+    throw new Error("apply: missing or invalid planId — re-plan");
+  }
+  if (thePlan.planId !== computePlanId(thePlan)) {
+    throw new Error("apply: planId does not match contents — re-plan");
   }
   assertDestructionMetadataIntegrity(
     thePlan.actions,

--- a/packages/pg-delta/src/apply/apply.ts
+++ b/packages/pg-delta/src/apply/apply.ts
@@ -15,7 +15,8 @@
 import type { Pool } from "pg";
 import type { FactBase } from "../core/fact.ts";
 import { extract } from "../extract/extract.ts";
-import { ENGINE_VERSION, computePlanId, type Plan } from "../plan/plan.ts";
+import { assertPlanId } from "../plan/artifact.ts";
+import { ENGINE_VERSION, type Plan } from "../plan/plan.ts";
 import { assertDestructionMetadataIntegrity } from "../plan/safety.ts";
 import { reconstructManagedView } from "../policy/reconstruct.ts";
 import { buildApplyPreamble } from "./apply-preamble.ts";
@@ -201,15 +202,7 @@ export async function apply(
       `apply: plan was produced by engine ${thePlan.engineVersion}, this engine is ${ENGINE_VERSION} — re-plan`,
     );
   }
-  if (
-    typeof thePlan.planId !== "string" ||
-    !/^[0-9a-f]{64}$/.test(thePlan.planId)
-  ) {
-    throw new Error("apply: missing or invalid planId — re-plan");
-  }
-  if (thePlan.planId !== computePlanId(thePlan)) {
-    throw new Error("apply: planId does not match contents — re-plan");
-  }
+  assertPlanId(thePlan, "apply");
   assertDestructionMetadataIntegrity(
     thePlan.actions,
     thePlan.acceptedRenames,

--- a/packages/pg-delta/src/cli/commands/apply.test.ts
+++ b/packages/pg-delta/src/cli/commands/apply.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { serializePlan, stampPlanId } from "../../plan/artifact.ts";
 import { ENGINE_VERSION } from "../../plan/plan.ts";
 import { cmdApply } from "./apply.ts";
 import { UsageError } from "../flags.ts";
@@ -20,37 +21,39 @@ function destructivePlan(): string {
   const path = join(dir, "plan.json");
   writeFileSync(
     path,
-    JSON.stringify({
-      formatVersion: 1,
-      engineVersion: ENGINE_VERSION,
-      source: { fingerprint: "a".repeat(64) },
-      target: { fingerprint: "b".repeat(64) },
-      preamble: [],
-      deltas: [],
-      filteredDeltas: [],
-      renameCandidates: [],
-      safetyReport: {
-        destructiveActions: 0,
-        rewriteRiskActions: 0,
-        nonTransactionalActions: 0,
-        lockClasses: {},
-      },
-      actions: [
-        {
-          sql: "DROP TABLE app.t",
-          verb: "drop",
-          produces: [],
-          consumes: [],
-          destroys: [{ kind: "table", schema: "app", name: "t" }],
-          releases: [],
-          transactionality: "transactional",
-          lockClass: "accessExclusive",
-          newSegmentBefore: false,
-          dataLoss: "destructive",
-          rewriteRisk: false,
+    serializePlan(
+      stampPlanId({
+        formatVersion: 1,
+        engineVersion: ENGINE_VERSION,
+        source: { fingerprint: "a".repeat(64) },
+        target: { fingerprint: "b".repeat(64) },
+        preamble: [],
+        deltas: [],
+        filteredDeltas: [],
+        renameCandidates: [],
+        safetyReport: {
+          destructiveActions: 0,
+          rewriteRiskActions: 0,
+          nonTransactionalActions: 0,
+          lockClasses: {},
         },
-      ],
-    }),
+        actions: [
+          {
+            sql: "DROP TABLE app.t",
+            verb: "drop",
+            produces: [],
+            consumes: [],
+            destroys: [{ kind: "table", schema: "app", name: "t" }],
+            releases: [],
+            transactionality: "transactional",
+            lockClass: "accessExclusive",
+            newSegmentBefore: false,
+            dataLoss: "destructive",
+            rewriteRisk: false,
+          },
+        ],
+      }),
+    ),
   );
   return path;
 }

--- a/packages/pg-delta/src/cli/commands/prove.test.ts
+++ b/packages/pg-delta/src/cli/commands/prove.test.ts
@@ -24,6 +24,7 @@ import { connectionEndpointHash } from "../connection-safety.ts";
 import type { ProofCoverage } from "../../proof/prove.ts";
 import { buildFactBase } from "../../core/fact.ts";
 import { serializeSnapshot } from "../../core/snapshot.ts";
+import { serializePlan, stampPlanId } from "../../plan/artifact.ts";
 import { ENGINE_VERSION } from "../../plan/plan.ts";
 import { UsageError } from "../flags.ts";
 import type { ProofVerdict } from "../../proof/prove.ts";
@@ -872,19 +873,28 @@ describe("cmdProve — desired-snapshot profile reconciliation", () => {
     // a minimal, parse-valid plan artifact stamping the plan's profile id
     writeFileSync(
       planPath,
-      JSON.stringify({
-        formatVersion: 1,
-        engineVersion: ENGINE_VERSION,
-        actions: [],
-        deltas: [],
-        renameCandidates: [],
-        safetyReport: { level: "safe", findings: [] },
-        redactSecrets: true,
-        profile: { id: planProfileId },
-        source: { fingerprint: "a".repeat(64) },
-        target: { fingerprint: "b".repeat(64) },
-        ...(projectionAudit === undefined ? {} : { projectionAudit }),
-      }),
+      serializePlan(
+        stampPlanId({
+          formatVersion: 1,
+          engineVersion: ENGINE_VERSION,
+          preamble: [],
+          filteredDeltas: [],
+          actions: [],
+          deltas: [],
+          renameCandidates: [],
+          safetyReport: {
+            destructiveActions: 0,
+            rewriteRiskActions: 0,
+            nonTransactionalActions: 0,
+            lockClasses: {},
+          },
+          redactSecrets: true,
+          profile: { id: planProfileId },
+          source: { fingerprint: "a".repeat(64) },
+          target: { fingerprint: "b".repeat(64) },
+          ...(projectionAudit === undefined ? {} : { projectionAudit }),
+        }),
+      ),
       "utf8",
     );
     writeFileSync(

--- a/packages/pg-delta/src/cli/commands/render.test.ts
+++ b/packages/pg-delta/src/cli/commands/render.test.ts
@@ -10,8 +10,12 @@ import { existsSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { Action, Plan } from "../../plan/plan.ts";
-import { ENGINE_VERSION } from "../../plan/plan.ts";
+import {
+  ENGINE_VERSION,
+  stampPlanId,
+  type Action,
+  type Plan,
+} from "../../plan/plan.ts";
 import { serializePlan } from "../../plan/artifact.ts";
 import { cmdRender } from "./render.ts";
 
@@ -33,7 +37,7 @@ function action(overrides: Partial<Action>): Action {
 }
 
 function makePlan(actions: Action[]): Plan {
-  return {
+  return stampPlanId({
     formatVersion: 1,
     engineVersion: ENGINE_VERSION,
     source: { fingerprint: "a".repeat(64) },
@@ -49,7 +53,7 @@ function makePlan(actions: Action[]): Plan {
       nonTransactionalActions: 0,
       lockClasses: {},
     },
-  } as Plan;
+  });
 }
 
 /** A 3-segment plan: two commitBoundaryAfter actions force `_1`/`_2`/`_3`. */

--- a/packages/pg-delta/src/cli/render.test.ts
+++ b/packages/pg-delta/src/cli/render.test.ts
@@ -5,7 +5,7 @@
  * rendered files reflect exactly how the plan would be executed.
  */
 import { describe, expect, test } from "bun:test";
-import type { Action, Plan } from "../plan/plan.ts";
+import { stampPlanId, type Action, type Plan } from "../plan/plan.ts";
 import { renderPlan } from "./render.ts";
 
 function action(overrides: Partial<Action>): Action {
@@ -26,7 +26,7 @@ function action(overrides: Partial<Action>): Action {
 }
 
 function makePlan(overrides: Partial<Plan>): Plan {
-  return {
+  return stampPlanId({
     formatVersion: 1,
     engineVersion: "test",
     source: { fingerprint: "a" },
@@ -43,7 +43,7 @@ function makePlan(overrides: Partial<Plan>): Plan {
       lockClasses: {},
     },
     ...overrides,
-  } as Plan;
+  });
 }
 
 describe("renderPlan", () => {

--- a/packages/pg-delta/src/frontends/render-apply-script.test.ts
+++ b/packages/pg-delta/src/frontends/render-apply-script.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Action, Plan } from "../plan/plan.ts";
+import { stampPlanId, type Action, type Plan } from "../plan/plan.ts";
 import { renderApplyScript } from "./render-apply-script.ts";
 
 function action(
@@ -22,7 +22,7 @@ function action(
 }
 
 function planWithMixedSegments(): Plan {
-  return {
+  return stampPlanId({
     formatVersion: 1,
     engineVersion: "test",
     source: { fingerprint: "source" },
@@ -48,7 +48,7 @@ function planWithMixedSegments(): Plan {
       nonTransactionalActions: 1,
       lockClasses: {},
     },
-  } as Plan;
+  });
 }
 
 describe("renderApplyScript", () => {

--- a/packages/pg-delta/src/frontends/render-plan-files.test.ts
+++ b/packages/pg-delta/src/frontends/render-plan-files.test.ts
@@ -5,7 +5,7 @@
  * rendered files reflect exactly how the plan would be executed.
  */
 import { describe, expect, test } from "bun:test";
-import type { Action, Plan } from "../plan/plan.ts";
+import { stampPlanId, type Action, type Plan } from "../plan/plan.ts";
 import { renderPlanFiles } from "./render-plan-files.ts";
 
 function action(overrides: Partial<Action>): Action {
@@ -26,7 +26,7 @@ function action(overrides: Partial<Action>): Action {
 }
 
 function makePlan(overrides: Partial<Plan>): Plan {
-  return {
+  return stampPlanId({
     formatVersion: 1,
     engineVersion: "test",
     source: { fingerprint: "a" },
@@ -43,7 +43,7 @@ function makePlan(overrides: Partial<Plan>): Plan {
       lockClasses: {},
     },
     ...overrides,
-  } as Plan;
+  });
 }
 
 describe("renderPlanFiles", () => {

--- a/packages/pg-delta/src/index.ts
+++ b/packages/pg-delta/src/index.ts
@@ -53,7 +53,12 @@ export {
   type ProjectionAuditSubject,
   type ProjectionAuditSuppression,
 } from "./plan/plan.ts";
-export { serializePlan, parsePlan } from "./plan/artifact.ts";
+export {
+  serializePlan,
+  parsePlan,
+  computePlanId,
+  stampPlanId,
+} from "./plan/artifact.ts";
 export { type RenameCandidate, type RenameMode } from "./plan/renames.ts";
 export { type LockClass } from "./plan/locks.ts";
 

--- a/packages/pg-delta/src/plan/artifact.test.ts
+++ b/packages/pg-delta/src/plan/artifact.test.ts
@@ -1,10 +1,16 @@
 /** Plan artifact v1: lossless round-trip + version refusals (stage 6). */
 import { describe, expect, test } from "bun:test";
-import { parsePlan, serializePlan } from "./artifact.ts";
-import { ENGINE_VERSION, type Plan } from "./plan.ts";
+import { buildFactBase } from "../core/fact.ts";
+import {
+  parsePlan,
+  serializePlan,
+  computePlanId,
+  stampPlanId,
+} from "./artifact.ts";
+import { ENGINE_VERSION, plan, type Plan } from "./plan.ts";
 import { normalizeProjectionAudit } from "../policy/reconstruct.ts";
 
-const samplePlan: Plan = {
+const samplePlan: Plan = stampPlanId({
   formatVersion: 1,
   engineVersion: ENGINE_VERSION,
   source: { fingerprint: "a".repeat(64) },
@@ -42,7 +48,7 @@ const samplePlan: Plan = {
     nonTransactionalActions: 0,
     lockClasses: { none: 1 },
   },
-};
+});
 
 describe("plan artifact v1", () => {
   test("round-trips losslessly, including bigint payload values", () => {
@@ -54,14 +60,14 @@ describe("plan artifact v1", () => {
   });
 
   test("round-trips an inlined applier capability (follow-up 2)", () => {
-    const withCapability: Plan = {
+    const withCapability: Plan = stampPlanId({
       ...samplePlan,
       capability: {
         role: "app_owner",
         isSuperuser: false,
         memberOf: ["app_owner", "readers"],
       },
-    };
+    });
     const parsed = parsePlan(serializePlan(withCapability));
     expect(parsed.capability).toEqual({
       role: "app_owner",
@@ -71,7 +77,10 @@ describe("plan artifact v1", () => {
   });
 
   test("round-trips the stamped integration profile id (P2 follow-up)", () => {
-    const withProfile: Plan = { ...samplePlan, profile: { id: "supabase" } };
+    const withProfile: Plan = stampPlanId({
+      ...samplePlan,
+      profile: { id: "supabase" },
+    });
     const parsed = parsePlan(serializePlan(withProfile));
     expect(parsed.profile).toEqual({ id: "supabase" });
   });
@@ -83,7 +92,7 @@ describe("plan artifact v1", () => {
 
   test("round-trips the additive projection audit", () => {
     const schemaId = { kind: "schema" as const, name: "hidden" };
-    const withAudit: Plan = {
+    const withAudit: Plan = stampPlanId({
       ...samplePlan,
       projectionAudit: {
         entries: [
@@ -111,7 +120,7 @@ describe("plan artifact v1", () => {
           baseline: 0,
         },
       },
-    };
+    });
     expect(parsePlan(serializePlan(withAudit)).projectionAudit).toEqual(
       withAudit.projectionAudit,
     );
@@ -124,7 +133,7 @@ describe("plan artifact v1", () => {
   });
 
   test("round-trips an opaque PostgreSQL source-lineage stamp", () => {
-    const stamped: Plan = {
+    const stamped: Plan = stampPlanId({
       ...samplePlan,
       source: {
         ...samplePlan.source,
@@ -135,7 +144,7 @@ describe("plan artifact v1", () => {
           databaseHash: "e".repeat(64),
         },
       },
-    };
+    });
 
     expect(parsePlan(serializePlan(stamped)).source).toEqual(stamped.source);
   });
@@ -649,9 +658,51 @@ describe("plan artifact v1", () => {
     // a plan produced with --unsafe-show-secrets fingerprints over unredacted
     // secrets; the artifact must carry redactSecrets:false so apply/prove
     // re-extract the target the same way (otherwise the fingerprint gate fails).
-    const unsafe: Plan = { ...samplePlan, redactSecrets: false };
+    const unsafe: Plan = stampPlanId({ ...samplePlan, redactSecrets: false });
     expect(parsePlan(serializePlan(unsafe)).redactSecrets).toBe(false);
     expect(parsePlan(serializePlan(samplePlan)).redactSecrets).toBeUndefined();
+  });
+
+  test("parsePlan refuses a missing planId", () => {
+    const artifact = JSON.parse(serializePlan(samplePlan)) as Record<
+      string,
+      unknown
+    >;
+    delete artifact["planId"];
+    const json = JSON.stringify(artifact);
+    expect(() => parsePlan(json)).toThrow(/planId/);
+    expect(() => parsePlan(json)).toThrow(/re-plan/);
+  });
+
+  test("parsePlan refuses a tampered action list (planId mismatch)", () => {
+    const artifact = JSON.parse(serializePlan(samplePlan)) as Record<
+      string,
+      unknown
+    >;
+    (artifact["actions"] as Array<Record<string, unknown>>)[0]!["sql"] =
+      "DROP SCHEMA app CASCADE";
+    const json = JSON.stringify(artifact);
+    expect(() => parsePlan(json)).toThrow(/planId/);
+    expect(() => parsePlan(json)).toThrow(/re-plan/);
+  });
+
+  test("stampPlanId is stable for the same ingredients and moves with source fingerprint", () => {
+    const again = stampPlanId({ ...samplePlan });
+    expect(again.planId).toBe(samplePlan.planId);
+    expect(again.planId).toMatch(/^[0-9a-f]{64}$/);
+    const moved = stampPlanId({
+      ...samplePlan,
+      source: { fingerprint: "c".repeat(64) },
+    });
+    expect(moved.planId).not.toBe(samplePlan.planId);
+    expect(computePlanId(moved)).toBe(moved.planId);
+  });
+
+  test("plan() stamps a planId matching the ingredients", () => {
+    const empty = buildFactBase([], []);
+    const thePlan = plan(empty, empty);
+    expect(thePlan.planId).toMatch(/^[0-9a-f]{64}$/);
+    expect(computePlanId(thePlan)).toBe(thePlan.planId);
   });
 
   test("rejects unknown formatVersion", () => {

--- a/packages/pg-delta/src/plan/artifact.test.ts
+++ b/packages/pg-delta/src/plan/artifact.test.ts
@@ -686,6 +686,22 @@ describe("plan artifact v1", () => {
     expect(() => parsePlan(json)).toThrow(/re-plan/);
   });
 
+  test("parsePlan refuses a tampered preamble (planId mismatch)", () => {
+    // the preamble is executed per segment by apply, so an edited artifact
+    // that changes it must not verify against the original digest
+    const artifact = JSON.parse(serializePlan(samplePlan)) as Record<
+      string,
+      unknown
+    >;
+    (artifact["preamble"] as Array<Record<string, unknown>>).push({
+      name: "check_function_bodies",
+      value: "off",
+    });
+    const json = JSON.stringify(artifact);
+    expect(() => parsePlan(json)).toThrow(/planId/);
+    expect(() => parsePlan(json)).toThrow(/re-plan/);
+  });
+
   test("stampPlanId is stable for the same ingredients and moves with source fingerprint", () => {
     const again = stampPlanId({ ...samplePlan });
     expect(again.planId).toBe(samplePlan.planId);

--- a/packages/pg-delta/src/plan/artifact.ts
+++ b/packages/pg-delta/src/plan/artifact.ts
@@ -257,6 +257,8 @@ function reviver(_key: string, value: unknown): unknown {
  * includes `planId` itself. `undefined` profile/scope/policy (direct
  * library / cluster-default) are omitted by canonicalize, not replaced
  * with invented strings. Absent `acceptedRenames` hashes as `[]`.
+ * The preamble is hashed because apply executes it per segment — it is
+ * run content, exactly like the action list, not reporting metadata.
  */
 export function computePlanId(plan: Omit<Plan, "planId">): string {
   const payload: Payload = {
@@ -264,6 +266,10 @@ export function computePlanId(plan: Omit<Plan, "planId">): string {
     engineVersion: plan.engineVersion,
     source: { fingerprint: plan.source.fingerprint },
     target: { fingerprint: plan.target.fingerprint },
+    preamble: plan.preamble.map((entry) => ({
+      name: entry.name,
+      value: entry.value,
+    })),
     acceptedRenames: plan.acceptedRenames ?? [],
     actions: plan.actions.map((action) => ({
       sql: action.sql,
@@ -288,6 +294,21 @@ export function computePlanId(plan: Omit<Plan, "planId">): string {
 /** Attach a freshly computed `planId`. Does not include the digest in its own hash. */
 export function stampPlanId(plan: Omit<Plan, "planId">): Plan {
   return { ...plan, planId: computePlanId(plan) };
+}
+
+/**
+ * Refuse a missing, malformed, or mismatching `planId`. Shared by
+ * `parsePlan` (artifact path) and `apply` (programmatic path — catches a
+ * plan mutated after `plan()` stamped it). `context` prefixes the error
+ * ("plan artifact" / "apply") so the two sites cannot drift.
+ */
+export function assertPlanId(thePlan: Plan, context: string): void {
+  if (typeof thePlan.planId !== "string" || !SHA256.test(thePlan.planId)) {
+    throw new Error(`${context}: missing or invalid planId — re-plan`);
+  }
+  if (thePlan.planId !== computePlanId(thePlan)) {
+    throw new Error(`${context}: planId does not match contents — re-plan`);
+  }
 }
 
 export function serializePlan(thePlan: Plan): string {
@@ -368,6 +389,15 @@ export function parsePlan(json: string): Plan {
   }
   exactKeys(artifact.target, ["fingerprint"], [], "target");
   sha256Field(artifact.target, "fingerprint", "target");
+  // the preamble is executed per segment by apply and joins the planId hash,
+  // so its shape must be pinned before computePlanId dereferences it
+  if (!Array.isArray(artifact.preamble)) fail("preamble", "an array");
+  artifact.preamble.forEach((entry, index) => {
+    if (!record(entry)) fail(`preamble[${index}]`, "an object");
+    exactKeys(entry, ["name", "value"], [], `preamble[${index}]`);
+    stringField(entry, "name", `preamble[${index}]`);
+    stringField(entry, "value", `preamble[${index}]`);
+  });
   if (artifact.projectionAudit !== undefined) {
     try {
       artifact.projectionAudit = normalizeProjectionAudit(
@@ -379,12 +409,6 @@ export function parsePlan(json: string): Plan {
       );
     }
   }
-  if (typeof artifact.planId !== "string" || !SHA256.test(artifact.planId)) {
-    throw new Error("plan artifact: missing or invalid planId — re-plan");
-  }
-  const computed = computePlanId(artifact as Omit<Plan, "planId">);
-  if (artifact.planId !== computed) {
-    throw new Error("plan artifact: planId does not match contents — re-plan");
-  }
+  assertPlanId(artifact as Plan, "plan artifact");
   return artifact as Plan;
 }

--- a/packages/pg-delta/src/plan/artifact.ts
+++ b/packages/pg-delta/src/plan/artifact.ts
@@ -8,6 +8,7 @@
  * Payload values can contain bigints (sequence bounds); they are encoded
  * as {"$bigint": "…"} exactly like fact snapshots (stage 1).
  */
+import { contentHash, type Payload } from "../core/hash.ts";
 import { ALL_FACT_KINDS, type StableId } from "../core/stable-id.ts";
 import { normalizeProjectionAudit } from "../policy/reconstruct.ts";
 import { ENGINE_VERSION, type Action, type Plan } from "./plan.ts";
@@ -251,6 +252,44 @@ function reviver(_key: string, value: unknown): unknown {
   return value;
 }
 
+/**
+ * SHA-256 content hash over the plan-bound approval ingredients. Never
+ * includes `planId` itself. `undefined` profile/scope/policy (direct
+ * library / cluster-default) are omitted by canonicalize, not replaced
+ * with invented strings. Absent `acceptedRenames` hashes as `[]`.
+ */
+export function computePlanId(plan: Omit<Plan, "planId">): string {
+  const payload: Payload = {
+    formatVersion: plan.formatVersion,
+    engineVersion: plan.engineVersion,
+    source: { fingerprint: plan.source.fingerprint },
+    target: { fingerprint: plan.target.fingerprint },
+    acceptedRenames: plan.acceptedRenames ?? [],
+    actions: plan.actions.map((action) => ({
+      sql: action.sql,
+      verb: action.verb,
+      produces: action.produces,
+      consumes: action.consumes,
+      destroys: action.destroys,
+      releases: action.releases,
+      transactionality: action.transactionality,
+      lockClass: action.lockClass,
+      newSegmentBefore: action.newSegmentBefore,
+      dataLoss: action.dataLoss,
+      rewriteRisk: action.rewriteRisk,
+    })),
+    profile: plan.profile,
+    scope: plan.scope,
+    policy: plan.policy as Payload | undefined,
+  };
+  return contentHash(payload);
+}
+
+/** Attach a freshly computed `planId`. Does not include the digest in its own hash. */
+export function stampPlanId(plan: Omit<Plan, "planId">): Plan {
+  return { ...plan, planId: computePlanId(plan) };
+}
+
 export function serializePlan(thePlan: Plan): string {
   return JSON.stringify(thePlan, replacer, 2);
 }
@@ -339,6 +378,13 @@ export function parsePlan(json: string): Plan {
         `plan artifact: invalid projectionAudit — ${error instanceof Error ? error.message : String(error)}`,
       );
     }
+  }
+  if (typeof artifact.planId !== "string" || !SHA256.test(artifact.planId)) {
+    throw new Error("plan artifact: missing or invalid planId — re-plan");
+  }
+  const computed = computePlanId(artifact as Omit<Plan, "planId">);
+  if (artifact.planId !== computed) {
+    throw new Error("plan artifact: planId does not match contents — re-plan");
   }
   return artifact as Plan;
 }

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -27,6 +27,7 @@ import {
   type PlanParams,
 } from "./rules.ts";
 import { roleReferencesOf } from "./rules/helpers.ts";
+import { stampPlanId } from "./artifact.ts";
 
 /** Engine version stamped into plan artifacts; apply refuses artifacts
  *  from an engine it does not understand (stage 6 deliverable 1). */
@@ -37,7 +38,12 @@ export const ENGINE_VERSION = "0.2.0";
 // `@supabase/pg-delta/plan` (the subpath that maps here), so the documented path
 // must be real. Cycle-safe: artifact.ts's only import from this module is
 // ENGINE_VERSION, which it reads inside a function body, never at module-eval time.
-export { parsePlan, serializePlan } from "./artifact.ts";
+export {
+  parsePlan,
+  serializePlan,
+  computePlanId,
+  stampPlanId,
+} from "./artifact.ts";
 export type {
   ProjectionAudit,
   ProjectionAuditEntry,
@@ -98,6 +104,11 @@ export interface SourceDatabaseIdentity {
 export interface Plan {
   formatVersion: 1;
   engineVersion: string;
+  /** SHA-256 content hash over the plan-bound approval ingredients
+   *  (formatVersion, engineVersion, source/target fingerprints,
+   *  acceptedRenames, the ordered action list, profile/scope/policy).
+   *  Required; a missing or mismatching artifact must be re-planned. */
+  planId: string;
   source: {
     fingerprint: string;
     /** Credential-free hash of the CLI source endpoint. Used only to reject
@@ -654,7 +665,7 @@ export function plan(
     rulesForId,
   });
 
-  return {
+  return stampPlanId({
     formatVersion: 1,
     engineVersion: ENGINE_VERSION,
     // Identity normalization rewrites source ids into desired-name space for
@@ -713,5 +724,5 @@ export function plan(
       : {}),
     actions: finalActions,
     safetyReport,
-  };
+  });
 }

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -105,7 +105,7 @@ export interface Plan {
   formatVersion: 1;
   engineVersion: string;
   /** SHA-256 content hash over the plan-bound approval ingredients
-   *  (formatVersion, engineVersion, source/target fingerprints,
+   *  (formatVersion, engineVersion, source/target fingerprints, preamble,
    *  acceptedRenames, the ordered action list, profile/scope/policy).
    *  Required; a missing or mismatching artifact must be re-planned. */
   planId: string;

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -30,8 +30,11 @@ import { roleReferencesOf } from "./rules/helpers.ts";
 import { stampPlanId } from "./artifact.ts";
 
 /** Engine version stamped into plan artifacts; apply refuses artifacts
- *  from an engine it does not understand (stage 6 deliverable 1). */
-export const ENGINE_VERSION = "0.2.0";
+ *  from an engine it does not understand (stage 6 deliverable 1).
+ *  0.3.0: required `planId` digest — bumped so a pre-planId executor
+ *  fails closed on stamped artifacts (it would otherwise parse them and
+ *  apply without verifying the digest), keeping fail-closed symmetric. */
+export const ENGINE_VERSION = "0.3.0";
 
 // The plan-artifact (JSON serialize/parse) helpers live in ./artifact.ts but are
 // part of this module's public surface: docs/getting-started.md imports them from

--- a/packages/pg-delta/src/proof/prove.test.ts
+++ b/packages/pg-delta/src/proof/prove.test.ts
@@ -94,6 +94,52 @@ describe("provePlan — destruction metadata preflight", () => {
       { actionIndex: 0, object: column },
     ]);
   });
+
+  test("a mutated plan is rejected by the planId preflight before any clone work", async () => {
+    const empty = buildFactBase([], []);
+    const stamped = stampPlanId({
+      formatVersion: 1,
+      engineVersion: ENGINE_VERSION,
+      source: { fingerprint: empty.rootHash },
+      target: { fingerprint: empty.rootHash },
+      preamble: [],
+      deltas: [],
+      filteredDeltas: [],
+      renameCandidates: [],
+      actions: [],
+      safetyReport: {
+        destructiveActions: 0,
+        rewriteRiskActions: 0,
+        nonTransactionalActions: 0,
+        lockClasses: {},
+      },
+    });
+    const tampered: Plan = {
+      ...stamped,
+      actions: [
+        {
+          sql: "DROP SCHEMA app CASCADE",
+          verb: "drop",
+          produces: [],
+          consumes: [],
+          destroys: [],
+          releases: [],
+          transactionality: "transactional",
+          lockClass: "accessExclusive",
+          newSegmentBefore: false,
+          dataLoss: "none",
+          rewriteRisk: false,
+        },
+      ],
+    };
+    expect(
+      provePlan(tampered, {} as Pool, empty, {
+        reextract: () => {
+          throw new Error("proof touched the clone before rejecting planId");
+        },
+      }),
+    ).rejects.toThrow(/planId.*re-plan/);
+  });
 });
 
 describe("detectViolations — content + coverage (review #3)", () => {

--- a/packages/pg-delta/src/proof/prove.test.ts
+++ b/packages/pg-delta/src/proof/prove.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Pool } from "pg";
 import { buildFactBase } from "../core/fact.ts";
-import { ENGINE_VERSION, type Plan } from "../plan/plan.ts";
+import { ENGINE_VERSION, stampPlanId, type Plan } from "../plan/plan.ts";
 import {
   composeAutoSeedBaseline,
   detectAutoSeedSideEffects,
@@ -52,7 +52,7 @@ describe("provePlan — destruction metadata preflight", () => {
       table: "t",
       name: "secret",
     };
-    const thePlan: Plan = {
+    const thePlan: Plan = stampPlanId({
       formatVersion: 1,
       engineVersion: ENGINE_VERSION,
       source: { fingerprint: empty.rootHash },
@@ -82,7 +82,7 @@ describe("provePlan — destruction metadata preflight", () => {
         nonTransactionalActions: 0,
         lockClasses: { accessExclusive: 1 },
       },
-    };
+    });
     const verdict = await provePlan(thePlan, {} as Pool, empty, {
       reextract: () => {
         throw new Error("proof touched the clone before rejecting metadata");

--- a/packages/pg-delta/src/proof/prove.ts
+++ b/packages/pg-delta/src/proof/prove.ts
@@ -15,6 +15,7 @@ import { diff, type Delta } from "../core/diff.ts";
 import type { FactBase } from "../core/fact.ts";
 import type { StableId } from "../core/stable-id.ts";
 import { extract } from "../extract/extract.ts";
+import { assertPlanId } from "../plan/artifact.ts";
 import type { Action, Plan, ProjectionAudit } from "../plan/plan.ts";
 import { projectTarget } from "../plan/project.ts";
 import {
@@ -638,6 +639,10 @@ export async function provePlan(
   desired: FactBase,
   options: ProveOptions = {},
 ): Promise<ProducedProofVerdict> {
+  // planId preflight: a plan mutated after plan() stamped it must be rejected
+  // BEFORE any clone work (re-extract, stats, auto-seed), not deep inside
+  // apply — every public execution path validates the immutable plan first.
+  assertPlanId(thePlan, "prove");
   const auditAvailable = thePlan.projectionAudit !== undefined;
   const projectionAuditStatus = auditAvailable ? "available" : "unavailable";
   const projectionAudit: ProjectionAudit = auditAvailable

--- a/packages/pg-delta/src/public-api.test.ts
+++ b/packages/pg-delta/src/public-api.test.ts
@@ -47,6 +47,10 @@ describe("public API surface", () => {
     // from the package root. A round-trip proves the re-export is the real thing.
     expect(typeof planSubpath.serializePlan).toBe("function");
     expect(typeof planSubpath.parsePlan).toBe("function");
+    expect(typeof planSubpath.computePlanId).toBe("function");
+    expect(typeof planSubpath.stampPlanId).toBe("function");
+    expect(typeof root.computePlanId).toBe("function");
+    expect(typeof root.stampPlanId).toBe("function");
   });
 
   test("package.json declares the ./plan subpath export", () => {

--- a/packages/pg-delta/tests/apply-nontransactional.test.ts
+++ b/packages/pg-delta/tests/apply-nontransactional.test.ts
@@ -6,7 +6,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import pg from "pg";
 import { apply } from "../src/apply/apply.ts";
-import { ENGINE_VERSION, type Plan } from "../src/plan/plan.ts";
+import { ENGINE_VERSION, stampPlanId, type Plan } from "../src/plan/plan.ts";
 import { createTestDb, type TestDb } from "./containers.ts";
 
 let db: TestDb;
@@ -20,7 +20,7 @@ afterAll(async () => {
 });
 
 function planWithFailingNonTxnAction(): Plan {
-  return {
+  return stampPlanId({
     formatVersion: 1,
     engineVersion: ENGINE_VERSION,
     source: { fingerprint: "a".repeat(64) },
@@ -50,7 +50,7 @@ function planWithFailingNonTxnAction(): Plan {
       nonTransactionalActions: 1,
       lockClasses: { none: 1 },
     },
-  };
+  });
 }
 
 describe("non-transactional apply: reset + inDoubt (P1)", () => {

--- a/packages/pg-delta/tests/cli.test.ts
+++ b/packages/pg-delta/tests/cli.test.ts
@@ -17,7 +17,11 @@ import {
 import { loadSnapshot } from "../src/frontends/snapshot-file.ts";
 import { serializeSnapshot } from "../src/core/snapshot.ts";
 import { extract } from "../src/extract/extract.ts";
-import { parsePlan, serializePlan } from "../src/plan/artifact.ts";
+import {
+  computePlanId,
+  parsePlan,
+  serializePlan,
+} from "../src/plan/artifact.ts";
 import { plan } from "../src/plan/plan.ts";
 import type { Policy } from "../src/policy/policy.ts";
 import { isolatedClusterPair, sharedCluster } from "./containers.ts";
@@ -116,6 +120,7 @@ describe("CLI: apply failure attribution", () => {
       ]);
       const thePlan = plan(sourceState.factBase, desiredState.factBase);
       thePlan.preamble = [{ name: "lock_timeout", value: "-1" }];
+      thePlan.planId = computePlanId(thePlan); // re-stamp: the preamble joins the hash
       const planFile = join(artifactDir, "plan.json");
       writeFileSync(planFile, serializePlan(thePlan), "utf8");
 

--- a/packages/pg-delta/tests/execution.test.ts
+++ b/packages/pg-delta/tests/execution.test.ts
@@ -7,7 +7,11 @@
 import { describe, expect, test } from "bun:test";
 import { apply } from "../src/apply/apply.ts";
 import { extract } from "../src/extract/extract.ts";
-import { parsePlan, serializePlan } from "../src/plan/artifact.ts";
+import {
+  computePlanId,
+  parsePlan,
+  serializePlan,
+} from "../src/plan/artifact.ts";
 import { plan } from "../src/plan/plan.ts";
 import { provePlan } from "../src/proof/prove.ts";
 import { sharedCluster } from "./containers.ts";
@@ -34,6 +38,7 @@ describe("stage 6: execution", () => {
         // sabotage the LAST action; everything before it is one segment
         const last = thePlan.actions.length - 1;
         thePlan.actions[last]!.sql = "SELECT 1/0";
+        thePlan.planId = computePlanId(thePlan); // re-stamp the sabotage past apply's planId gate
         const report = await apply(thePlan, db.pool, {
           fingerprintGate: false,
         });
@@ -78,6 +83,7 @@ describe("stage 6: execution", () => {
       expect(boundaryPos).toBeGreaterThan(0);
       // sabotage an action AFTER the boundary: segment 1 must stay applied
       thePlan.actions[boundaryPos]!.sql = "SELECT 1/0";
+      thePlan.planId = computePlanId(thePlan); // re-stamp the sabotage past apply's planId gate
       const report = await apply(thePlan, source.pool, {
         fingerprintGate: false,
       });

--- a/packages/pg-delta/tests/proof-target-safety.test.ts
+++ b/packages/pg-delta/tests/proof-target-safety.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { extract } from "../src/extract/extract.ts";
-import { plan } from "../src/plan/plan.ts";
+import { computePlanId, plan } from "../src/plan/plan.ts";
 import { provePlan } from "../src/proof/prove.ts";
 import { sharedCluster } from "./containers.ts";
 
@@ -117,6 +117,7 @@ describe("proof target safety", () => {
         dataLoss: "none",
         rewriteRisk: false,
       });
+      thePlan.planId = computePlanId(thePlan); // re-stamp the injection past apply's planId gate
 
       const verdict = await provePlan(thePlan, clone.pool, state.factBase);
 
@@ -154,6 +155,7 @@ describe("proof target safety", () => {
         dataLoss: "none",
         rewriteRisk: false,
       });
+      thePlan.planId = computePlanId(thePlan); // re-stamp the injection past apply's planId gate
 
       const verdict = await provePlan(thePlan, clone.pool, state.factBase);
       expect(verdict.ok).toBe(false);
@@ -193,6 +195,7 @@ describe("proof target safety", () => {
         dataLoss: "none",
         rewriteRisk: false,
       });
+      thePlan.planId = computePlanId(thePlan); // re-stamp the injection past apply's planId gate
 
       const verdict = await provePlan(thePlan, clone.pool, state.factBase);
       expect(verdict.ok).toBe(false);

--- a/packages/pg-delta/tests/proof.test.ts
+++ b/packages/pg-delta/tests/proof.test.ts
@@ -6,7 +6,12 @@
  */
 import { describe, expect, test } from "bun:test";
 import { extract } from "../src/extract/extract.ts";
-import { plan, type Plan, type ProjectionAudit } from "../src/plan/plan.ts";
+import {
+  computePlanId,
+  plan,
+  type Plan,
+  type ProjectionAudit,
+} from "../src/plan/plan.ts";
 import { provePlan } from "../src/proof/prove.ts";
 import type { Policy } from "../src/policy/policy.ts";
 import { sharedCluster } from "./containers.ts";
@@ -72,6 +77,7 @@ describe("proof: rewrite observation", () => {
       // must now catch the relfilenode change that nobody warned about.
       const buggy = structuredClone(honest);
       for (const a of buggy.actions) a.rewriteRisk = false;
+      buggy.planId = computePlanId(buggy); // re-stamp the lie past apply's planId gate
       const verdict = await provePlan(buggy, source.pool, d.factBase);
       expect(verdict.rewriteViolations.length).toBeGreaterThan(0);
       // `.table` is structured { schema, name } — unambiguous (identifiers can
@@ -144,6 +150,7 @@ describe("proof: auto-seed data preservation", () => {
         dataLoss: "none", // the lie the proof must catch
         rewriteRisk: false,
       });
+      thePlan.planId = computePlanId(thePlan); // re-stamp the lie past apply's planId gate
       // without auto-seed the kept table is empty, so the loss is invisible
       const blind = await provePlan(
         structuredClone(thePlan),
@@ -173,6 +180,7 @@ describe("proof: auto-seed data preservation", () => {
           dataLoss: "none",
           rewriteRisk: false,
         });
+        thePlan2.planId = computePlanId(thePlan2); // re-stamp the lie past apply's planId gate
         const seeded = await provePlan(thePlan2, source2.pool, d.factBase, {
           autoSeed: true,
         });
@@ -284,6 +292,7 @@ describe("proof: projection audit on early returns", () => {
         dataLoss: "none",
         rewriteRisk: false,
       });
+      thePlan.planId = computePlanId(thePlan); // re-stamp the injection past apply's planId gate
       const audit = installSuspiciousAudit(thePlan);
 
       const verdict = await provePlan(thePlan, source.pool, factBase, {

--- a/packages/pg-delta/tests/renames.test.ts
+++ b/packages/pg-delta/tests/renames.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, test } from "bun:test";
 import { apply } from "../src/apply/apply.ts";
 import { extract } from "../src/extract/extract.ts";
 import { normalizeRoleIdentities } from "../src/plan/identity-normalize.ts";
-import { plan } from "../src/plan/plan.ts";
+import { computePlanId, plan } from "../src/plan/plan.ts";
 import type { Policy } from "../src/policy/policy.ts";
 import { provePlan } from "../src/proof/prove.ts";
 import {
@@ -442,6 +442,7 @@ describe("stage 9: renames", () => {
         dataLoss: "none",
         rewriteRisk: false,
       });
+      thePlan.planId = computePlanId(thePlan); // re-stamp the lie past apply's planId gate
       const verdict = await provePlan(thePlan, dbs.source.pool, d.factBase);
       // row count dropped 5 → 0 under the NEW name — a data violation
       expect(verdict.dataViolations).toEqual([

--- a/packages/pg-delta/tests/view-aware-gate.test.ts
+++ b/packages/pg-delta/tests/view-aware-gate.test.ts
@@ -11,7 +11,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { apply } from "../src/apply/apply.ts";
 import { extract } from "../src/extract/extract.ts";
-import { plan, type Plan } from "../src/plan/plan.ts";
+import { plan, stampPlanId, type Plan } from "../src/plan/plan.ts";
 import type { Policy } from "../src/policy/policy.ts";
 import { buildFactBase } from "../src/core/fact.ts";
 import { createTestDb, type TestDb } from "./containers.ts";
@@ -57,10 +57,10 @@ describe("view-aware apply/prove fingerprint gate (P0-2)", () => {
       baseline: "platform-baseline",
     };
     // a hand-built 0-action plan that records a baseline-declaring policy
-    const baselinePlan: Plan = {
+    const baselinePlan: Plan = stampPlanId({
       ...plan(buildFactBase([], []), buildFactBase([], [])),
       policy: baselinePolicy,
-    };
+    });
     let err: unknown;
     try {
       await apply(baselinePlan, db.pool); // no options.baseline


### PR DESCRIPTION
## Summary

- Schema-first CLI enablement **WP1** ([plan](docs/roadmap/schema-first-cli-enablement.md)): every `Plan` now carries a required `planId` — a SHA-256 content hash over format/engine version, source/target fingerprints, accepted renames, the ordered action list, and profile/scope/policy.
- `plan()` stamps it via `stampPlanId`. `parsePlan` and `apply()` refuse a missing or mismatching digest (`re-plan`). Stale artifacts are never silently upgraded. `formatVersion` stays `1`.
- Hashing uses existing `canonicalize` + `contentHash`. `computePlanId` / `stampPlanId` are exported from the package root and `@supabase/pg-delta/plan`.

## Test plan

- [x] RED: `parsePlan` of an unstamped `samplePlan` succeeded (`expect(…).toThrow(/planId/)` did not throw)
- [x] GREEN: `bun test src/plan/artifact.test.ts src/apply/apply.test.ts src/frontends/render-apply-script.test.ts src/frontends/render-plan-files.test.ts src/public-api.test.ts` — 72 pass
- [x] Hand-built Plan fixtures wrapped with `stampPlanId` so `check-types` passes
- [x] CI on this PR

Does not include WP2 (hazards) or WP3c–f.