### PR TITLE
docs(pg-delta): mark schema-first CLI V1 work packages as shipped

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -19,9 +19,10 @@ performance, then DX.
 - **[ephemeral-shadow-design.md](ephemeral-shadow-design.md)** — full design for
   auto-provisioning an ephemeral shadow database (deferred).
 - **[schema-first-cli-enablement.md](schema-first-cli-enablement.md)** — what
-  pg-delta must export so the Supabase CLI can build the schema-first workflow
-  (`schema pull / diff / generate / apply / push`). WP3a (export-file
-  classification) is in progress; remaining WPs are sequenced there.
+  pg-delta exports so the Supabase CLI can build the schema-first workflow
+  (`schema pull / diff / generate / apply / push`). V1 work packages have
+  shipped (#414, #416, #418–#421, #423); remaining items are WP5 (not V1)
+  and WP6 (deferred).
 
 ## How the engine got here
 

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -77,21 +77,21 @@ one unsplittable query that caps the ceiling). Deferred.
 
 ## Milestone B — DX
 
-### 🟡 Schema-first CLI enablement
+### ✅ Schema-first CLI enablement
 Promote engine primitives the RFC's `PgDeltaSchemaEngine` adapter needs onto
 the exported library surface (stable `planId`, `HazardKind` codes, file
 classification, segments, coverage/data-loss helpers, named loader options).
-Most of the RFC's integration boundary is already satisfied; the work is
-targeted additions plus moving CLI-only logic out of `src/cli/**`. Full plan
-and WP sequencing: [schema-first-cli-enablement.md](schema-first-cli-enablement.md).
-WP3a (pure `classifySqlFiles` helper) ships with this change. Linear: the
-RFC plus CLI-1459–1464 (WP2).
+*Shipped* (#414, #416, #418–#421, #423). The Supabase CLI owns the workflow
+adapter. Remaining tracks (WP5 supporting, WP6 provenance) are documented in
+[schema-first-cli-enablement.md](schema-first-cli-enablement.md).
 
 ### 🟡 Risk classification 2.0
-The engine already computes proof-verified per-action safety (`dataLoss`,
-`rewriteRisk`, `lockClass`, `transactionality`). Derive stable `HazardKind` codes
-from those fields, attach them to the plan artifact (additive), add an
-`--allow-hazards` gate and a GitLab Code-Quality JSON reporter. CLI-1459–1464.
+Library classification shipped with schema-first WP2 (#420): `actionHazards` /
+`classifyPlanHazards` expose stable `HazardKind` codes as a view over
+proof-verified safety fields and coverage diagnostics. Policy stays in the
+Supabase CLI. Remaining `pgdelta` CLI DX (an `--allow-hazards` gate and a
+GitLab Code-Quality JSON reporter) is optional and not a V1 RFC blocker.
+CLI-1459–1464.
 
 ### 🟡 Migration squash / repair
 Collapse a chain of migration files into one consolidated migration, and emit it

--- a/docs/roadmap/schema-first-cli-enablement.md
+++ b/docs/roadmap/schema-first-cli-enablement.md
@@ -1,12 +1,13 @@
 # Schema-first CLI enablement
 
-- **Status**: In progress — WP1 shipping; remaining WPs sequenced below.
-- **Date**: 2026-08-13
+- **Status**: Shipped — every V1 work package has landed. Remaining items
+  are WP5 (not V1) and WP6 (deferred).
+- **Date**: 2026-08-13 (status refresh 2026-08-14)
 - **Source**: RFC *Schema-First Database Development* (Linear
   `rfc-schema-first-database-development-532de5a122d5`, 2026-08-12, **revised
   2026-08-13**).
 
-What `@supabase/pg-delta` must add so the Supabase CLI can build the
+What `@supabase/pg-delta` exports so the Supabase CLI can build the
 schema-first workflow (`schema pull / diff / generate / apply / push`).
 pg-delta is the schema compiler; the CLI owns the workflow layer.
 
@@ -17,9 +18,7 @@ base. Observed provenance (WP6) is deferred.
 
 | Symbol | Meaning |
 |---|---|
-| ✅ | Already provided by the engine |
-| 🟠 | Net-new engineering |
-| 🟡 | Substrate exists; build the consumer/surface |
+| ✅ | Shipped / already provided by the engine |
 | ⚪ | Deliberate deferral |
 
 ---
@@ -47,60 +46,54 @@ flattened to rendered SQL:
 - `_custom/` preservation (exporter never writes/prunes/claims it) and
   `ExportManifest.files` ownership list.
 
-**Inventory corrections vs the RFC text:**
-
-- Plan artifacts already stamp `formatVersion` + `engineVersion`; `parsePlan`
-  and `apply()` refuse a mismatch. WP1 adds required `Plan.planId` (this change).
-- `segmentActions()` is already exported from `@supabase/pg-delta/apply`. WP3
-  still needs the `Segment` type, a `planSegments(plan)` helper, and
-  root/`frontends` re-exports, plus `renderApplyScript`.
-
 ---
 
-## WP1 — **this change** Stable plan identifier
+## WP1 — ✅ Stable plan identifier (#418)
 
 `Plan.planId` is a required SHA-256 content hash over `formatVersion`,
-`engineVersion`, source/target fingerprints, the `preamble` (executed per
-segment by apply — run content, like the action list), `acceptedRenames`,
-the ordered action list, and `profile`/`scope`/`policy`. `plan()` stamps it via
-`stampPlanId`; `parsePlan` and `apply()` refuse a missing or mismatching
-digest (`re-plan` — never silently upgrade). Version fail-closed for
-`formatVersion`/`engineVersion` was already in place. Stale artifacts
-without `planId` must be re-planned.
+`engineVersion`, source/target fingerprints, `preamble`, `acceptedRenames`,
+the ordered action list, and `profile`/`scope`/`policy`. `plan()` stamps it
+via `stampPlanId`; `parsePlan` and `apply()` refuse a missing or mismatching
+digest (`re-plan` — never silently upgrade).
 
 ---
 
-## WP2 — 🟡 Hazard classification 2.0
+## WP2 — ✅ Hazard classification 2.0 (#420)
 
-Derive per-action `HazardKind[]` from existing proof-verified safety fields
-plus coverage diagnostics. Export stable codes and a plan-level hazard
-report. Policy (which hazards block which target class) stays in the
+`actionHazards` / `classifyPlanHazards` export stable `HazardKind` codes
+derived from proof-verified action safety fields (`dataLoss`, `rewriteRisk`,
+`transactionality`, `lockClass`) and coverage diagnostics. Hazard kinds are
+a **view** — they are not stored on `Plan`/`Action` and are not part of
+`planId`. Policy (which hazards block which target class) stays in the
 Supabase CLI. Linear: CLI-1459–1464.
 
+The original backlog also named a `pgdelta --allow-hazards` gate and a
+GitLab Code-Quality JSON reporter. Those remain optional `pgdelta` CLI DX;
+the RFC adapter classifies via the library and applies policy itself.
+
 ---
 
-## WP3 — 🟡 Promote CLI-only logic into exported library frontends
+## WP3 — ✅ Promote CLI-only logic into exported library frontends
 
 Library frontends accept pools and SQL files; they return typed data. No
 `supabase/` paths, prompts, or CLI JSON. `pgdelta` stays a thin consumer.
 
 | Slice | Status | Notes |
 |---|---|---|
-| **WP3a** export file classification | shipped (#414) | Pure `classifySqlFiles` / `classifySqlContent`. Does **not** export `writeExportFiles` (writes, scaffolds `_custom/README.md`, refuses unmanaged). |
-| **WP3b** | next | Re-export `pruneStaleSqlFiles`, `renderApplyScript`, `probeUnmodeledIdentitiesPinned`. |
-| **WP3c** | | Export `Segment` + `planSegments(plan)` from root/`frontends`. |
-| **WP3d** | | Move `STRICT_COVERAGE_CODES` + `hasBlockingDiagnostics` into a frontend; leave `printDiagnostics` / `exitIfBlocking` in the CLI. |
-| **WP3e** | | Move `dataLossActions` into a frontend; leave `assertDataLossAllowed` in the CLI. |
-| **WP3f** | | Export `SourceDatabaseIdentity` + `src/database-identity.ts` helpers (not URL parsing). |
+| **WP3a** export file classification | ✅ #414 | Pure `classifySqlFiles` / `classifySqlContent`. Does **not** export `writeExportFiles`. |
+| **WP3b** prune / dry-run / unmodeled probe | ✅ #416 | `pruneStaleSqlFiles`, `renderApplyScript`, `probeUnmodeledIdentitiesPinned`. |
+| **WP3c** segments | ✅ #421 | `Segment` + `planSegments(plan)` from root/`frontends`. |
+| **WP3d** strict-coverage gate | ✅ #423 | `STRICT_COVERAGE_CODES` + `hasBlockingDiagnostics`. `printDiagnostics` / `exitIfBlocking` stay in the CLI. |
+| **WP3e** data-loss helpers | ✅ #423 | `dataLossActions`. `assertDataLossAllowed` stays in the CLI. |
+| **WP3f** target-identity safety | ✅ #423 | `SourceDatabaseIdentity` + `database-identity.ts` helpers (not URL parsing). |
 
 ---
 
-## WP4 — 🟠 Loader contract polish
+## WP4 — ✅ Loader contract polish (#419)
 
-Name and export `LoadSqlFilesOptions`. Library default for
+`LoadSqlFilesOptions` is a named, exported type. The library default for
 `strictDataStatements` stays permissive (warning); the Supabase CLI adapter
-**must** pass `strictDataStatements: true`. Flipping the library default is
-a breaking change with no engine benefit.
+**must** pass `strictDataStatements: true`.
 
 ---
 
@@ -120,17 +113,22 @@ designed, or if diff-UX demand justifies Tier 1 on its own.
 
 ---
 
-## Sequencing
+## RFC phase mapping (pg-delta side)
 
-WP3a → WP3b/c (pull's file summary + segments) → WP1 → WP2 → WP3d/e/f → WP4.
+| RFC phase | pg-delta |
+|---|---|
+| Phase 0 — strengthen current declarative workflow | ✅ WP2 + WP3d |
+| Phase 1 — `schema pull` / `diff` / `generate` | ✅ WP1 + WP3a–c |
+| Phase 2 — `schema apply` + draft journal | ✅ `apply()` plus WP1 `planId` and WP2 hazard codes |
+| Phase 3–4 — `schema push` / top-level composition | Nothing new on the pg-delta side |
+| Phase 5 — stronger verification | WP5 tracks |
 
-RFC phase mapping: Phase 0 needs WP2 + WP3d; Phase 1 needs WP1 + WP3a–c;
-Phase 2 consumes `planId` + hazard codes; Phases 3–4 need nothing new on
-the pg-delta side.
+The remaining work is the **Supabase CLI adapter**: staging, `--force`,
+unmanaged-file policy, checkpoints, draft journals, and hazard *policy*.
 
 ---
 
-## Boundary (binding on every WP)
+## Boundary (binding)
 
 - pg-delta does not learn about `supabase/database`, `supabase/migrations`,
   linked projects, branch protection, prompts, or CLI JSON.


### PR DESCRIPTION
## Summary

- Mark schema-first CLI V1 as shipped in the enablement doc, roadmap index, and backlog (WP1–WP4 / WP3a–f: #414, #416, #418–#421, #423).
- Record leftover tracks accurately: WP5 is not a V1 blocker, WP6 stays deferred, and `HazardKind` remains a view (library classification shipped; `pgdelta` CLI DX optional).
- Remaining work is the Supabase CLI adapter, not more pg-delta engine surface.

Supersedes #422 (that PR was written mid-flight and is now conflicting).

## Linked issue

N/A — docs-only status refresh after the V1 work packages merged.

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change (docs-only; no code change)
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`) (not needed)
- [x] `bun run format-and-lint` and `bun run check-types` pass (docs-only markdown; `oxfmt` ignores these files)