### PR TITLE
perf(pg-delta): index extension members per extension in the replace satellite replay

### DIFF
--- a/.changeset/extension-replace-satellite-lookup.md
+++ b/.changeset/extension-replace-satellite-lookup.md
@@ -1,0 +1,10 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Replace the per-replace scan over the full extension-member closure in the
+satellite-replay loop with an inverted extension → members index plus an
+extension kind guard. Emission order and rendered SQL are unchanged; plans with
+wide replace sets on extension-heavy schemas (PostGIS, TimescaleDB) no longer
+pay O(replaced facts × total extension members), and extension-free plans skip
+building the closure entirely.

--- a/packages/pg-delta/src/plan/phases/action-emitter.ts
+++ b/packages/pg-delta/src/plan/phases/action-emitter.ts
@@ -189,12 +189,29 @@ export function emitActions(input: ActionEmitterInput): ActionEmitterOutput {
     );
   }
 
-  // Desired-side member closure, computed lazily — only an extension REPLACE
-  // needs it (see the satellite replay below).
-  let desiredMemberClosureMemo: Map<string, StableId[]> | undefined;
-  const desiredMemberClosureOf = (): Map<string, StableId[]> => {
-    desiredMemberClosureMemo ??= extensionMemberClosure(projectedDesired);
-    return desiredMemberClosureMemo;
+  // Desired-side extension → member-keys index, computed lazily — only an
+  // extension REPLACE needs it (see the satellite replay below). Inverted from
+  // extensionMemberClosure so each replaced extension does ONE Map lookup
+  // instead of scanning every member of every extension per replace key;
+  // members keep the closure's iteration order, so emission order is unchanged.
+  let desiredMembersByExtensionMemo: Map<string, string[]> | undefined;
+  const desiredMembersByExtension = (): Map<string, string[]> => {
+    if (desiredMembersByExtensionMemo === undefined) {
+      desiredMembersByExtensionMemo = new Map();
+      for (const [memberKey, exts] of extensionMemberClosure(
+        projectedDesired,
+      )) {
+        for (const extKey of new Set(exts.map((ext) => encodeId(ext)))) {
+          const members = desiredMembersByExtensionMemo.get(extKey);
+          if (members === undefined) {
+            desiredMembersByExtensionMemo.set(extKey, [memberKey]);
+          } else {
+            members.push(memberKey);
+          }
+        }
+      }
+    }
+    return desiredMembersByExtensionMemo;
   };
 
   // replaces: drop old + create new (+ recreate unchanged descendants).
@@ -272,17 +289,18 @@ export function emitActions(input: ActionEmitterInput): ActionEmitterOutput {
     // both sides there is no delta to re-emit it. Replay them from the
     // projected target; the member consume orders them after the re-CREATE.
     // (The closure maps members to their owning EXTENSIONS only, so a
-    // non-extension replace key simply matches no members — no kind check.)
-    for (const [memberKey, exts] of desiredMemberClosureOf()) {
-      if (!exts.some((ext) => encodeId(ext) === key)) continue;
-      const member = projectedDesired.getByEncoded(memberKey);
-      if (!member) continue;
-      for (const child of projectedDesired.childrenOf(member.id)) {
-        if (ruleFlag(child.id.kind, "metadata") !== true) continue;
-        const childKey = encodeId(child.id);
-        if (added.has(childKey) || producerOf.has(childKey)) continue;
-        recreatedByReplace.add(childKey);
-        emitCreate(child, projectedDesired);
+    // non-extension replace key can never have members — skip the lookup.)
+    if (oldFact.id.kind === "extension") {
+      for (const memberKey of desiredMembersByExtension().get(key) ?? []) {
+        const member = projectedDesired.getByEncoded(memberKey);
+        if (!member) continue;
+        for (const child of projectedDesired.childrenOf(member.id)) {
+          if (ruleFlag(child.id.kind, "metadata") !== true) continue;
+          const childKey = encodeId(child.id);
+          if (added.has(childKey) || producerOf.has(childKey)) continue;
+          recreatedByReplace.add(childKey);
+          emitCreate(child, projectedDesired);
+        }
       }
     }
   }

--- a/packages/pg-delta/src/plan/plan.guard.test.ts
+++ b/packages/pg-delta/src/plan/plan.guard.test.ts
@@ -42,7 +42,11 @@ const KIND_LITERAL_BASELINE: Readonly<Record<string, number>> = {
   // "defaultPrivilege" }>` cast — narrowing on the `!==` check suffices.
   "internal.ts": 29,
   "locks.ts": 18,
-  "phases/action-emitter.ts": 10,
+  // 10 → 11: the extension-replace satellite replay guards on
+  // `oldFact.id.kind === "extension"` so a plan with no extension replace
+  // never builds the member-closure index — 1 deliberate literal (the closure
+  // maps members to owning EXTENSIONS only, so the guard is behavior-neutral).
+  "phases/action-emitter.ts": 11,
   "phases/action-graph.ts": 1,
   "phases/change-set.ts": 4,
   "phases/replacement-expansion.ts": 0,


### PR DESCRIPTION
## Summary

The satellite-replay loop added in #410 (a204214a) scanned the **entire** `desiredMemberClosureOf()` map — every member of every extension — for **every** replaced fact, testing `exts.some((ext) => encodeId(ext) === key)`. That is O(replaceIds × totalExtensionMembers): negligible on extension-free schemas, but a real quadratic-ish cost on extension-heavy schemas (PostGIS/TimescaleDB, hundreds–thousands of members) combined with wide replace sets.

Two behavior-preserving changes in `src/plan/phases/action-emitter.ts`:

- **Extension kind guard.** The replay now runs only when the replaced fact's kind is `extension`. The closure maps members to their owning EXTENSIONS only and `encodeId` embeds the kind, so a non-extension replace key could never match; extension-free plans now never build the closure at all (previously the first replace key triggered it regardless of kind).
- **Inverted index.** The lazy memo now inverts `extensionMemberClosure` once per `emitActions` call into `Map<encodedExtensionKey, memberKey[]>`, so each replaced extension does one `Map.get` instead of a full scan. Member lists are built in the closure's iteration order, and members owned by multiple extensions are deduped per extension key — so the emitted member subsequence per extension, emission order, and rendered SQL are byte-identical to before.

Knock-on: the kind-literal ratchet in `src/plan/plan.guard.test.ts` moves `phases/action-emitter.ts` 10 → 11 for the deliberate `"extension"` guard literal, annotated in the baseline per the file's convention.

Perf-only refactor, no behavior change — no new RED test; the gate is the existing #410 regression tests (SQL inline snapshots unchanged) plus a full corpus run.

## Verification

- `bun test src/` — **1262 pass, 0 fail** (includes the 6 regression tests from #410 in `src/plan/extension-replace-member-cycle.test.ts`, whose inline SQL snapshots pin the rendered output)
- `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts` — corpus **662/662 pass**
- `PGDELTA_NEXT_SUPABASE_TESTS=1 bun test --test-name-pattern "pg_net extnamespace" tests/supabase-integration.test.ts` (on `supabase/postgres:17.6.1.135`) — **2/2 pass**
- `bun run format-and-lint` / `bun run check-types` green; pg-delta knip green (pg-topo knip reports pre-existing unused-file findings unrelated to this change)

## Linked issue

Refs #410 (follow-up perf refactor to the fix that landed there — no `open-for-contribution` issue; Supabase maintainer).

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change (covered by existing #410 regression tests + corpus; no behavior change)
- [x] Changeset added if this is a user-facing fix/feature (`.changeset/extension-replace-satellite-lookup.md`, patch)
- [x] `bun run format-and-lint` and `bun run check-types` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)