### PR TITLE
fix(pg-delta): add flag to bypass the same-database identity refusal for cloned shadows

### DIFF
--- a/.changeset/lucky-pugs-shake.md
+++ b/.changeset/lucky-pugs-shake.md
@@ -15,3 +15,13 @@ accepts `--allow-same-database-identity`, to proceed in that case; both emit a
 loud warning naming what was bypassed. Default behavior is unchanged (the
 refusal still fires), and both refusal messages now explain that physically
 cloned shadows legitimately trigger the guard and name the escape hatch.
+
+The pre-existing PostgreSQL-lineage containment guards (`isolatedShadow` /
+`--scope cluster` / `--isolated-shadow`, which check `systemIdentifier` alone)
+are now also exempted, but only for the exact-identity match the bypass
+already covers — a physical clone shares the target's lineage by construction,
+so without this the lineage guard would reject the very case the bypass exists
+to allow. A same-lineage **sibling** database (same system identifier,
+different database OID — a genuinely different database on the same cluster)
+is not covered: it still fails `isSameDatabase()` and the lineage guards still
+refuse it even with the flag set.

--- a/.changeset/lucky-pugs-shake.md
+++ b/.changeset/lucky-pugs-shake.md
@@ -1,0 +1,17 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Add an opt-in bypass for the shadow-vs-target same-database identity refusal.
+
+A physically restored shadow — a warm shadow cache rehydrated from a PGDATA
+snapshot of the target cluster, as the Supabase CLI provisions — inherits the
+target's `system_identifier` and every database OID, so the identity guard
+cannot tell it apart from the target and refused to load declarative SQL,
+blocking declarative sync whenever the shadow cache was on.
+
+`planSchemaFiles` now accepts `allowSameDatabaseIdentity`, and `schema apply`
+accepts `--allow-same-database-identity`, to proceed in that case; both emit a
+loud warning naming what was bypassed. Default behavior is unchanged (the
+refusal still fires), and both refusal messages now explain that physically
+cloned shadows legitimately trigger the guard and name the escape hatch.

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -928,10 +928,11 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
     if (shadowFlag !== undefined) {
       const { targetIdentity, shadowIdentity } =
         await observeExplicitShadowIdentities(tgt.pool, shadow.pool);
-      if (
-        isSameDatabase(targetIdentity, shadowIdentity) &&
-        !flags["allow-same-database-identity"]
-      ) {
+      const sameDatabaseIdentity = isSameDatabase(
+        targetIdentity,
+        shadowIdentity,
+      );
+      if (sameDatabaseIdentity && !flags["allow-same-database-identity"]) {
         throw new UsageError(
           `schema apply: shadow and target are the same observed database (${targetIdentity.database}); refusing to load declarative SQL. ` +
             `A physically cloned shadow (e.g. a warm shadow cache restored from a PGDATA snapshot of the target cluster) inherits the ` +
@@ -939,20 +940,31 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
             `server, pass --allow-same-database-identity to bypass this check`,
         );
       }
+      // The flag attests "my shadow is a physical clone of the target" — it exempts
+      // lineage containment ONLY for that exact-identity match, never for a
+      // same-lineage sibling database (same system identifier, different database
+      // OID), which is a genuinely different database on the same cluster and must
+      // still be refused.
+      const trustedCloneBypass =
+        flags["allow-same-database-identity"] === true && sameDatabaseIdentity;
       if (
         scope === "cluster" &&
-        isSamePostgresLineage(targetIdentity, shadowIdentity)
+        isSamePostgresLineage(targetIdentity, shadowIdentity) &&
+        !trustedCloneBypass
       ) {
         throw new UsageError(
-          "schema apply: --scope cluster requires a shadow from a different PostgreSQL lineage; the supplied shadow shares the target lineage",
+          "schema apply: --scope cluster requires a shadow from a different PostgreSQL lineage; the supplied shadow shares the target lineage " +
+            "(same-lineage sibling databases are not covered by --allow-same-database-identity)",
         );
       }
       if (
         flags["isolated-shadow"] &&
-        isSamePostgresLineage(targetIdentity, shadowIdentity)
+        isSamePostgresLineage(targetIdentity, shadowIdentity) &&
+        !trustedCloneBypass
       ) {
         throw new UsageError(
-          "schema apply: an isolated shadow (--isolated-shadow) requires a different PostgreSQL lineage; the supplied shadow shares the target lineage",
+          "schema apply: an isolated shadow (--isolated-shadow) requires a different PostgreSQL lineage; the supplied shadow shares the target lineage " +
+            "(same-lineage sibling databases are not covered by --allow-same-database-identity)",
         );
       }
     }

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -709,6 +709,7 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
       "allow-data-loss": { type: "boolean" },
       "trusted-local-host": { type: "multi" },
       "allow-remote-shadow": { type: "boolean" },
+      "allow-same-database-identity": { type: "boolean" },
     });
   } catch (err) {
     if (err instanceof UsageError) {
@@ -716,7 +717,7 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
         `${err.message}\nUsage: pgdelta schema apply --dir <dir> --target <pg-url> [--shadow <pg-url>] ` +
           `[--renames auto|prompt|off] [--force] [--accept-rename <from>=<to>] ... ` +
           `[--profile ${PROFILE_IDS}] [--restrict-to-applier] [--strict-coverage] [--strict-function-bodies] [--strict-data-statements] [--no-reorder] [--unsafe-show-secrets] [--isolated-shadow] [--scope database|cluster] [--skip-cluster-ddl] [--keep-shadow] [--allow-data-loss] ` +
-          `[--trusted-local-host <hostname>]... [--allow-remote-shadow]\n` +
+          `[--trusted-local-host <hostname>]... [--allow-remote-shadow] [--allow-same-database-identity]\n` +
           `  [--dry-run] (print the portable apply script to stdout; apply nothing; see pgdelta --help for execution requirements) [--verbose] (stream per-statement progress to stderr) [--out-plan <plan.json>] (write the plan artifact)\n` +
           `  --shadow omitted: a co-located shadow database is created on the target's cluster (database scope only) and dropped after.`,
       );
@@ -927,9 +928,15 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
     if (shadowFlag !== undefined) {
       const { targetIdentity, shadowIdentity } =
         await observeExplicitShadowIdentities(tgt.pool, shadow.pool);
-      if (isSameDatabase(targetIdentity, shadowIdentity)) {
+      if (
+        isSameDatabase(targetIdentity, shadowIdentity) &&
+        !flags["allow-same-database-identity"]
+      ) {
         throw new UsageError(
-          `schema apply: shadow and target are the same observed database (${targetIdentity.database}); refusing to load declarative SQL`,
+          `schema apply: shadow and target are the same observed database (${targetIdentity.database}); refusing to load declarative SQL. ` +
+            `A physically cloned shadow (e.g. a warm shadow cache restored from a PGDATA snapshot of the target cluster) inherits the ` +
+            `target's system identifier and database OIDs and reports as the same database here; if the shadow is known to be a separate ` +
+            `server, pass --allow-same-database-identity to bypass this check`,
         );
       }
       if (
@@ -977,6 +984,10 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
       redactSecrets,
       skipClusterDdl: flags["skip-cluster-ddl"] === true,
       isolatedShadow: flags["isolated-shadow"] === true,
+      // Threaded through so the library guard does not re-refuse what the CLI
+      // guard was told to allow; the bypass WARNING is emitted there (onWarning
+      // below prints it) rather than twice from both layers.
+      allowSameDatabaseIdentity: flags["allow-same-database-identity"] === true,
       seedAssumedSchemas: coLocated !== undefined,
       renames,
       ...(acceptRenames.length > 0 ? { acceptRenames } : {}),

--- a/packages/pg-delta/src/cli/main.ts
+++ b/packages/pg-delta/src/cli/main.ts
@@ -81,6 +81,7 @@ Commands:
                  [--renames auto|prompt|off] [--force] [--allow-data-loss]
                  [--scope database|cluster] [--isolated-shadow] [--strict-data-statements]
                  [--trusted-local-host <hostname>]... [--allow-remote-shadow]
+                 [--allow-same-database-identity]
                  [--accept-rename <from>=<to>] ... [--no-reorder]
                  [--dry-run] [--verbose] [--out-plan <plan.json>]
   schema lint    --dir <dir>
@@ -130,6 +131,12 @@ Notes:
     the same endpoint and identity rules via --allow-remote-shadow. Clone and
     explicit-shadow URLs must stay pinned to one database and physical lineage;
     multi-cluster transaction/load-balancing endpoints are unsupported.
+    --allow-same-database-identity (schema apply): proceed when an explicit
+    --shadow observes the SAME database identity as the target. A physically
+    restored shadow (warm shadow cache rehydrated from a PGDATA snapshot of the
+    target cluster) inherits the target's system identifier and database OIDs,
+    so it is indistinguishable from the target here; supply this only when the
+    shadow is known to be a separate server. Bypassing is reported as a WARNING.
     apply/schema apply refuse actions marked
     dataLoss:"destructive" unless --allow-data-loss is supplied; --force only
     skips the source fingerprint gate and never implies data-loss approval.
@@ -202,6 +209,7 @@ Subcommands:
                  [--renames auto|prompt|off] [--force] [--allow-data-loss]
                  [--scope database|cluster] [--isolated-shadow] [--strict-data-statements]
                  [--trusted-local-host <hostname>]... [--allow-remote-shadow]
+                 [--allow-same-database-identity]
                  [--accept-rename <from>=<to>] ... [--no-reorder]
                  [--dry-run] [--verbose] [--out-plan <plan.json>]
   schema lint    --dir <dir>

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -286,6 +286,14 @@ export interface PlanSchemaFilesOptions {
   allowPreExistingRows?: boolean;
   /** Make the shadow load's DML observation fatal again (default: warning). */
   strictDataStatements?: boolean;
+  /** Proceed when the shadow and the target observe the SAME database identity
+   *  (system identifier + database OID) instead of refusing. Physical clones —
+   *  a warm shadow cache restored from a PGDATA snapshot of the target cluster —
+   *  inherit both, so a genuinely separate shadow server is indistinguishable
+   *  from the target here. Off by default; when it is on and the identities do
+   *  match, the bypass is reported through {@link PlanSchemaFilesOptions.onWarning}.
+   *  A no-op when the identities differ. */
+  allowSameDatabaseIdentity?: boolean;
   /** Statement-reorder assist. Default: true. */
   reorder?: boolean;
   /** Soft warnings (reorder fallback, ADP caveat, …). */
@@ -383,8 +391,19 @@ export async function planSchemaFiles(
     "planSchemaFiles shadow safety",
   );
   if (isSameDatabase(targetIdentity, shadowIdentity)) {
-    throw new SchemaFrontendError(
-      `planSchemaFiles: shadow and target are the same observed database (${targetIdentity.database}); refusing to load declarative SQL`,
+    if (options.allowSameDatabaseIdentity !== true) {
+      throw new SchemaFrontendError(
+        `planSchemaFiles: shadow and target are the same observed database (${targetIdentity.database}); refusing to load declarative SQL. ` +
+          `A physically cloned shadow (e.g. a warm shadow cache restored from a PGDATA snapshot of the target cluster) inherits the target's ` +
+          `system identifier and database OIDs and reports as the same database here; if the shadow is known to be a separate server, ` +
+          `pass allowSameDatabaseIdentity: true to bypass this check`,
+      );
+    }
+    options.onWarning?.(
+      `shadow and target report the same database identity (system identifier + database OID) for "${targetIdentity.database}". ` +
+        `This is expected for a physically restored/cloned shadow; the same-database safety guard was explicitly bypassed ` +
+        `(allowSameDatabaseIdentity / --allow-same-database-identity). If the shadow is NOT a separate server, ` +
+        `declarative SQL is being loaded into the target itself.`,
     );
   }
   if (

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -292,7 +292,15 @@ export interface PlanSchemaFilesOptions {
    *  inherit both, so a genuinely separate shadow server is indistinguishable
    *  from the target here. Off by default; when it is on and the identities do
    *  match, the bypass is reported through {@link PlanSchemaFilesOptions.onWarning}.
-   *  A no-op when the identities differ. */
+   *  A no-op when the identities differ.
+   *
+   *  For that same exact-identity match, this also exempts the `isolatedShadow`
+   *  / cluster-scope PostgreSQL lineage containment check below — a physical
+   *  clone shares the target's lineage by construction, so the lineage guard
+   *  would otherwise reject the very case this option exists to allow. It does
+   *  NOT exempt a same-lineage sibling database (same system identifier,
+   *  different database OID); that case still fails `isSameDatabase()` and the
+   *  lineage guard still refuses it. */
   allowSameDatabaseIdentity?: boolean;
   /** Statement-reorder assist. Default: true. */
   reorder?: boolean;
@@ -390,7 +398,8 @@ export async function planSchemaFiles(
     shadowPool,
     "planSchemaFiles shadow safety",
   );
-  if (isSameDatabase(targetIdentity, shadowIdentity)) {
+  const sameDatabaseIdentity = isSameDatabase(targetIdentity, shadowIdentity);
+  if (sameDatabaseIdentity) {
     if (options.allowSameDatabaseIdentity !== true) {
       throw new SchemaFrontendError(
         `planSchemaFiles: shadow and target are the same observed database (${targetIdentity.database}); refusing to load declarative SQL. ` +
@@ -402,16 +411,24 @@ export async function planSchemaFiles(
     options.onWarning?.(
       `shadow and target report the same database identity (system identifier + database OID) for "${targetIdentity.database}". ` +
         `This is expected for a physically restored/cloned shadow; the same-database safety guard was explicitly bypassed ` +
-        `(allowSameDatabaseIdentity / --allow-same-database-identity). If the shadow is NOT a separate server, ` +
-        `declarative SQL is being loaded into the target itself.`,
+        `(allowSameDatabaseIdentity / --allow-same-database-identity), and the lineage containment checks below were exempted ` +
+        `for this exact-identity match too. If the shadow is NOT a separate server, declarative SQL is being loaded into the target itself.`,
     );
   }
+  // The bypass attests "my shadow is a physical clone of the target" — it exempts
+  // lineage containment ONLY for that exact-identity match, never for a same-lineage
+  // sibling database (same systemIdentifier, different databaseOid), which is a
+  // genuinely different database on the same cluster and must still be refused.
+  const trustedCloneBypass =
+    options.allowSameDatabaseIdentity === true && sameDatabaseIdentity;
   if (
     options.isolatedShadow === true &&
-    isSamePostgresLineage(targetIdentity, shadowIdentity)
+    isSamePostgresLineage(targetIdentity, shadowIdentity) &&
+    !trustedCloneBypass
   ) {
     throw new SchemaFrontendError(
-      "planSchemaFiles: an isolated shadow requires a different PostgreSQL lineage; the supplied shadow shares the target lineage",
+      "planSchemaFiles: an isolated shadow requires a different PostgreSQL lineage; the supplied shadow shares the target lineage " +
+        "(same-lineage sibling databases are not covered by allowSameDatabaseIdentity)",
     );
   }
 

--- a/packages/pg-delta/tests/schema-same-database-identity.test.ts
+++ b/packages/pg-delta/tests/schema-same-database-identity.test.ts
@@ -98,7 +98,9 @@ describe("planSchemaFiles same-database identity bypass", () => {
           `SELECT to_regnamespace('cloned_shadow') IS NOT NULL AS present`,
         ),
       ).toMatchObject({ rows: [{ present: true }] });
-      expect(warnings.some((w) => /same database identity/i.test(w))).toBe(true);
+      expect(warnings.some((w) => /same database identity/i.test(w))).toBe(
+        true,
+      );
     } finally {
       await db.drop();
     }

--- a/packages/pg-delta/tests/schema-same-database-identity.test.ts
+++ b/packages/pg-delta/tests/schema-same-database-identity.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Opt-in bypass of the shadow-vs-target "same observed database" refusal.
+ *
+ * Physically restored shadows (a warm shadow cache rehydrated from a PGDATA
+ * snapshot, as the Supabase CLI provisions) inherit the target cluster's
+ * system_identifier AND every database OID, so the identity guard cannot tell
+ * such a shadow apart from the target and refuses to load declarative SQL.
+ * The bypass lets an operator who knows the shadow is a separate server
+ * proceed; it is off by default and warns loudly when used.
+ *
+ * Integration (Postgres via testcontainers).
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cmdSchemaApply } from "../src/cli/commands/schema.ts";
+import { planSchemaFiles, type SqlFile } from "../src/frontends/index.ts";
+import { rawProfile } from "../src/integrations/index.ts";
+import { createTestDb, sharedCluster } from "./containers.ts";
+
+const FILES: SqlFile[] = [
+  {
+    name: "schema.sql",
+    sql: "CREATE SCHEMA cloned_shadow;\nCREATE TABLE cloned_shadow.items (id integer PRIMARY KEY);\n",
+  },
+];
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected operation to reject");
+}
+
+function sqlDir(name: string, sql: string): string {
+  const dir = join(tmpdir(), `${name}-${Date.now()}-${Math.random()}`);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "schema.sql"), sql);
+  return dir;
+}
+
+/** A second URL for the same database with a different endpoint spelling.
+ *  `schema apply` rejects a literally identical --shadow/--target endpoint
+ *  before it ever observes identities, so reaching the identity guard (the
+ *  guard a physically cloned shadow trips, where the endpoints legitimately
+ *  differ) requires an alias — the same trick tests/schema-shadow-safety.ts
+ *  uses. */
+function aliasUri(uri: string): string {
+  const alias = new URL(uri);
+  alias.hostname = alias.hostname === "localhost" ? "127.0.0.1" : "localhost";
+  return alias.toString();
+}
+
+describe("planSchemaFiles same-database identity bypass", () => {
+  test("refuses by default and names the escape hatch", async () => {
+    const db = await createTestDb("same_identity_default");
+    try {
+      const error = await captureError(
+        planSchemaFiles(db.pool, db.pool, FILES, {
+          profile: rawProfile,
+          scope: "database",
+        }),
+      );
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toMatch(/same observed database/i);
+      // The field failure is a physically cloned shadow — the message must say
+      // so and name the opt-out, or the operator has no way forward.
+      expect(message).toContain("allowSameDatabaseIdentity");
+      expect(
+        await db.pool.query(
+          `SELECT to_regnamespace('cloned_shadow') IS NULL AS absent`,
+        ),
+      ).toMatchObject({ rows: [{ absent: true }] });
+    } finally {
+      await db.drop();
+    }
+  }, 120_000);
+
+  test("proceeds with a warning when the bypass is set", async () => {
+    const db = await createTestDb("same_identity_bypass");
+    try {
+      const warnings: string[] = [];
+      const result = await planSchemaFiles(db.pool, db.pool, FILES, {
+        profile: rawProfile,
+        scope: "database",
+        allowSameDatabaseIdentity: true,
+        onWarning: (message) => warnings.push(message),
+      });
+      // The target is extracted before the shadow load, so the loaded objects
+      // still show up as planned creations even though both pools share a db.
+      expect(result.plan.deltas.length).toBeGreaterThan(0);
+      expect(
+        await db.pool.query(
+          `SELECT to_regnamespace('cloned_shadow') IS NOT NULL AS present`,
+        ),
+      ).toMatchObject({ rows: [{ present: true }] });
+      expect(warnings.some((w) => /same database identity/i.test(w))).toBe(true);
+    } finally {
+      await db.drop();
+    }
+  }, 120_000);
+
+  test("the bypass is a no-op when the identities differ", async () => {
+    const target = await createTestDb("same_identity_noop_t");
+    const shadow = await createTestDb("same_identity_noop_s");
+    try {
+      const warnings: string[] = [];
+      const result = await planSchemaFiles(target.pool, shadow.pool, FILES, {
+        profile: rawProfile,
+        scope: "database",
+        allowSameDatabaseIdentity: true,
+        onWarning: (message) => warnings.push(message),
+      });
+      expect(result.plan.deltas.length).toBeGreaterThan(0);
+      expect(warnings.some((w) => /same database identity/i.test(w))).toBe(
+        false,
+      );
+    } finally {
+      await target.drop();
+      await shadow.drop();
+    }
+  }, 120_000);
+});
+
+describe("schema apply --allow-same-database-identity", () => {
+  test("refuses without the flag and names it", async () => {
+    const cluster = await sharedCluster();
+    const target = await cluster.createDb("same_identity_cli_deny");
+    try {
+      const dir = sqlDir("same-identity-deny", "CREATE SCHEMA cloned_shadow;");
+      const error = await captureError(
+        cmdSchemaApply([
+          "--dir",
+          dir,
+          "--shadow",
+          aliasUri(target.uri),
+          "--target",
+          target.uri,
+          "--dry-run",
+        ]),
+      );
+      expect((error as Error).message).toContain(
+        "shadow and target are the same observed database",
+      );
+      expect((error as Error).message).toContain(
+        "--allow-same-database-identity",
+      );
+    } finally {
+      await target.drop();
+    }
+  }, 120_000);
+
+  test("proceeds with a stderr warning when the flag is passed", async () => {
+    const cluster = await sharedCluster();
+    const target = await cluster.createDb("same_identity_cli_allow");
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    const captured: string[] = [];
+    try {
+      const dir = sqlDir("same-identity-allow", "CREATE SCHEMA cloned_shadow;");
+      (process.stderr as { write: unknown }).write = (
+        chunk: string | Uint8Array,
+        ...rest: unknown[]
+      ): boolean => {
+        captured.push(typeof chunk === "string" ? chunk : String(chunk));
+        return (originalWrite as (...a: unknown[]) => boolean)(chunk, ...rest);
+      };
+      await cmdSchemaApply([
+        "--dir",
+        dir,
+        "--shadow",
+        aliasUri(target.uri),
+        "--target",
+        target.uri,
+        "--allow-same-database-identity",
+        "--dry-run",
+      ]);
+      expect(
+        captured.some((line) => /same database identity/i.test(line)),
+      ).toBe(true);
+    } finally {
+      (process.stderr as { write: unknown }).write = originalWrite;
+      await target.drop();
+    }
+  }, 120_000);
+});

--- a/packages/pg-delta/tests/schema-same-database-identity.test.ts
+++ b/packages/pg-delta/tests/schema-same-database-identity.test.ts
@@ -126,6 +126,42 @@ describe("planSchemaFiles same-database identity bypass", () => {
       await shadow.drop();
     }
   }, 120_000);
+
+  test("the bypass also exempts the isolated-shadow lineage guard for the exact-identity match", async () => {
+    const db = await createTestDb("same_identity_isolated_bypass");
+    try {
+      const result = await planSchemaFiles(db.pool, db.pool, FILES, {
+        profile: rawProfile,
+        scope: "database",
+        allowSameDatabaseIdentity: true,
+        isolatedShadow: true,
+      });
+      expect(result.plan.deltas.length).toBeGreaterThan(0);
+    } finally {
+      await db.drop();
+    }
+  }, 120_000);
+
+  test("the bypass does NOT exempt a same-lineage sibling database from the isolated-shadow lineage guard", async () => {
+    const target = await createTestDb("same_identity_sibling_t");
+    const shadow = await createTestDb("same_identity_sibling_s");
+    try {
+      const error = await captureError(
+        planSchemaFiles(target.pool, shadow.pool, FILES, {
+          profile: rawProfile,
+          scope: "database",
+          allowSameDatabaseIdentity: true,
+          isolatedShadow: true,
+        }),
+      );
+      expect((error as Error).message).toMatch(
+        /isolated shadow requires a different PostgreSQL lineage/i,
+      );
+    } finally {
+      await target.drop();
+      await shadow.drop();
+    }
+  }, 120_000);
 });
 
 describe("schema apply --allow-same-database-identity", () => {
@@ -185,6 +221,30 @@ describe("schema apply --allow-same-database-identity", () => {
       ).toBe(true);
     } finally {
       (process.stderr as { write: unknown }).write = originalWrite;
+      await target.drop();
+    }
+  }, 120_000);
+
+  test("proceeds with --isolated-shadow when the flag is passed and shadow is a cloned target", async () => {
+    const cluster = await sharedCluster();
+    const target = await cluster.createDb("same_identity_cli_isolated");
+    try {
+      const dir = sqlDir(
+        "same-identity-isolated",
+        "CREATE SCHEMA cloned_shadow;",
+      );
+      await cmdSchemaApply([
+        "--dir",
+        dir,
+        "--shadow",
+        aliasUri(target.uri),
+        "--target",
+        target.uri,
+        "--isolated-shadow",
+        "--allow-same-database-identity",
+        "--dry-run",
+      ]);
+    } finally {
       await target.drop();
     }
   }, 120_000);


### PR DESCRIPTION
## Problem

The shadow-vs-target safety guard refuses to load declarative SQL when both connections observe the same database identity (`system_identifier` + database OID, see `isSameDatabase()` in `src/database-identity.ts`). A **physically restored shadow** — e.g. the Supabase CLI's warm shadow cache rehydrated from a PGDATA snapshot of the target cluster — inherits both, so a genuinely separate shadow server is indistinguishable from the target and the guard refuses:

```
Declarative schema planning failed: planSchemaFiles: shadow and target are the same observed database (postgres); refusing to load declarative SQL
```

This blocks `db schema declarative sync` whenever the shadow cache is on (both cold and warm paths); `SUPABASE_SHADOW_CACHE=false` was the only workaround.

## Fix (opt-in bypass, default unchanged)

- `planSchemaFiles` gains `allowSameDatabaseIdentity?: boolean`; `pgdelta schema apply` gains `--allow-same-database-identity`.
- Default off: the refusal still fires, and its message now explains that physically cloned shadows legitimately trigger it and names the escape hatch.
- With the flag on and identities matching, planning proceeds and a loud warning is emitted through `onWarning` stating exactly what was bypassed. The flag is a no-op when identities differ.
- The earlier endpoint-hash guard (`--shadow` resolving to the target endpoint) is deliberately **not** relaxed — a warm-cached shadow always has a distinct host/port.

Callers provisioning physically cloned shadows should pass the flag; alternatively, running `pg_resetwal` on the restored PGDATA gives clones a fresh system identifier and makes the flag unnecessary.

## RED → GREEN

New regression file `tests/schema-same-database-identity.test.ts` (5 tests: library refuse/bypass/no-op, CLI refuse/bypass). RED on the test-only commit (b795c753):

```
Expected to contain: "allowSameDatabaseIdentity"
Received: "planSchemaFiles: shadow and target are the same observed database (same_identity_default_0); refusing to load declarative SQL"
UsageError: Unknown flag: --allow-same-database-identity
1 pass / 4 fail
```

GREEN after the fix commit: `5 pass, 0 fail`.

## Validation

- Focused file (postgres:17-alpine): 5 pass / 0 fail
- Unit suite `bun test src/`: 1267 pass / 0 fail
- Full corpus `tests/engine.test.ts` (postgres:17-alpine): 662 pass / 0 fail
- `format-and-lint:fix`, `check-types`: pass. `knip`: pre-existing pg-topo `Unused files` failure only, reproduces on the base commit; `@supabase/pg-delta` exits 0.

Changeset included (`patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)