### PR TITLE
feat(pg-delta): default flat declarative export layout with pathStyle option

### DIFF
--- a/.changeset/flat-declarative-export-layout.md
+++ b/.changeset/flat-declarative-export-layout.md
@@ -24,6 +24,7 @@ unaffected — but a re-export into an existing directory will move every file.
 - `pathStyle` composes with every `layout` (`by-object`, `ordered`, `grouped`).
   Under `ordered` the flattened file names get correspondingly shorter
   (`0001_app_tables_users.sql`).
-- A schema literally named `_cluster` or `_custom` — the two directories the
-  export tree reserves at its root — escapes its leading underscore
-  (`%5Fcluster/`, `%5Fcustom/`) so it can never claim one of them.
+- A schema named `_cluster` or `_custom` — the two directories the export tree
+  reserves at its root — or any case variant of one escapes its leading
+  underscore (`%5Fcluster/`, `%5FCUSTOM/`) so it can never claim, or case-fold
+  into, one of them on a case-insensitive filesystem.

--- a/.changeset/flat-declarative-export-layout.md
+++ b/.changeset/flat-declarative-export-layout.md
@@ -1,0 +1,29 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Flatten the default declarative-export tree.
+
+`schema export` now writes one directory **per schema at the root** of the
+output directory and puts the cluster-level files under `_cluster/`:
+
+```text
+schema/
+  _cluster/roles.sql
+  app/schema.sql
+  app/tables/users.sql
+```
+
+Previously those paths were `schemas/app/tables/users.sql` and
+`cluster/roles.sql`. Nothing below the root segment changed, and the loader is
+structure-agnostic, so `schema apply --dir` and `load(export(db)) ≡ db` are
+unaffected — but a re-export into an existing directory will move every file.
+
+- Pass `pathStyle: "nested"` (library) or `--path-style nested` (CLI) to keep
+  the previous paths.
+- `pathStyle` composes with every `layout` (`by-object`, `ordered`, `grouped`).
+  Under `ordered` the flattened file names get correspondingly shorter
+  (`0001_app_tables_users.sql`).
+- A schema literally named `_cluster` or `_custom` — the two directories the
+  export tree reserves at its root — escapes its leading underscore
+  (`%5Fcluster/`, `%5Fcustom/`) so it can never claim one of them.

--- a/.changeset/flat-declarative-export-layout.md
+++ b/.changeset/flat-declarative-export-layout.md
@@ -1,8 +1,8 @@
 ---
-"@supabase/pg-delta": minor
+"@supabase/pg-delta": major
 ---
 
-Flatten the default declarative-export tree.
+**Breaking:** flatten the default declarative-export tree.
 
 `schema export` now writes one directory **per schema at the root** of the
 output directory and puts the cluster-level files under `_cluster/`:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -179,6 +179,14 @@ Export the inverse — a live database back out to `.sql` files:
 
 ```bash
 pgdelta schema export --source "$SOURCE_URL" --out-dir ./schema
+# Writes one directory per schema at the root plus a reserved _cluster/ for
+# objects that belong to no schema:
+#   ./schema/_cluster/roles.sql
+#   ./schema/app/schema.sql
+#   ./schema/app/tables/users.sql
+# --path-style nested reproduces the historical schemas/app/tables/users.sql +
+# cluster/roles.sql tree (composes with every --layout).
+#
 # --layout by-object (default) groups by schema/kind; --layout ordered emits a
 # single load order with the load(export(db)) ≡ db guarantee
 #
@@ -221,7 +229,7 @@ has drifted (and prints the deltas) — handy in CI.
 | `prove` | Apply a plan to a clone and verify convergence + data preservation | `--plan` `--clone` `--desired-snapshot` `[--profile]` `[--strict-audit]` `[--audit-all]` `[--trusted-local-host]` `[--allow-remote-clone]` `[--allow-unverified-source-identity]` |
 | `snapshot` | Save a database's fact base to a file | `--source` `--out` `[--strict-coverage]` |
 | `drift` | Compare a live DB against a saved snapshot | `--env` `--snapshot` `[--strict-coverage]` |
-| `schema export` | Export a live DB to `.sql` files | `--source` `--out-dir` `[--layout]` `[--profile]` `[--strict-coverage]` |
+| `schema export` | Export a live DB to `.sql` files | `--source` `--out-dir` `[--layout]` `[--path-style]` `[--profile]` `[--strict-coverage]` |
 | `schema apply` | Load `.sql` files via a shadow DB and migrate a target | `--dir` `[--shadow]` `--target` `[--scope]` `[--isolated-shadow]` `[--renames]` `[--accept-rename]` `[--force]` `[--allow-data-loss]` `[--trusted-local-host]` `[--allow-remote-shadow]` `[--profile]` `[--restrict-to-applier]` `[--strict-coverage]` `[--dry-run]` `[--verbose]` `[--out-plan]` |
 
 Common flags, explained:

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -115,6 +115,43 @@ reported** as `unmodeled_kind` diagnostics, never silently dropped.
 See [COVERAGE.md](./COVERAGE.md) for the authoritative map and the deliberate
 exclusions, and `_custom/` below for where that SQL lives.
 
+## Export tree layout
+
+`schema export` writes one directory per schema at the root of the output
+directory, plus a reserved `_cluster/` directory for the cluster-level objects
+that belong to no schema:
+
+```text
+schema/
+  _cluster/
+    roles.sql
+    publications.sql
+    extensions/pgcrypto.sql
+  app/
+    schema.sql
+    tables/users.sql          ← columns, defaults, constraints, indexes,
+    views/user_notes.sql         triggers and policies live with their relation
+    functions/add.sql
+```
+
+Two flags shape this tree, and they compose:
+
+- `--path-style flat|nested` — where the two **root** segments live. `flat` is
+  the default (shown above). `nested` reproduces the historical
+  `schemas/app/tables/users.sql` + `cluster/roles.sql` tree, for tooling that
+  pins those paths. Nothing below the root segment differs.
+  A schema literally named `_cluster` or `_custom` — the two reserved root
+  directories — escapes its leading underscore under `flat`
+  (`%5Fcluster/`, `%5Fcustom/`), so it can never claim a directory the export
+  owns.
+- `--layout by-object|ordered|grouped` — how statements are distributed across
+  files: one file per object (default), numbered files in dependency order, or
+  the category-ordered "nice" export with opt-in grouping.
+
+The loader is structure-agnostic — `schema apply --dir` reads every `.sql`
+under the directory recursively — so the layout is purely a readability
+choice. `load(export(db)) ≡ db` holds for every combination.
+
 ## `_custom/` — the escape hatch inside an export
 
 `schema export` owns its output directory: it prunes what a previous export
@@ -126,7 +163,9 @@ schema/
   _custom/           ← yours; never written to, never pruned, never refused on
     README.md        ← scaffolded on export, documents this contract
     text-search.sql
-  schemas/…          ← regenerated on every export
+  _cluster/…         ← regenerated on every export (roles, publications, …)
+  public/…           ← one directory per schema
+  app/…
   .pgdelta-export.json
 ```
 

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -140,10 +140,10 @@ Two flags shape this tree, and they compose:
   the default (shown above). `nested` reproduces the historical
   `schemas/app/tables/users.sql` + `cluster/roles.sql` tree, for tooling that
   pins those paths. Nothing below the root segment differs.
-  A schema literally named `_cluster` or `_custom` — the two reserved root
-  directories — escapes its leading underscore under `flat`
-  (`%5Fcluster/`, `%5Fcustom/`), so it can never claim a directory the export
-  owns.
+  A schema named `_cluster` or `_custom` — the two reserved root directories —
+  or any case variant of one escapes its leading underscore under `flat`
+  (`%5Fcluster/`, `%5FCUSTOM/`), so it can never claim, or case-fold into, a
+  directory the export owns.
 - `--layout by-object|ordered|grouped` — how statements are distributed across
   files: one file per object (default), numbered files in dependency order, or
   the category-ordered "nice" export with opt-in grouping.

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -3,8 +3,16 @@
  *   Export the source database as SQL files written to disk.
  *   Maps to old `declarative-export`.
  *
+ *   --path-style flat|nested (any layout) — where the two ROOT segments live.
+ *     flat (default): schema directories at the export root and cluster-level
+ *       files under `_cluster/` — `app/tables/t.sql`, `_cluster/roles.sql`.
+ *       A schema literally named `_cluster` / `_custom` (the two reserved root
+ *       directories) escapes to `%5Fcluster/` / `%5Fcustom/`.
+ *     nested: the historical `schemas/app/tables/t.sql` + `cluster/roles.sql`
+ *       tree, for callers whose tooling pins those paths.
+ *
  *   Layouts:
- *     by-object (default) — the familiar tree (schemas/<s>/tables/<t>.sql, …),
+ *     by-object (default) — the familiar tree (<s>/tables/<t>.sql, …),
  *       files in dependency/plan order.
  *     ordered — numbered files in plan order; the loader converges in one pass.
  *     grouped — the old engine's "nice" export: files ordered by semantic
@@ -127,6 +135,7 @@ import { join, dirname, relative, resolve, sep } from "node:path";
 import type {
   ExportGrouping,
   ExportGroupingPattern,
+  ExportPathStyle,
 } from "../../frontends/export-sql-files.ts";
 import type { SqlFormatOptions } from "../../frontends/sql-format/index.ts";
 import {
@@ -394,6 +403,7 @@ export async function cmdSchemaExport(args: string[]): Promise<void> {
       source: { type: "value", required: true },
       "out-dir": { type: "value", required: true },
       layout: { type: "value" },
+      "path-style": { type: "value" },
       profile: { type: "value" },
       "strict-coverage": { type: "boolean" },
       "unsafe-show-secrets": { type: "boolean" },
@@ -411,7 +421,8 @@ export async function cmdSchemaExport(args: string[]): Promise<void> {
     if (err instanceof UsageError) {
       throw new UsageError(
         `${err.message}\nUsage: pgdelta schema export --source <pg-url> --out-dir <dir> ` +
-          `[--layout by-object|ordered|grouped] [--profile ${PROFILE_IDS}] [--strict-coverage] [--unsafe-show-secrets] [--scope database|cluster] [--prune-unmanaged]\n` +
+          `[--layout by-object|ordered|grouped] [--path-style flat|nested] [--profile ${PROFILE_IDS}] [--strict-coverage] [--unsafe-show-secrets] [--scope database|cluster] [--prune-unmanaged]\n` +
+          `  [--path-style flat|nested] (flat, the default: <schema>/tables/t.sql + _cluster/roles.sql; nested: the historical schemas/<schema>/… + cluster/…)\n` +
           `  [--default-owner <role|none>] (which owner stays implicit; default: profile default or the database owner; "none" emits every OWNER TO)\n` +
           `  [--prune-unmanaged] (delete .sql files in --out-dir this export does not own; refuse otherwise)\n` +
           `  [--format-options '{"keywordCase":"upper","maxWidth":180}'] [--no-format]\n` +
@@ -447,6 +458,17 @@ export async function cmdSchemaExport(args: string[]): Promise<void> {
       );
     }
     layout = v;
+  }
+  // Root-segment style, orthogonal to --layout: `flat` (default) puts schema
+  // directories at the export root with cluster files under `_cluster/`;
+  // `nested` reproduces the historical `schemas/<s>/…` + `cluster/…` tree.
+  let pathStyle: ExportPathStyle = "flat";
+  if (flags["path-style"] !== undefined) {
+    const v = flags["path-style"];
+    if (v !== "flat" && v !== "nested") {
+      throw new UsageError(`--path-style must be flat or nested (got: ${v})`);
+    }
+    pathStyle = v;
   }
 
   // Grouping options apply only to the grouped layout. Parse them up front so
@@ -538,6 +560,7 @@ export async function cmdSchemaExport(args: string[]): Promise<void> {
       scope: exportScope,
       redactSecrets,
       layout,
+      pathStyle,
       ...(grouping !== undefined ? { grouping } : {}),
       ...(format !== undefined ? { format } : {}),
       ...(flags["default-owner"] === "none"
@@ -597,7 +620,7 @@ export async function cmdSchemaExport(args: string[]): Promise<void> {
       );
     }
     process.stderr.write(
-      `Exported ${result.files.length} file(s) to ${outDir} (layout: ${layout}): ` +
+      `Exported ${result.files.length} file(s) to ${outDir} (layout: ${layout}, path style: ${pathStyle}): ` +
         `${created.length} created, ${updated.length} updated, ${unchanged.length} unchanged\n`,
     );
   } finally {

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -6,8 +6,9 @@
  *   --path-style flat|nested (any layout) — where the two ROOT segments live.
  *     flat (default): schema directories at the export root and cluster-level
  *       files under `_cluster/` — `app/tables/t.sql`, `_cluster/roles.sql`.
- *       A schema literally named `_cluster` / `_custom` (the two reserved root
- *       directories) escapes to `%5Fcluster/` / `%5Fcustom/`.
+ *       A schema named `_cluster` / `_custom` — the two reserved root
+ *       directories — or any CASE VARIANT of one escapes its leading
+ *       underscore: `%5Fcluster/`, `%5FCUSTOM/`.
  *     nested: the historical `schemas/app/tables/t.sql` + `cluster/roles.sql`
  *       tree, for callers whose tooling pins those paths.
  *
@@ -327,10 +328,17 @@ export function writeExportFiles(
     );
   }
   // Refuse BEFORE writing anything, like the unmanaged check: no layout emits a
-  // `_custom/…` path, so this is unreachable — but the reservation must be
-  // ENFORCED where files are written, not assumed, since writing there would
-  // silently overwrite hand-authored SQL the pruner is protecting.
-  const reserved = files.filter((file) => isCustomPath(file.name));
+  // `_custom/…` path (the flat style escapes a schema of that name — and of any
+  // CASE VARIANT of it — to `%5Fcustom/`), so this is unreachable — but the
+  // reservation must be ENFORCED where files are written, not assumed, since
+  // writing there would silently overwrite hand-authored SQL the pruner is
+  // protecting. Matched case-INSENSITIVELY here: on APFS/NTFS a `_CUSTOM/…`
+  // path resolves into the reserved directory just the same, and unlike the
+  // unmanaged check there is no exported path to collide with that would
+  // surface it (Codex review, PR #430).
+  const reserved = files.filter((file) =>
+    isCustomPath(file.name.toLowerCase()),
+  );
   if (reserved.length > 0) {
     throw new Error(
       `export: refusing to write into the reserved ${CUSTOM_DIR_NAME}/ directory:\n` +

--- a/packages/pg-delta/src/cli/main.ts
+++ b/packages/pg-delta/src/cli/main.ts
@@ -26,6 +26,7 @@
  *   drift          --env <pg-url> --snapshot <file>
  *   snapshot       --source <pg-url> --out <file>
  *   schema export  --source <pg-url> --out-dir <dir> [--layout by-object|ordered|grouped]
+ *                  [--path-style flat|nested]
  *   schema apply   --dir <dir> [--shadow <pg-url>] --target <pg-url>
  *                  [--renames auto|prompt|off] [--force]
  *                  [--accept-rename <from>=<to>] ... [--no-reorder]
@@ -74,6 +75,7 @@ Commands:
   drift          --env <pg-url> --snapshot <file>
   snapshot       --source <pg-url> --out <file>
   schema export  --source <pg-url> --out-dir <dir> [--layout by-object|ordered|grouped]
+                 [--path-style flat|nested]   (flat: <schema>/…, _cluster/…)
                  [--format-options <json>]   (pretty-print SQL; any layout)
                  grouped adds: [--grouping-mode single-file|subdirectory]
                  [--group-patterns <json>] [--flat-schemas <csv>] [--no-group-partitions]
@@ -203,6 +205,7 @@ pgdelta schema <subcommand> [options]
 
 Subcommands:
   schema export  --source <pg-url> --out-dir <dir> [--layout by-object|ordered|grouped]
+                 [--path-style flat|nested]   (flat: <schema>/…, _cluster/…)
                  [--format-options <json>]   (pretty-print SQL; any layout)
                  grouped adds: [--grouping-mode single-file|subdirectory]
                  [--group-patterns <json>] [--flat-schemas <csv>] [--no-group-partitions]

--- a/packages/pg-delta/src/frontends/export-case-collisions.test.ts
+++ b/packages/pg-delta/src/frontends/export-case-collisions.test.ts
@@ -180,14 +180,12 @@ describe("exportSqlFiles merges case-colliding paths into one file", () => {
       const files = exportSqlFiles(buildFactBase(facts, []), options);
       expectCaseInsensitivelyUnique(names(files));
       // both twins' DDL lands in ONE shared file at the canonical member path
-      const merged = files.find(
-        (f) => f.name === "schemas/public/tables/Users.sql",
-      );
+      const merged = files.find((f) => f.name === "public/tables/Users.sql");
       expect(merged?.sql).toContain(`"Users"`);
       expect(merged?.sql).toContain(`"users"`);
-      expect(names(files)).not.toContain("schemas/public/tables/users.sql");
+      expect(names(files)).not.toContain("public/tables/users.sql");
       // bystander untouched
-      expect(names(files)).toContain("schemas/public/tables/orders.sql");
+      expect(names(files)).toContain("public/tables/orders.sql");
     });
   }
 
@@ -216,7 +214,7 @@ describe("exportSqlFiles merges case-colliding paths into one file", () => {
     ];
     const files = exportSqlFiles(buildFactBase(dotted, []));
     const table = files.find((f) => f.name.includes("Foo"));
-    expect(table?.name).toBe("schemas/public/tables/Foo%2Efk.sql");
+    expect(table?.name).toBe("public/tables/Foo%2Efk.sql");
     // no spoofed split-file header on an ordinary table file
     expect(table?.sql).not.toContain("reference cycle");
   });

--- a/packages/pg-delta/src/frontends/export-path-style.test.ts
+++ b/packages/pg-delta/src/frontends/export-path-style.test.ts
@@ -1,0 +1,66 @@
+/**
+ * `pathStyle` decides the two ROOT segments of every export path, orthogonally
+ * to `layout`. These are pure fact-base → path assertions (no database): the
+ * end-to-end coverage lives in tests/export-layout.test.ts and
+ * tests/export.test.ts (round-trip through the escape).
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import { CUSTOM_DIR_NAME } from "./custom-dir.ts";
+import { exportSqlFiles, RESERVED_ROOT_SEGMENTS } from "./export-sql-files.ts";
+
+const schemaFacts = (...schemas: string[]): Fact[] =>
+  schemas.flatMap((name): Fact[] => [
+    { id: { kind: "schema", name }, payload: {} },
+    {
+      id: { kind: "table", schema: name, name: "t" },
+      parent: { kind: "schema", name },
+      payload: { persistence: "p" },
+    },
+  ]);
+
+const names = (facts: Fact[], options?: Parameters<typeof exportSqlFiles>[1]) =>
+  exportSqlFiles(buildFactBase(facts, []), options).map((f) => f.name);
+
+describe("export path style", () => {
+  test("flat is the default: schema dirs at the root", () => {
+    const flat = names(schemaFacts("app"));
+    expect(flat).toContain("app/schema.sql");
+    expect(flat).toContain("app/tables/t.sql");
+    expect(flat.some((n) => n.startsWith("schemas/"))).toBe(false);
+    expect(names(schemaFacts("app"), { pathStyle: "flat" })).toEqual(flat);
+  });
+
+  test('"nested" keeps the historical schemas/ wrapper', () => {
+    const nested = names(schemaFacts("app"), { pathStyle: "nested" });
+    expect(nested).toContain("schemas/app/schema.sql");
+    expect(nested).toContain("schemas/app/tables/t.sql");
+  });
+
+  test("reserved root names escape their leading underscore under flat", () => {
+    const flat = names(schemaFacts("_cluster", "_custom", "_foo"));
+    expect(flat).toContain("%5Fcluster/schema.sql");
+    expect(flat).toContain("%5Fcustom/schema.sql");
+    // an ordinary underscore-prefixed schema is untouched
+    expect(flat).toContain("_foo/schema.sql");
+    // …and the escape is injective: `%` is itself percent-encoded, so no
+    // other identifier can produce the escaped spelling.
+    expect(names(schemaFacts("%5Fcluster"))).toContain(
+      "%255Fcluster/schema.sql",
+    );
+  });
+
+  test("nested reserves nothing — the schemas/ wrapper separates namespaces", () => {
+    const nested = names(schemaFacts("_cluster", "_custom"), {
+      pathStyle: "nested",
+    });
+    expect(nested).toContain("schemas/_cluster/schema.sql");
+    expect(nested).toContain("schemas/_custom/schema.sql");
+  });
+
+  test("the reserved set agrees with the _custom directory contract", () => {
+    // export-sql-files.ts keeps the name as a literal so the pure path layer
+    // does not import the fs-touching custom-dir module; this pins them equal.
+    expect(RESERVED_ROOT_SEGMENTS.has(CUSTOM_DIR_NAME)).toBe(true);
+  });
+});

--- a/packages/pg-delta/src/frontends/export-path-style.test.ts
+++ b/packages/pg-delta/src/frontends/export-path-style.test.ts
@@ -50,6 +50,29 @@ describe("export path style", () => {
     );
   });
 
+  test("the reservation is case-INSENSITIVE (APFS/NTFS fold one directory)", () => {
+    // `_CUSTOM/schema.sql` and `_custom/…` are ONE physical file on a
+    // case-insensitive filesystem, so an exact-case reservation puts exported
+    // schema content inside the reserved hand-authored directory: nothing
+    // detects it (no exported action path lives under `_custom/`, so the
+    // case-collision fold never sees a collision) and `writeExportFiles`
+    // classifies a hand-authored `_custom/schema.sql` as an UPDATE and
+    // overwrites it. Every case variant escapes instead, preserving its own
+    // spelling after the `%5F`.
+    // (`_CUSTOM` and `_Cluster` are not case twins of EACH OTHER, so this
+    // isolates the reservation from the separate case-collision fold.)
+    const flat = names(schemaFacts("_CUSTOM", "_Cluster"));
+    expect(flat).toContain("%5FCUSTOM/schema.sql");
+    expect(flat).toContain("%5FCluster/schema.sql");
+    expect(flat).toContain("%5FCluster/tables/t.sql");
+    // no emitted path may land in a reserved root under case folding
+    const roots = flat.map((n) => n.split("/")[0]?.toLowerCase());
+    expect(roots).not.toContain("_custom");
+    expect(roots).not.toContain("_cluster");
+    // each case variant keeps its own spelling → distinct objects stay distinct
+    expect(names(schemaFacts("_custom"))).toContain("%5Fcustom/schema.sql");
+  });
+
   test("nested reserves nothing — the schemas/ wrapper separates namespaces", () => {
     const nested = names(schemaFacts("_cluster", "_custom"), {
       pathStyle: "nested",

--- a/packages/pg-delta/src/frontends/export-schema-adp.test.ts
+++ b/packages/pg-delta/src/frontends/export-schema-adp.test.ts
@@ -57,14 +57,14 @@ describe("schema-scoped ADP export routing", () => {
   for (const layout of ["by-object", "grouped"] as const) {
     test(`schema-scoped ADP is split out of the role file (${layout})`, () => {
       const name = fileOf(layout, "IN SCHEMA");
-      expect(name).not.toBe("cluster/roles.sql");
-      expect(name.startsWith("schemas/app/")).toBe(true);
+      expect(name).not.toBe("_cluster/roles.sql");
+      expect(name.startsWith("app/")).toBe(true);
     });
 
     test(`a global ADP stays in the role file (${layout})`, () => {
       // the FUNCTIONS (objtype f) ADP has no schema — keep it with the roles
       const name = fileOf(layout, "ON FUNCTIONS");
-      expect(name).toBe("cluster/roles.sql");
+      expect(name).toBe("_cluster/roles.sql");
     });
   }
 });

--- a/packages/pg-delta/src/frontends/export-sql-files.ts
+++ b/packages/pg-delta/src/frontends/export-sql-files.ts
@@ -5,13 +5,17 @@
  *
  * Two layouts:
  * - "by-object" (default): the human layout users know from the old
- *   engine's exporter — cluster/roles.sql, schemas/<s>/tables/<t>.sql, …
+ *   engine's exporter — _cluster/roles.sql, <schema>/tables/<t>.sql, …
  *   Files within a path are emitted in plan (dependency) order, but the
  *   loader's lexicographic discovery may need its bounded retry rounds for
  *   cross-file references. Fidelity is the gate: load(export(fb)) ≡ fb.
  * - "ordered": file names carry a zero-padded sequence prefix in plan
  *   order, so lexicographic discovery IS dependency order and the loader
  *   converges with zero deferred rounds (the stage-9 zero-round gate).
+ *
+ * Orthogonally, `pathStyle` decides the two ROOT segments every layout builds
+ * on ({@link clusterRoot} / {@link schemaRoot}) — "flat" (default) or the
+ * historical "nested". Nothing below the root differs between the styles.
  */
 import { createHash } from "node:crypto";
 import { buildFactBase, type FactBase } from "../core/fact.ts";
@@ -46,8 +50,26 @@ export interface ExportGrouping {
   autoGroupPartitions?: boolean;
 }
 
+/**
+ * Where the two ROOT segments of an export tree live. Orthogonal to `layout`
+ * (every layout composes with both styles), and everything BELOW the root is
+ * identical either way.
+ *
+ * - `"flat"` (default): schema directories sit at the export root
+ *   (`app/tables/t.sql`) and cluster-level files under `_cluster/`
+ *   (`_cluster/roles.sql`). One level less nesting in the tree users read,
+ *   diff, and review.
+ * - `"nested"`: the historical `schemas/app/tables/t.sql` + `cluster/roles.sql`
+ *   tree, kept as a back-compat escape hatch for callers whose tooling pins
+ *   those paths.
+ */
+export type ExportPathStyle = "flat" | "nested";
+
 export interface ExportOptions {
   layout?: "by-object" | "ordered" | "grouped";
+  /** Root-segment layout of the emitted paths (default: `"flat"`).
+   *  See {@link ExportPathStyle}. */
+  pathStyle?: ExportPathStyle;
   /** Grouping rules for the "grouped" layout; ignored by other layouts. */
   grouping?: ExportGrouping;
   /** Pretty-print each file's SQL with the formatter (frontends/sql-format).
@@ -263,18 +285,19 @@ function scopeRank(id: StableId): number {
   }
 }
 
+/** Cluster-level file names, RELATIVE to {@link clusterRoot}. */
 const CLUSTER_FILES: Record<string, string> = {
-  role: "cluster/roles.sql",
-  membership: "cluster/roles.sql",
-  defaultPrivilege: "cluster/roles.sql",
-  fdw: "cluster/foreign_data_wrappers.sql",
-  server: "cluster/foreign_data_wrappers.sql",
-  userMapping: "cluster/foreign_data_wrappers.sql",
-  publication: "cluster/publications.sql",
-  publicationRel: "cluster/publications.sql",
-  publicationSchema: "cluster/publications.sql",
-  subscription: "cluster/subscriptions.sql",
-  eventTrigger: "cluster/event_triggers.sql",
+  role: "roles.sql",
+  membership: "roles.sql",
+  defaultPrivilege: "roles.sql",
+  fdw: "foreign_data_wrappers.sql",
+  server: "foreign_data_wrappers.sql",
+  userMapping: "foreign_data_wrappers.sql",
+  publication: "publications.sql",
+  publicationRel: "publications.sql",
+  publicationSchema: "publications.sql",
+  subscription: "subscriptions.sql",
+  eventTrigger: "event_triggers.sql",
 };
 
 const SCHEMA_DIRS: Record<string, string> = {
@@ -335,11 +358,58 @@ function clampSegment(segment: string): string {
   return `${segment.slice(0, MAX_SEGMENT_LENGTH - 17)}-${hash.slice(0, 16)}`;
 }
 
+/**
+ * Root-level directory names the export tree owns under the `"flat"` style,
+ * where SCHEMA directories are root-level too and could otherwise claim one:
+ *
+ * - `_cluster` holds the cluster-level files this module emits (roles,
+ *   publications, extensions, …);
+ * - `_custom` is the reserved hand-authored-SQL directory (custom-dir.ts):
+ *   the exporter must never write into it (the CLI turns a collision into a
+ *   hard error) and the pruner never scans it, so a schema claiming it would
+ *   make the export unwritable. Kept as a literal rather than an import so the
+ *   pure path layer stays free of the fs-touching module; `_custom` is not
+ *   reserved under `"nested"`, where the `schemas/` wrapper separates the two
+ *   namespaces (export-path-style.test.ts pins that the two names agree).
+ *
+ * Matching is exact and case-SENSITIVE: `_CLUSTER` keeps its own spelling and
+ * is handled downstream by the case-collision fold (export-case-collisions.ts),
+ * which merges the twin roots into one spelling and reports it.
+ */
+export const RESERVED_ROOT_SEGMENTS: ReadonlySet<string> = new Set([
+  "_cluster",
+  "_custom",
+]);
+
+/** Root directory of the cluster-level files, for a path style. */
+function clusterRoot(style: ExportPathStyle): string {
+  return style === "flat" ? "_cluster" : "cluster";
+}
+
+/**
+ * Root directory of a SCHEMA's files, for a path style. Under `"flat"` a
+ * schema whose encoded segment is exactly a {@link RESERVED_ROOT_SEGMENTS}
+ * name percent-encodes its leading underscore (`_cluster` → `%5Fcluster`), so
+ * it can never claim a directory the export tree owns. `%` itself is escaped
+ * by `encodeURIComponent`, so no other identifier can ever encode to the
+ * escaped spelling — the escape is injective. Other underscore-prefixed
+ * schemas (`_foo`) are untouched.
+ */
+function schemaRoot(style: ExportPathStyle, schema: string): string {
+  const segment = seg(schema);
+  if (style === "nested") return `schemas/${segment}`;
+  return RESERVED_ROOT_SEGMENTS.has(segment)
+    ? `%5F${segment.slice(1)}`
+    : segment;
+}
+
 /** Precomputed routing context threaded through {@link pathFor}: the cyclic-FK
  *  split set, the extension-member map, the index→relation parent map, the
  *  relation-kind map, and the concurrent-index exception set. Built once per
  *  export. */
 interface PathContext {
+  /** Root-segment style of every path built here ({@link ExportPathStyle}). */
+  readonly pathStyle: ExportPathStyle;
   /** Encoded ids of cycle-participating FK constraints (→ `.fk.sql`). */
   readonly cyclicFks: ReadonlySet<string>;
   /** Encoded extension-member object id → owning extension name. Satellites
@@ -689,6 +759,7 @@ function mergeDependencyCycles(
 function pathFor(id: StableId, ctx: PathContext): string {
   const target = fileTarget(id);
   const kind = target.kind;
+  const cluster = clusterRoot(ctx.pathStyle);
   // A satellite (acl/comment, unwrapped by fileTarget) whose target is an
   // EXTENSION MEMBER files into the owning extension's file, next to its
   // CREATE EXTENSION. Member objects themselves never yield actions
@@ -697,7 +768,7 @@ function pathFor(id: StableId, ctx: PathContext): string {
   // the state stays fully managed, only its file placement changes.
   const memberExtension = ctx.memberExt.get(encodeId(target));
   if (memberExtension !== undefined) {
-    return `cluster/extensions/${seg(memberExtension)}.sql`;
+    return `${cluster}/extensions/${seg(memberExtension)}.sql`;
   }
   // A schema-scoped ALTER DEFAULT PRIVILEGES depends on its schema, so it must
   // NOT share the atomic cluster/roles.sql file with CREATE ROLE: with reorder
@@ -708,16 +779,17 @@ function pathFor(id: StableId, ctx: PathContext): string {
   if (kind === "defaultPrivilege") {
     const schema = (target as { schema: string | null }).schema;
     if (schema !== null) {
-      return `schemas/${seg(schema)}/default_privileges.sql`;
+      return `${schemaRoot(ctx.pathStyle, schema)}/default_privileges.sql`;
     }
   }
   const clusterFile = CLUSTER_FILES[kind];
-  if (clusterFile !== undefined) return clusterFile;
+  if (clusterFile !== undefined) return `${cluster}/${clusterFile}`;
   if (kind === "extension") {
-    return `cluster/extensions/${seg((target as { name: string }).name)}.sql`;
+    return `${cluster}/extensions/${seg((target as { name: string }).name)}.sql`;
   }
   if (kind === "schema") {
-    return `schemas/${seg((target as { name: string }).name)}/schema.sql`;
+    const name = (target as { name: string }).name;
+    return `${schemaRoot(ctx.pathStyle, name)}/schema.sql`;
   }
   if (TABLE_SCOPED.has(kind)) {
     const t = target as { schema: string; table: string };
@@ -731,14 +803,14 @@ function pathFor(id: StableId, ctx: PathContext): string {
     // stay INLINE for readability — the loader's bounded retry orders their
     // files. `cyclicFks` is precomputed by {@link cyclicForeignKeys}.
     if (target.kind === "constraint" && ctx.cyclicFks.has(encodeId(target))) {
-      return `schemas/${seg(t.schema)}/tables/${seg(t.table)}.fk.sql`;
+      return `${schemaRoot(ctx.pathStyle, t.schema)}/tables/${seg(t.table)}.fk.sql`;
     }
     // The `table` field of a TABLE_SCOPED id names a RELATION, not necessarily
     // a table: an INSTEAD OF trigger / rule / comment can target a view or a
     // materialized view — file those with their actual relation.
     const relationDir =
       ctx.relationDir.get(nameKey(t.schema, t.table)) ?? "tables";
-    return `schemas/${seg(t.schema)}/${relationDir}/${seg(t.table)}.sql`;
+    return `${schemaRoot(ctx.pathStyle, t.schema)}/${relationDir}/${seg(t.table)}.sql`;
   }
   if (kind === "index") {
     const t = target as { schema: string; name: string };
@@ -748,17 +820,18 @@ function pathFor(id: StableId, ctx: PathContext): string {
     // (only rendered under the opt-in `concurrentIndexes` param): it is
     // non-transactional and must stay ALONE in its file (loader contract).
     const parent = ctx.indexParent.get(encodeId(target));
+    const root = schemaRoot(ctx.pathStyle, t.schema);
     if (parent !== undefined && !ctx.concurrentIndexes.has(encodeId(target))) {
-      return `schemas/${seg(t.schema)}/${parent.dir}/${seg(parent.name)}.sql`;
+      return `${root}/${parent.dir}/${seg(parent.name)}.sql`;
     }
-    return `schemas/${seg(t.schema)}/indexes/${seg(t.name)}.sql`;
+    return `${root}/indexes/${seg(t.name)}.sql`;
   }
   const dir = SCHEMA_DIRS[kind];
   if (dir !== undefined) {
     const t = target as { schema: string; name: string };
-    return `schemas/${seg(t.schema)}/${dir}/${seg(t.name)}.sql`;
+    return `${schemaRoot(ctx.pathStyle, t.schema)}/${dir}/${seg(t.name)}.sql`;
   }
-  return "cluster/misc.sql";
+  return `${cluster}/misc.sql`;
 }
 
 export function exportSqlFiles(
@@ -766,6 +839,7 @@ export function exportSqlFiles(
   options: ExportOptions = {},
 ): SqlFile[] {
   const layout = options.layout ?? "by-object";
+  const pathStyle = options.pathStyle ?? "flat";
   // Render against a PRISTINE baseline, not absolute emptiness, so the export
   // reflects what a real target already has:
   //   - schema "public" always exists, so seed its EXISTENCE (a CREATE SCHEMA
@@ -832,6 +906,7 @@ export function exportSqlFiles(
   // relation-kind map (satellites on views), and the concurrent-index
   // exception set (must stay alone in their file).
   const pathContext: PathContext = {
+    pathStyle,
     cyclicFks,
     memberExt: extensionMembersByEncoded(fb),
     indexParent: indexParentsByEncoded(fb),
@@ -851,11 +926,10 @@ export function exportSqlFiles(
   }
 
   // Each action's file path, in plan order (shared by both layouts below).
+  const miscPath = `${clusterRoot(pathStyle)}/misc.sql`;
   const actionPaths = rendered.actions.map((action) => {
     const subject = subjectOf(action);
-    return subject === undefined
-      ? "cluster/misc.sql"
-      : pathFor(subject, pathContext);
+    return subject === undefined ? miscPath : pathFor(subject, pathContext);
   });
 
   if (layout === "ordered") {
@@ -989,6 +1063,9 @@ function exportGrouped(
     return categoryOf(id);
   };
 
+  const style = pathContext.pathStyle;
+  const extensionsPrefix = `${clusterRoot(style)}/extensions/`;
+
   const groupedPath = (id: StableId): string => {
     const base = pathFor(id, pathContext);
     // Cycle-participating FKs keep their sibling `<table>.fk.sql` path in EVERY
@@ -1001,7 +1078,7 @@ function exportGrouped(
     // Satellites routed to an extension's file stay there: their TARGET has a
     // schema (e.g. a pgcrypto function in `public`), so the flat/pattern
     // regrouping below would otherwise pull them back into `schemas/<s>/…`.
-    if (base.startsWith("cluster/extensions/")) return base;
+    if (base.startsWith(extensionsPrefix)) return base;
     // a CONCURRENTLY index (or one with no resolvable parent) keeps its own
     // indexes/<name>.sql file — flat regrouping would fold the
     // non-transactional statement into an atomic multi-statement file.
@@ -1011,19 +1088,18 @@ function exportGrouped(
     if (schema === undefined) return base;
 
     const category = categoryFor(id);
+    const root = schemaRoot(style, schema);
 
     // flat schema: collapse to one file per category (schema.sql stays put)
     if (flatSet.has(schema)) {
-      return category === "schema"
-        ? base
-        : `schemas/${seg(schema)}/${category}.sql`;
+      return category === "schema" ? base : `${root}/${category}.sql`;
     }
 
     // partition child → its parent table's file (co-locate with the parent)
     if (autoGroupPartitions) {
       const parent = partitionParentName(id, fb);
       if (parent !== undefined) {
-        return `schemas/${seg(schema)}/tables/${seg(parent)}.sql`;
+        return `${root}/tables/${seg(parent)}.sql`;
       }
     }
 
@@ -1032,8 +1108,8 @@ function exportGrouped(
       for (const p of patterns) {
         if (p.regex.test(objectName)) {
           return mode === "single-file"
-            ? `schemas/${seg(schema)}/${category}/${seg(p.name)}.sql`
-            : `schemas/${seg(schema)}/${seg(p.name)}/${category}.sql`;
+            ? `${root}/${category}/${seg(p.name)}.sql`
+            : `${root}/${seg(p.name)}/${category}.sql`;
         }
       }
     }
@@ -1049,7 +1125,9 @@ function exportGrouped(
   // computed on the final grouped paths.
   const actionPaths = actions.map((action) => {
     const subject = subjectOf(action);
-    return subject === undefined ? "cluster/misc.sql" : groupedPath(subject);
+    return subject === undefined
+      ? `${clusterRoot(style)}/misc.sql`
+      : groupedPath(subject);
   });
   const folds = foldCaseCollidingPaths(actionPaths, options.onWarning);
   const foldedPaths = actionPaths.map((p) => folds.get(p) ?? p);

--- a/packages/pg-delta/src/frontends/export-sql-files.ts
+++ b/packages/pg-delta/src/frontends/export-sql-files.ts
@@ -372,9 +372,15 @@ function clampSegment(segment: string): string {
  *   reserved under `"nested"`, where the `schemas/` wrapper separates the two
  *   namespaces (export-path-style.test.ts pins that the two names agree).
  *
- * Matching is exact and case-SENSITIVE: `_CLUSTER` keeps its own spelling and
- * is handled downstream by the case-collision fold (export-case-collisions.ts),
- * which merges the twin roots into one spelling and reports it.
+ * Matching is case-INSENSITIVE (entries are lower-case; compare via
+ * `toLowerCase()`), because the hazard is a case-insensitive filesystem: on
+ * APFS/NTFS `_CUSTOM/schema.sql` IS `_custom/schema.sql`. The case-collision
+ * fold cannot cover that one — it only sees paths the export itself emits, and
+ * the export emits nothing under `_custom/`, so a schema landing there
+ * collides with HAND-AUTHORED SQL that no exported path can be compared
+ * against (Codex review, PR #430). Escaping every case variant keeps the two
+ * namespaces disjoint by construction, and is cleaner for `_cluster` too: the
+ * schema gets its own directory instead of sharing the folded one.
  */
 export const RESERVED_ROOT_SEGMENTS: ReadonlySet<string> = new Set([
   "_cluster",
@@ -388,17 +394,19 @@ function clusterRoot(style: ExportPathStyle): string {
 
 /**
  * Root directory of a SCHEMA's files, for a path style. Under `"flat"` a
- * schema whose encoded segment is exactly a {@link RESERVED_ROOT_SEGMENTS}
- * name percent-encodes its leading underscore (`_cluster` → `%5Fcluster`), so
- * it can never claim a directory the export tree owns. `%` itself is escaped
- * by `encodeURIComponent`, so no other identifier can ever encode to the
- * escaped spelling — the escape is injective. Other underscore-prefixed
- * schemas (`_foo`) are untouched.
+ * schema whose encoded segment case-insensitively equals a
+ * {@link RESERVED_ROOT_SEGMENTS} name percent-encodes its leading underscore
+ * (`_cluster` → `%5Fcluster`, `_CUSTOM` → `%5FCUSTOM`), so it can never claim
+ * — or case-fold into — a directory the export tree owns. The rest of the
+ * segment keeps its original spelling, so distinct case variants stay distinct
+ * objects. `%` itself is escaped by `encodeURIComponent`, so no other
+ * identifier can ever encode to the escaped spelling — the escape is
+ * injective. Other underscore-prefixed schemas (`_foo`) are untouched.
  */
 function schemaRoot(style: ExportPathStyle, schema: string): string {
   const segment = seg(schema);
   if (style === "nested") return `schemas/${segment}`;
-  return RESERVED_ROOT_SEGMENTS.has(segment)
+  return RESERVED_ROOT_SEGMENTS.has(segment.toLowerCase())
     ? `%5F${segment.slice(1)}`
     : segment;
 }

--- a/packages/pg-delta/src/frontends/index.ts
+++ b/packages/pg-delta/src/frontends/index.ts
@@ -10,7 +10,11 @@ export {
   type LoadSqlFilesOptions,
 } from "./load-sql-files.ts";
 
-export { exportSqlFiles, type ExportOptions } from "./export-sql-files.ts";
+export {
+  exportSqlFiles,
+  type ExportOptions,
+  type ExportPathStyle,
+} from "./export-sql-files.ts";
 
 export { saveSnapshot, loadSnapshot } from "./snapshot-file.ts";
 

--- a/packages/pg-delta/src/frontends/schema-export.ts
+++ b/packages/pg-delta/src/frontends/schema-export.ts
@@ -13,7 +13,11 @@ import {
 import { flattenPolicy } from "../policy/policy.ts";
 import { reconstructManagedView } from "../policy/reconstruct.ts";
 import type { ManagementScope } from "../policy/view.ts";
-import { exportSqlFiles, type ExportGrouping } from "./export-sql-files.ts";
+import {
+  exportSqlFiles,
+  type ExportGrouping,
+  type ExportPathStyle,
+} from "./export-sql-files.ts";
 import type { ExportManifest } from "./export-manifest.ts";
 import type { SqlFile } from "./load-sql-files.ts";
 import type { SqlFormatOptions } from "./sql-format/index.ts";
@@ -31,6 +35,10 @@ export interface BuildSchemaExportOptions {
   /** Extra resolveProfile options (restrictToApplier, baselineDir, …). */
   resolveOptions?: Omit<ResolveProfileOptions, "redactSecrets">;
   layout?: "by-object" | "ordered" | "grouped";
+  /** Root-segment style of the emitted paths. Default: `"flat"`
+   *  (`<schema>/tables/t.sql` + `_cluster/roles.sql`); `"nested"` reproduces
+   *  the historical `schemas/<schema>/…` + `cluster/…` tree. */
+  pathStyle?: ExportPathStyle;
   grouping?: ExportGrouping;
   /** Pretty-print options; omit for raw renderer output. */
   format?: SqlFormatOptions;
@@ -135,6 +143,9 @@ export async function buildSchemaExport(
 
   const files = exportSqlFiles(scopedView, {
     layout,
+    ...(options.pathStyle !== undefined
+      ? { pathStyle: options.pathStyle }
+      : {}),
     ...(options.grouping !== undefined ? { grouping: options.grouping } : {}),
     ...(options.format !== undefined ? { format: options.format } : {}),
     ...(assumedSchemas.length > 0 ? { assumedSchemas } : {}),

--- a/packages/pg-delta/src/index.ts
+++ b/packages/pg-delta/src/index.ts
@@ -100,6 +100,7 @@ export {
 export {
   exportSqlFiles,
   type ExportOptions,
+  type ExportPathStyle,
 } from "./frontends/export-sql-files.ts";
 export { saveSnapshot, loadSnapshot } from "./frontends/snapshot-file.ts";
 export {

--- a/packages/pg-delta/tests/cli.test.ts
+++ b/packages/pg-delta/tests/cli.test.ts
@@ -852,7 +852,7 @@ describe("CLI: schema export", () => {
       const first = await runCli(args);
       expect(first.exitCode).toBe(0);
       expect(first.stderr).toMatch(
-        /Exported (\d+) file\(s\) to \S+ \(layout: by-object\): \1 created, 0 updated, 0 unchanged\n/,
+        /Exported (\d+) file\(s\) to \S+ \(layout: by-object, path style: flat\): \1 created, 0 updated, 0 unchanged\n/,
       );
       expect(first.stderr).not.toContain("Removed");
 
@@ -865,7 +865,7 @@ describe("CLI: schema export", () => {
       expect(re.exitCode).toBe(0);
       expect(re.stderr).toContain("Removed 1 stale .sql file(s)");
       expect(re.stderr).toMatch(
-        /Exported \d+ file\(s\) to \S+ \(layout: by-object\): 0 created, 1 updated, \d+ unchanged\n/,
+        /Exported \d+ file\(s\) to \S+ \(layout: by-object, path style: flat\): 0 created, 1 updated, \d+ unchanged\n/,
       );
     } finally {
       await source.drop();

--- a/packages/pg-delta/tests/cli.test.ts
+++ b/packages/pg-delta/tests/cli.test.ts
@@ -733,7 +733,7 @@ describe("CLI: schema export --scope", () => {
           ])
         ).exitCode,
       ).toBe(0);
-      expect(existsSync(join(dbDir, "cluster/roles.sql"))).toBe(false);
+      expect(existsSync(join(dbDir, "_cluster/roles.sql"))).toBe(false);
       expect(scopeOf(dbDir)).toBe("database");
 
       // cluster scope keeps roles.
@@ -752,7 +752,7 @@ describe("CLI: schema export --scope", () => {
           ])
         ).exitCode,
       ).toBe(0);
-      expect(existsSync(join(clDir, "cluster/roles.sql"))).toBe(true);
+      expect(existsSync(join(clDir, "_cluster/roles.sql"))).toBe(true);
       expect(scopeOf(clDir)).toBe("cluster");
     } finally {
       await source.drop();
@@ -784,9 +784,7 @@ describe("CLI: schema export", () => {
 
       // verify expected file exists
       const { existsSync } = await import("node:fs");
-      expect(existsSync(join(outDir, "schemas/clitest/tables/items.sql"))).toBe(
-        true,
-      );
+      expect(existsSync(join(outDir, "clitest/tables/items.sql"))).toBe(true);
     } finally {
       await source.drop();
     }
@@ -814,7 +812,7 @@ describe("CLI: schema export", () => {
 
       expect((await runCli(args)).exitCode).toBe(0);
       const { existsSync } = await import("node:fs");
-      const goneFile = join(outDir, "schemas/clitest/tables/gone.sql");
+      const goneFile = join(outDir, "clitest/tables/gone.sql");
       expect(existsSync(goneFile)).toBe(true);
 
       // drop the object and re-export into the SAME dir.
@@ -825,9 +823,7 @@ describe("CLI: schema export", () => {
       // RED before the fix: the loop only overwrote new paths, so gone.sql
       // lingered and `schema apply --dir` would reload the dropped table.
       expect(existsSync(goneFile)).toBe(false);
-      expect(existsSync(join(outDir, "schemas/clitest/tables/items.sql"))).toBe(
-        true,
-      );
+      expect(existsSync(join(outDir, "clitest/tables/items.sql"))).toBe(true);
     } finally {
       await source.drop();
     }
@@ -1283,9 +1279,7 @@ describe("CLI: schema profile-awareness", () => {
       expect(result.exitCode).toBe(0);
       expect(result.stderr).toContain("Exported");
       const { existsSync } = await import("node:fs");
-      expect(existsSync(join(outDir, "schemas/clitest/tables/items.sql"))).toBe(
-        true,
-      );
+      expect(existsSync(join(outDir, "clitest/tables/items.sql"))).toBe(true);
     } finally {
       await source.drop();
     }
@@ -2062,13 +2056,10 @@ describe("CLI: schema export --layout grouped", () => {
       expect(result.stderr).toContain("layout: grouped");
       // auth_users consolidated under the auth group; the other table keeps its file
       expect(
-        readFileSync(join(outDir, "schemas/app/auth/tables.sql"), "utf8"),
+        readFileSync(join(outDir, "app/auth/tables.sql"), "utf8"),
       ).toContain("auth_users");
       expect(
-        readFileSync(
-          join(outDir, "schemas/app/tables/billing_invoices.sql"),
-          "utf8",
-        ),
+        readFileSync(join(outDir, "app/tables/billing_invoices.sql"), "utf8"),
       ).toContain("billing_invoices");
     } finally {
       await source.drop();
@@ -2112,10 +2103,7 @@ describe("CLI: schema export --layout grouped", () => {
         '{"keywordCase":"lower"}',
       ]);
       expect(result.exitCode).toBe(0);
-      const sql = readFileSync(
-        join(outDir, "schemas/app/tables/t.sql"),
-        "utf8",
-      );
+      const sql = readFileSync(join(outDir, "app/tables/t.sql"), "utf8");
       expect(sql).toContain("create table");
       expect(sql).not.toContain("CREATE TABLE");
     } finally {

--- a/packages/pg-delta/tests/export-case-collision.test.ts
+++ b/packages/pg-delta/tests/export-case-collision.test.ts
@@ -42,7 +42,9 @@ const CASE_TWIN_SQL = `
 function forLoad(files: { name: string; sql: string }[]) {
   // cluster-global roles already exist in the shared cluster (same filter as
   // export-fidelity.test.ts).
-  return files.filter((f) => !/cluster[_/]roles/.test(f.name));
+  // case-insensitive: a `_CLUSTER` schema can fold the reserved cluster
+  // directory to its own spelling (see the reserved-name suite below).
+  return files.filter((f) => !/cluster[_/]roles/i.test(f.name));
 }
 
 // An FK chain that is ACYCLIC at table grain becomes a real cycle at FILE
@@ -154,6 +156,54 @@ describe("export: non-FK dependency chain through case twins stays loadable", ()
   }
 });
 
+// The flat path style reserves the ROOT segment `_cluster` for the
+// cluster-level files, and escapes a schema of that literal name
+// (`%5Fcluster/`). The reservation is case-SENSITIVE, so a schema named
+// `_CLUSTER` keeps its own spelling — and then case-twins the reserved
+// directory on APFS/NTFS. No new machinery handles that: the existing
+// case-collision fold owns it, contracting both roots to the
+// lexicographically smallest spelling (`_CLUSTER`, uppercase sorts first) and
+// reporting it through `onWarning`. The two trees share a DIRECTORY but never
+// a FILE (`schema.sql` / `tables/` vs `roles.sql` / `extensions/`), so nothing
+// is silently overwritten and the export still round-trips.
+describe("export: a _CLUSTER schema case-twins the reserved _cluster dir", () => {
+  test("folds to one spelling with a warning, and still round-trips", async () => {
+    const cluster = await sharedCluster();
+    const src = await cluster.createDb("reserved_twin_src");
+    const shadow = await cluster.createDb("reserved_twin_shadow");
+    try {
+      await src.pool.query(`
+        CREATE SCHEMA "_CLUSTER";
+        CREATE TABLE "_CLUSTER".t (id integer PRIMARY KEY);
+      `);
+      const fb = (await extract(src.pool)).factBase;
+      const warnings: string[] = [];
+      const files = exportSqlFiles(fb, {
+        onWarning: (m) => warnings.push(m),
+      });
+      const names = files.map((f) => f.name);
+
+      // (1) no two paths may be one physical file on APFS/NTFS
+      expect(new Set(names.map((n) => n.toLowerCase())).size).toBe(
+        names.length,
+      );
+      // (2) both trees agree on ONE root spelling — the smallest present
+      expect(names).toContain("_CLUSTER/schema.sql");
+      expect(names).toContain("_CLUSTER/tables/t.sql");
+      expect(names).toContain("_CLUSTER/roles.sql");
+      expect(names.some((n) => n.startsWith("_cluster/"))).toBe(false);
+      // (3) the collision is reported, never silent
+      expect(warnings.join("\n")).toContain("_CLUSTER");
+
+      // (4) fidelity survives the fold
+      const loaded = await loadSqlFiles(forLoad(files), shadow.pool);
+      expect(loaded.factBase.rootHash).toBe(fb.rootHash);
+    } finally {
+      await Promise.all([src.drop(), shadow.drop()]);
+    }
+  }, 120_000);
+});
+
 describe("export: case-twin objects survive case-insensitive filesystems", () => {
   for (const layout of LAYOUTS) {
     test(`paths are case-insensitively unique and round-trip (${layout})`, async () => {
@@ -178,7 +228,7 @@ describe("export: case-twin objects survive case-insensitive filesystems", () =>
         // ordered layout instead keeps them apart via its sequence prefix)
         if (layout !== "ordered") {
           const merged = files.find(
-            (f) => f.name === "schemas/public/tables/Users.sql",
+            (f) => f.name === "public/tables/Users.sql",
           );
           expect(merged?.sql).toContain(`"Users"`);
           expect(merged?.sql).toContain(`"users"`);

--- a/packages/pg-delta/tests/export-case-collision.test.ts
+++ b/packages/pg-delta/tests/export-case-collision.test.ts
@@ -42,9 +42,7 @@ const CASE_TWIN_SQL = `
 function forLoad(files: { name: string; sql: string }[]) {
   // cluster-global roles already exist in the shared cluster (same filter as
   // export-fidelity.test.ts).
-  // case-insensitive: a `_CLUSTER` schema can fold the reserved cluster
-  // directory to its own spelling (see the reserved-name suite below).
-  return files.filter((f) => !/cluster[_/]roles/i.test(f.name));
+  return files.filter((f) => !/cluster[_/]roles/.test(f.name));
 }
 
 // An FK chain that is ACYCLIC at table grain becomes a real cycle at FILE
@@ -156,18 +154,18 @@ describe("export: non-FK dependency chain through case twins stays loadable", ()
   }
 });
 
-// The flat path style reserves the ROOT segment `_cluster` for the
-// cluster-level files, and escapes a schema of that literal name
-// (`%5Fcluster/`). The reservation is case-SENSITIVE, so a schema named
-// `_CLUSTER` keeps its own spelling — and then case-twins the reserved
-// directory on APFS/NTFS. No new machinery handles that: the existing
-// case-collision fold owns it, contracting both roots to the
-// lexicographically smallest spelling (`_CLUSTER`, uppercase sorts first) and
-// reporting it through `onWarning`. The two trees share a DIRECTORY but never
-// a FILE (`schema.sql` / `tables/` vs `roles.sql` / `extensions/`), so nothing
-// is silently overwritten and the export still round-trips.
-describe("export: a _CLUSTER schema case-twins the reserved _cluster dir", () => {
-  test("folds to one spelling with a warning, and still round-trips", async () => {
+// The flat path style reserves the ROOT segments `_cluster` (its own
+// cluster-level files) and `_custom` (hand-authored SQL, frontends/custom-dir.ts)
+// and escapes a schema named after either — case-INSENSITIVELY, because the
+// hazard is a case-insensitive filesystem: `_CLUSTER/schema.sql` and
+// `_cluster/roles.sql` are one directory on APFS/NTFS. The case-collision fold
+// could contract the two roots for `_cluster`, but not for `_custom` (the
+// export emits no path under it, so there is no collision to detect — only
+// hand-authored SQL to silently overwrite), so the escape owns both
+// (Codex review, PR #430). Result: the schema gets its OWN directory,
+// disjoint from anything the export tree reserves.
+describe("export: a case-variant reserved-name schema escapes the reserved dir", () => {
+  test("escapes to %5F… keeping its spelling, and still round-trips", async () => {
     const cluster = await sharedCluster();
     const src = await cluster.createDb("reserved_twin_src");
     const shadow = await cluster.createDb("reserved_twin_shadow");
@@ -175,27 +173,34 @@ describe("export: a _CLUSTER schema case-twins the reserved _cluster dir", () =>
       await src.pool.query(`
         CREATE SCHEMA "_CLUSTER";
         CREATE TABLE "_CLUSTER".t (id integer PRIMARY KEY);
+        CREATE SCHEMA "_Custom";
+        CREATE TABLE "_Custom".t (id integer PRIMARY KEY);
       `);
       const fb = (await extract(src.pool)).factBase;
-      const warnings: string[] = [];
-      const files = exportSqlFiles(fb, {
-        onWarning: (m) => warnings.push(m),
-      });
+      const files = exportSqlFiles(fb);
       const names = files.map((f) => f.name);
 
       // (1) no two paths may be one physical file on APFS/NTFS
       expect(new Set(names.map((n) => n.toLowerCase())).size).toBe(
         names.length,
       );
-      // (2) both trees agree on ONE root spelling — the smallest present
-      expect(names).toContain("_CLUSTER/schema.sql");
-      expect(names).toContain("_CLUSTER/tables/t.sql");
-      expect(names).toContain("_CLUSTER/roles.sql");
-      expect(names.some((n) => n.startsWith("_cluster/"))).toBe(false);
-      // (3) the collision is reported, never silent
-      expect(warnings.join("\n")).toContain("_CLUSTER");
+      // (2) each schema escapes into its OWN directory, spelling preserved
+      expect(names).toContain("%5FCLUSTER/schema.sql");
+      expect(names).toContain("%5FCLUSTER/tables/t.sql");
+      expect(names).toContain("%5FCustom/schema.sql");
+      expect(names).toContain("%5FCustom/tables/t.sql");
+      // (3) the reserved roots stay disjoint from schema content under folding
+      const roots = names.map((n) => n.split("/")[0]?.toLowerCase());
+      expect(roots).not.toContain("_custom");
+      expect(new Set(roots).has("_cluster")).toBe(true);
+      for (const name of names) {
+        if (name.startsWith("_cluster/")) {
+          expect(name).not.toContain("/tables/");
+          expect(name).not.toBe("_cluster/schema.sql");
+        }
+      }
 
-      // (4) fidelity survives the fold
+      // (4) fidelity survives the escape
       const loaded = await loadSqlFiles(forLoad(files), shadow.pool);
       expect(loaded.factBase.rootHash).toBe(fb.rootHash);
     } finally {

--- a/packages/pg-delta/tests/export-fidelity.test.ts
+++ b/packages/pg-delta/tests/export-fidelity.test.ts
@@ -232,9 +232,7 @@ describe("export: round-trip fidelity (all layouts)", () => {
       `);
       const fb = (await extract(src.pool)).factBase;
       const files = forLoad(exportSqlFiles(fb));
-      const orders = files.find(
-        (f) => f.name === "schemas/f/tables/orders.sql",
-      )?.sql;
+      const orders = files.find((f) => f.name === "f/tables/orders.sql")?.sql;
       expect(orders).toBeDefined();
       // all four validated constraints inline, names preserved
       expect(orders).toContain(`CONSTRAINT "orders_pk" PRIMARY KEY`);
@@ -273,7 +271,7 @@ describe("export: round-trip fidelity (all layouts)", () => {
         }),
       );
       const extFile = files.find(
-        (f) => f.name === "cluster/extensions/pgcrypto.sql",
+        (f) => f.name === "_cluster/extensions/pgcrypto.sql",
       );
       expect(extFile?.sql).toContain("gen_salt");
       // no member ACL leaks back into a public functions file (the public

--- a/packages/pg-delta/tests/export-format.test.ts
+++ b/packages/pg-delta/tests/export-format.test.ts
@@ -38,7 +38,7 @@ describe("export: SQL formatting", () => {
       const fb = (await extract(src.pool)).factBase;
 
       const tableOf = (files: { name: string; sql: string }[]) =>
-        files.find((f) => f.name === "schemas/app/tables/users.sql")?.sql ?? "";
+        files.find((f) => f.name === "app/tables/users.sql")?.sql ?? "";
 
       // default: unformatted — the renderer emits upper-case DDL keywords
       const plain = tableOf(exportSqlFiles(fb));
@@ -67,7 +67,7 @@ describe("export: SQL formatting", () => {
       const defaultDir = join(mkdtempSync(join(tmpdir(), "expfmt-")), "d");
       await cmdSchemaExport(["--source", src.uri, "--out-dir", defaultDir]);
       const formatted = readFileSync(
-        join(defaultDir, "schemas/app/tables/users.sql"),
+        join(defaultDir, "app/tables/users.sql"),
         "utf8",
       );
       expect(formatted).toContain("create table");
@@ -81,10 +81,7 @@ describe("export: SQL formatting", () => {
         rawDir,
         "--no-format",
       ]);
-      const raw = readFileSync(
-        join(rawDir, "schemas/app/tables/users.sql"),
-        "utf8",
-      );
+      const raw = readFileSync(join(rawDir, "app/tables/users.sql"), "utf8");
       expect(raw).toContain("CREATE TABLE");
     } finally {
       await src.drop();
@@ -101,7 +98,7 @@ describe("export: SQL formatting", () => {
 
       const formatted = exportSqlFiles(fb, {
         format: { keywordCase: "upper", maxWidth: 80 },
-      }).filter((f) => !f.name.startsWith("cluster/roles"));
+      }).filter((f) => !f.name.startsWith("_cluster/roles"));
 
       const loaded = await loadSqlFiles(formatted, shadow.pool);
       expect(loaded.factBase.rootHash).toBe(fb.rootHash);

--- a/packages/pg-delta/tests/export-grouped.test.ts
+++ b/packages/pg-delta/tests/export-grouped.test.ts
@@ -37,8 +37,8 @@ describe("export: grouped layout (v1 parity)", () => {
         (f) => f.name,
       );
 
-      const viewAt = names.indexOf("schemas/app/views/v.sql");
-      const fnAt = names.indexOf("schemas/app/functions/f.sql");
+      const viewAt = names.indexOf("app/views/v.sql");
+      const fnAt = names.indexOf("app/functions/f.sql");
       expect(viewAt).toBeGreaterThanOrEqual(0);
       expect(fnAt).toBeGreaterThanOrEqual(0);
       expect(viewAt).toBeLessThan(fnAt);
@@ -58,9 +58,7 @@ describe("export: grouped layout (v1 parity)", () => {
       `);
       const fb = (await extract(src.pool)).factBase;
       const files = exportSqlFiles(fb, { layout: "grouped" });
-      const tableFile = files.find(
-        (f) => f.name === "schemas/app/tables/t.sql",
-      );
+      const tableFile = files.find((f) => f.name === "app/tables/t.sql");
       expect(tableFile).toBeDefined();
       const sql = tableFile?.sql ?? "";
       expect(sql).toContain("CREATE TABLE");
@@ -93,11 +91,11 @@ describe("export: grouped layout (v1 parity)", () => {
       }).map((f) => f.name);
 
       // both auth_* tables consolidate under the auth group…
-      expect(names).toContain("schemas/app/auth/tables.sql");
-      expect(names).not.toContain("schemas/app/tables/auth_users.sql");
-      expect(names).not.toContain("schemas/app/tables/auth_sessions.sql");
+      expect(names).toContain("app/auth/tables.sql");
+      expect(names).not.toContain("app/tables/auth_users.sql");
+      expect(names).not.toContain("app/tables/auth_sessions.sql");
       // …the non-matching table keeps its own per-object file
-      expect(names).toContain("schemas/app/tables/billing_invoices.sql");
+      expect(names).toContain("app/tables/billing_invoices.sql");
     } finally {
       await src.drop();
     }
@@ -118,9 +116,9 @@ describe("export: grouped layout (v1 parity)", () => {
         grouping: { flatSchemas: ["ext"] },
       });
       const names = files.map((f) => f.name);
-      expect(names).toContain("schemas/ext/tables.sql");
-      expect(names).not.toContain("schemas/ext/tables/a.sql");
-      const flat = files.find((f) => f.name === "schemas/ext/tables.sql");
+      expect(names).toContain("ext/tables.sql");
+      expect(names).not.toContain("ext/tables/a.sql");
+      const flat = files.find((f) => f.name === "ext/tables.sql");
       expect(flat?.sql).toContain('"ext"."a"');
       expect(flat?.sql).toContain('"ext"."b"');
     } finally {
@@ -144,12 +142,39 @@ describe("export: grouped layout (v1 parity)", () => {
 
       // the child does NOT get its own file (the by-object contract); it lands
       // in the parent's file
-      expect(names).not.toContain("schemas/app/tables/measurements_2024.sql");
+      expect(names).not.toContain("app/tables/measurements_2024.sql");
       const parentFile = files.find(
-        (f) => f.name === "schemas/app/tables/measurements.sql",
+        (f) => f.name === "app/tables/measurements.sql",
       );
       expect(parentFile?.sql).toContain("measurements_2024");
       expect(parentFile?.sql).toContain("PARTITION OF");
+    } finally {
+      await src.drop();
+    }
+  }, 60_000);
+
+  test('pathStyle "nested" keeps the historical grouped paths', async () => {
+    const cluster = await sharedCluster();
+    const src = await cluster.createDb("expgrp_nested");
+    try {
+      await src.pool.query(`
+        CREATE SCHEMA app;
+        CREATE TABLE app.auth_users (id integer PRIMARY KEY);
+        CREATE TABLE app.billing_invoices (id integer PRIMARY KEY);
+      `);
+      const fb = (await extract(src.pool)).factBase;
+      const names = exportSqlFiles(fb, {
+        layout: "grouped",
+        pathStyle: "nested",
+        grouping: {
+          mode: "subdirectory",
+          groupPatterns: [{ pattern: "^auth_", name: "auth" }],
+        },
+      }).map((f) => f.name);
+
+      expect(names).toContain("schemas/app/auth/tables.sql");
+      expect(names).toContain("schemas/app/tables/billing_invoices.sql");
+      expect(names.some((n) => n.startsWith("_cluster/"))).toBe(false);
     } finally {
       await src.drop();
     }
@@ -170,7 +195,7 @@ describe("export: grouped layout (v1 parity)", () => {
       `);
       const fb = (await extract(src.pool)).factBase;
       const grouped = exportSqlFiles(fb, { layout: "grouped" }).filter(
-        (f) => !f.name.startsWith("cluster/roles"),
+        (f) => !f.name.startsWith("_cluster/roles"),
       );
       const loaded = await loadSqlFiles(grouped, shadow.pool);
       expect(loaded.factBase.rootHash).toBe(fb.rootHash);

--- a/packages/pg-delta/tests/export-layout.test.ts
+++ b/packages/pg-delta/tests/export-layout.test.ts
@@ -94,8 +94,8 @@ describe("export: by-object file mapping (v2 contract)", () => {
         files.some((f) => f.name.includes(frag));
 
       // --- preserved co-location (old declarative-schema-export intent) ---
-      const usersFile = byName.get("schemas/test_schema/tables/users.sql");
-      const postsFile = byName.get("schemas/test_schema/tables/posts.sql");
+      const usersFile = byName.get("test_schema/tables/users.sql");
+      const postsFile = byName.get("test_schema/tables/posts.sql");
       expect(usersFile).toBeDefined();
       expect(postsFile).toBeDefined();
       // an ACYCLIC FK stays INLINE in the owning table's file (readability);
@@ -106,13 +106,9 @@ describe("export: by-object file mapping (v2 contract)", () => {
       expect(has("foreign_keys/")).toBe(false);
       // a CYCLIC FK pair moves to sibling .fk.sql files (atomic files can't
       // hold a reference cycle), and the table files carry no REFERENCES.
-      expect(byName.get("schemas/test_schema/tables/m1.fk.sql")).toContain(
-        "m1_m2_fk",
-      );
-      expect(byName.get("schemas/test_schema/tables/m2.fk.sql")).toContain(
-        "m2_m1_fk",
-      );
-      expect(byName.get("schemas/test_schema/tables/m1.sql")).not.toContain(
+      expect(byName.get("test_schema/tables/m1.fk.sql")).toContain("m1_m2_fk");
+      expect(byName.get("test_schema/tables/m2.fk.sql")).toContain("m2_m1_fk");
+      expect(byName.get("test_schema/tables/m1.sql")).not.toContain(
         "REFERENCES",
       );
 
@@ -120,7 +116,7 @@ describe("export: by-object file mapping (v2 contract)", () => {
       // function) files into the owning extension's file, next to its CREATE
       // EXTENSION — NOT into schemas/<s>/functions/ (a real DB with pgTAP would
       // otherwise sprout hundreds of REVOKE-only function files).
-      const pgcryptoFile = byName.get("cluster/extensions/pgcrypto.sql");
+      const pgcryptoFile = byName.get("_cluster/extensions/pgcrypto.sql");
       expect(pgcryptoFile).toContain("CREATE EXTENSION");
       expect(pgcryptoFile).toContain("gen_salt");
       expect(has("functions/gen_salt")).toBe(false);
@@ -140,22 +136,18 @@ describe("export: by-object file mapping (v2 contract)", () => {
       // matviews under materialized_views/ (old engine used matviews/), and a
       // matview's index co-locates with the matview file
       expect(
-        byName.get("schemas/test_schema/materialized_views/user_summary.sql"),
+        byName.get("test_schema/materialized_views/user_summary.sql"),
       ).toContain("user_summary_idx");
       expect(has("matviews/")).toBe(false);
       // a trigger on a VIEW files with the view, not under tables/
-      expect(byName.get("schemas/test_schema/views/v_users.sql")).toContain(
+      expect(byName.get("test_schema/views/v_users.sql")).toContain(
         "v_users_ins",
       );
       expect(has("tables/v_users")).toBe(false);
       // a partition child is its OWN table file (old engine grouped it)
-      expect(has("schemas/test_schema/tables/measurements.sql")).toBe(true);
-      expect(has("schemas/test_schema/tables/measurements_2024.sql")).toBe(
-        true,
-      );
-      const parentFile = byName.get(
-        "schemas/test_schema/tables/measurements.sql",
-      );
+      expect(has("test_schema/tables/measurements.sql")).toBe(true);
+      expect(has("test_schema/tables/measurements_2024.sql")).toBe(true);
+      const parentFile = byName.get("test_schema/tables/measurements.sql");
       expect(parentFile).not.toContain("measurements_2024");
     } finally {
       await src.drop();
@@ -188,18 +180,18 @@ describe("export: by-object file mapping (v2 contract)", () => {
       // v1-parity win: a partition child is grouped INTO its parent table's
       // file (autoGroupPartitions), not emitted as a standalone file — this is
       // the old engine's "partitioned tables" behavior.
-      expect(
-        byName.get("schemas/test_schema/tables/measurements.sql"),
-      ).toContain("measurements_2024");
+      expect(byName.get("test_schema/tables/measurements.sql")).toContain(
+        "measurements_2024",
+      );
       expect(has("tables/measurements_2024.sql")).toBe(false);
 
       // indexes co-locate with their table / matview file in grouped too
       // (old-engine behavior, restored by user decision) — no indexes/ dir.
-      expect(byName.get("schemas/test_schema/tables/users.sql")).toContain(
+      expect(byName.get("test_schema/tables/users.sql")).toContain(
         "users_name_idx",
       );
       expect(
-        byName.get("schemas/test_schema/materialized_views/user_summary.sql"),
+        byName.get("test_schema/materialized_views/user_summary.sql"),
       ).toContain("user_summary_idx");
       expect(has("indexes/")).toBe(false);
       expect(has("matviews/")).toBe(false);
@@ -207,4 +199,180 @@ describe("export: by-object file mapping (v2 contract)", () => {
       await src.drop();
     }
   }, 120_000);
+});
+
+/**
+ * `pathStyle` decides the two ROOT segments of every path, orthogonally to
+ * `layout`:
+ *   - "flat" (default): schema directories sit at the export root and the
+ *     cluster-level files live in `_cluster/` — one less level of nesting for
+ *     the tree users actually read and diff.
+ *   - "nested": the historical `schemas/<s>/…` + `cluster/…` tree, kept as a
+ *     back-compat escape hatch.
+ * Everything BELOW the root segment is identical in both styles, so this suite
+ * pins the roots (and the reserved-name escape) rather than re-pinning the
+ * whole mapping the suite above already covers.
+ */
+describe("export: path style", () => {
+  const SETUP = `
+    CREATE SCHEMA app;
+    CREATE TABLE app.t (id integer PRIMARY KEY);
+    CREATE VIEW app.v AS SELECT id FROM app.t;
+    CREATE FUNCTION app.f() RETURNS integer LANGUAGE sql IMMUTABLE AS 'SELECT 1';
+    CREATE EXTENSION pgcrypto;
+  `;
+
+  test("flat is the default: schema dirs at the root, cluster files under _cluster/", async () => {
+    const cluster = await sharedCluster();
+    const src = await cluster.createDb("exppath_flat");
+    try {
+      await src.pool.query(SETUP);
+      const fb = (await extract(src.pool)).factBase;
+      const names = exportSqlFiles(fb).map((f) => f.name);
+
+      expect(names).toContain("app/schema.sql");
+      expect(names).toContain("app/tables/t.sql");
+      expect(names).toContain("app/views/v.sql");
+      expect(names).toContain("app/functions/f.sql");
+      expect(names).toContain("_cluster/roles.sql");
+      expect(names).toContain("_cluster/extensions/pgcrypto.sql");
+      // the `schemas/` wrapper and the un-prefixed `cluster/` dir are gone
+      expect(names.some((n) => n.startsWith("schemas/"))).toBe(false);
+      expect(names.some((n) => n.startsWith("cluster/"))).toBe(false);
+
+      // explicit "flat" is the same thing as the default
+      expect(
+        exportSqlFiles(fb, { pathStyle: "flat" }).map((f) => f.name),
+      ).toEqual(names);
+    } finally {
+      await src.drop();
+    }
+  }, 60_000);
+
+  test('pathStyle "nested" reproduces the previous schemas/ + cluster/ tree', async () => {
+    const cluster = await sharedCluster();
+    const src = await cluster.createDb("exppath_nested");
+    try {
+      await src.pool.query(SETUP);
+      const fb = (await extract(src.pool)).factBase;
+      const names = exportSqlFiles(fb, { pathStyle: "nested" }).map(
+        (f) => f.name,
+      );
+
+      expect(names).toContain("schemas/app/schema.sql");
+      expect(names).toContain("schemas/app/tables/t.sql");
+      expect(names).toContain("schemas/app/views/v.sql");
+      expect(names).toContain("schemas/app/functions/f.sql");
+      expect(names).toContain("cluster/roles.sql");
+      expect(names).toContain("cluster/extensions/pgcrypto.sql");
+      expect(names.some((n) => n.startsWith("_cluster/"))).toBe(false);
+
+      // the nested tree is exactly the flat tree with the two roots rewritten
+      const flat = exportSqlFiles(fb).map((f) => f.name);
+      expect(
+        names.map((n) =>
+          n.startsWith("cluster/") ? `_${n}` : n.replace(/^schemas\//, ""),
+        ),
+      ).toEqual(flat);
+    } finally {
+      await src.drop();
+    }
+  }, 60_000);
+
+  test("schemas named after a reserved root dir escape to %5F… under flat", async () => {
+    const cluster = await sharedCluster();
+    const src = await cluster.createDb("exppath_reserved");
+    try {
+      await src.pool.query(`
+        CREATE SCHEMA "_cluster";
+        CREATE TABLE "_cluster".t (id integer PRIMARY KEY);
+        -- _custom/ is the export tree's other reserved root directory
+        -- (frontends/custom-dir.ts): never written into, never pruned.
+        CREATE SCHEMA "_custom";
+        CREATE TABLE "_custom".t (id integer PRIMARY KEY);
+        -- an ordinary underscore-prefixed schema is NOT reserved
+        CREATE SCHEMA "_foo";
+        CREATE TABLE "_foo".t (id integer PRIMARY KEY);
+      `);
+      const fb = (await extract(src.pool)).factBase;
+      const names = exportSqlFiles(fb).map((f) => f.name);
+
+      // the reserved root segment belongs to the cluster files…
+      expect(names).toContain("_cluster/roles.sql");
+      // …so the same-named SCHEMA percent-encodes its leading underscore
+      expect(names).toContain("%5Fcluster/schema.sql");
+      expect(names).toContain("%5Fcluster/tables/t.sql");
+      expect(names).not.toContain("_cluster/schema.sql");
+      expect(names).not.toContain("_cluster/tables/t.sql");
+      // same for the reserved `_custom/` hand-authored-SQL directory: writing
+      // there is a hard error in the CLI, so the schema must not claim it
+      expect(names).toContain("%5Fcustom/schema.sql");
+      expect(names).toContain("%5Fcustom/tables/t.sql");
+      expect(names.some((n) => n.startsWith("_custom/"))).toBe(false);
+      // only the literal reserved names escape — `_foo` keeps its own spelling
+      expect(names).toContain("_foo/schema.sql");
+      expect(names).toContain("_foo/tables/t.sql");
+
+      // nested has no reserved-name problem: the schemas/ wrapper separates it
+      const nested = exportSqlFiles(fb, { pathStyle: "nested" }).map(
+        (f) => f.name,
+      );
+      expect(nested).toContain("schemas/_cluster/schema.sql");
+      expect(nested).toContain("schemas/_custom/schema.sql");
+      expect(nested).toContain("schemas/_foo/schema.sql");
+    } finally {
+      await src.drop();
+    }
+  }, 60_000);
+
+  test("pathStyle composes with the ordered layout (shorter flattened names)", async () => {
+    const cluster = await sharedCluster();
+    const src = await cluster.createDb("exppath_ordered");
+    try {
+      await src.pool.query(SETUP);
+      const fb = (await extract(src.pool)).factBase;
+      const flat = exportSqlFiles(fb, { layout: "ordered" }).map((f) => f.name);
+      const nested = exportSqlFiles(fb, {
+        layout: "ordered",
+        pathStyle: "nested",
+      }).map((f) => f.name);
+
+      expect(flat.some((n) => /^\d{4}_app_tables_t\.sql$/.test(n))).toBe(true);
+      expect(
+        nested.some((n) => /^\d{4}_schemas_app_tables_t\.sql$/.test(n)),
+      ).toBe(true);
+      expect(flat.some((n) => /^\d{4}__cluster_roles\.sql$/.test(n))).toBe(
+        true,
+      );
+      // same file COUNT and ordering — only the flattened names differ
+      expect(flat.length).toBe(nested.length);
+    } finally {
+      await src.drop();
+    }
+  }, 60_000);
+
+  test("pathStyle composes with the grouped layout", async () => {
+    const cluster = await sharedCluster();
+    const src = await cluster.createDb("exppath_grouped");
+    try {
+      await src.pool.query(`
+        CREATE SCHEMA ext;
+        CREATE TABLE ext.a (id integer PRIMARY KEY);
+        CREATE TABLE ext.b (id integer PRIMARY KEY);
+      `);
+      const fb = (await extract(src.pool)).factBase;
+      const opts = {
+        layout: "grouped",
+        grouping: { flatSchemas: ["ext"] },
+      } as const;
+      expect(exportSqlFiles(fb, opts).map((f) => f.name)).toContain(
+        "ext/tables.sql",
+      );
+      expect(
+        exportSqlFiles(fb, { ...opts, pathStyle: "nested" }).map((f) => f.name),
+      ).toContain("schemas/ext/tables.sql");
+    } finally {
+      await src.drop();
+    }
+  }, 60_000);
 });

--- a/packages/pg-delta/tests/export-layout.test.ts
+++ b/packages/pg-delta/tests/export-layout.test.ts
@@ -36,7 +36,10 @@
  */
 import { describe, expect, test } from "bun:test";
 import { extract } from "../src/extract/extract.ts";
-import { exportSqlFiles } from "../src/frontends/export-sql-files.ts";
+import {
+  exportSqlFiles,
+  type ExportOptions,
+} from "../src/frontends/export-sql-files.ts";
 import { sharedCluster } from "./containers.ts";
 
 describe("export: by-object file mapping (v2 contract)", () => {
@@ -361,10 +364,10 @@ describe("export: path style", () => {
         CREATE TABLE ext.b (id integer PRIMARY KEY);
       `);
       const fb = (await extract(src.pool)).factBase;
-      const opts = {
+      const opts: ExportOptions = {
         layout: "grouped",
         grouping: { flatSchemas: ["ext"] },
-      } as const;
+      };
       expect(exportSqlFiles(fb, opts).map((f) => f.name)).toContain(
         "ext/tables.sql",
       );

--- a/packages/pg-delta/tests/export-ownership.test.ts
+++ b/packages/pg-delta/tests/export-ownership.test.ts
@@ -47,9 +47,9 @@ async function runCli(args: string[]): Promise<SpawnResult> {
 const readManifest = (dir: string): Record<string, unknown> =>
   JSON.parse(readFileSync(join(dir, ".pgdelta-export.json"), "utf8"));
 const readTable = (dir: string, table: string): string =>
-  readFileSync(join(dir, `schemas/public/tables/${table}.sql`), "utf8");
+  readFileSync(join(dir, `public/tables/${table}.sql`), "utf8");
 const readTableIn = (dir: string, schema: string, table: string): string =>
-  readFileSync(join(dir, `schemas/${schema}/tables/${table}.sql`), "utf8");
+  readFileSync(join(dir, `${schema}/tables/${table}.sql`), "utf8");
 
 const dbs: TestDb[] = [];
 afterAll(async () => {

--- a/packages/pg-delta/tests/export-supabase-publication.test.ts
+++ b/packages/pg-delta/tests/export-supabase-publication.test.ts
@@ -66,7 +66,7 @@ describe("supabase profile: platform publication supabase_realtime (#370)", () =
     // the platform publication object is not ours to recreate ...
     expect(allSql).not.toMatch(/CREATE PUBLICATION "?supabase_realtime"?/i);
     // ... but the user's membership on it IS exported, filed with publications
-    const pubFile = files.find((f) => f.name === "cluster/publications.sql");
+    const pubFile = files.find((f) => f.name === "_cluster/publications.sql");
     expect(pubFile?.sql).toMatch(
       /ALTER PUBLICATION "supabase_realtime" ADD TABLE/,
     );

--- a/packages/pg-delta/tests/export.test.ts
+++ b/packages/pg-delta/tests/export.test.ts
@@ -45,7 +45,7 @@ describe("stage 9: declarative export", () => {
       const fb = (await extract(source.pool)).factBase;
 
       const byObject = exportSqlFiles(fb).filter(
-        (f) => !f.name.startsWith("cluster/roles"),
+        (f) => !f.name.startsWith("_cluster/roles"),
       );
       const ordered = exportSqlFiles(fb, { layout: "ordered" }).filter(
         (f) => !f.name.includes("cluster_roles"),
@@ -76,13 +76,46 @@ describe("stage 9: declarative export", () => {
       `);
       const fb = (await extract(source.pool)).factBase;
       const names = exportSqlFiles(fb).map((f) => f.name);
-      expect(names).toContain("cluster/roles.sql");
-      expect(names).toContain("schemas/app/schema.sql");
-      expect(names).toContain("schemas/app/tables/t.sql");
-      expect(names).toContain("schemas/app/views/v.sql");
-      expect(names).toContain("schemas/app/functions/f.sql");
+      expect(names).toContain("_cluster/roles.sql");
+      expect(names).toContain("app/schema.sql");
+      expect(names).toContain("app/tables/t.sql");
+      expect(names).toContain("app/views/v.sql");
+      expect(names).toContain("app/functions/f.sql");
     } finally {
       await source.drop();
     }
   }, 60_000);
+
+  // The flat style puts schema directories at the export root, where
+  // `_cluster/` is reserved for the cluster-level files. A schema of that
+  // literal name escapes to `%5Fcluster/` — the fidelity gate must still hold
+  // through the escape (the loader is structure-agnostic, so this proves the
+  // escape loses nothing and the two trees never overwrite each other).
+  test("a schema named _cluster round-trips under the flat style", async () => {
+    const cluster = await sharedCluster();
+    const source = await cluster.createDb("exp_reserved_src");
+    const shadow = await cluster.createDb("exp_reserved_shadow");
+    try {
+      await source.pool.query(`
+        CREATE SCHEMA "_cluster";
+        CREATE TABLE "_cluster".t (id integer PRIMARY KEY, body text);
+        CREATE VIEW "_cluster".v AS SELECT id FROM "_cluster".t;
+        COMMENT ON SCHEMA "_cluster" IS 'reserved-name schema';
+      `);
+      const fb = (await extract(source.pool)).factBase;
+      const files = exportSqlFiles(fb);
+      const names = files.map((f) => f.name);
+      expect(names).toContain("%5Fcluster/schema.sql");
+      expect(names).toContain("%5Fcluster/tables/t.sql");
+      expect(names).toContain("_cluster/roles.sql");
+
+      const loaded = await loadSqlFiles(
+        files.filter((f) => !f.name.startsWith("_cluster/roles")),
+        shadow.pool,
+      );
+      expect(loaded.factBase.rootHash).toBe(fb.rootHash);
+    } finally {
+      await Promise.all([source.drop(), shadow.drop()]);
+    }
+  }, 120_000);
 });

--- a/packages/pg-delta/tests/profile-baseline.test.ts
+++ b/packages/pg-delta/tests/profile-baseline.test.ts
@@ -66,14 +66,11 @@ describe("profile-declared baseline (end-to-end)", () => {
       // the export contains the user schema and NOT the baselined platform schema
       const manifest = readExportManifest(outDir);
       expect(manifest?.baselineDigest).toBeDefined();
-      const appFile = readFileSync(
-        join(outDir, "schemas/app/schema.sql"),
-        "utf8",
-      );
+      const appFile = readFileSync(join(outDir, "app/schema.sql"), "utf8");
       // the CLI formats by default (lowercase keywords)
       expect(appFile).toContain(`create schema "app"`);
       expect(() =>
-        readFileSync(join(outDir, "schemas/plat/schema.sql"), "utf8"),
+        readFileSync(join(outDir, "plat/schema.sql"), "utf8"),
       ).toThrow(); // plat was subtracted by the baseline → no file
 
       // 4. a profile whose baseline digest differs → apply fails loud. Build a

--- a/packages/pg-delta/tests/supabase-cluster-scope-roles.test.ts
+++ b/packages/pg-delta/tests/supabase-cluster-scope-roles.test.ts
@@ -52,7 +52,7 @@ describe("supabase profile — cluster-scope export excludes platform role plumb
       scope: "cluster",
     });
     const rolesSql =
-      result.files.find((f) => f.name === "cluster/roles.sql")?.sql ?? "";
+      result.files.find((f) => f.name === "_cluster/roles.sql")?.sql ?? "";
 
     // Platform plumbing must be invisible (issue #371's four statements).
     expect(rolesSql).not.toContain("supabase_privileged_role");


### PR DESCRIPTION
## What

Adds a `pathStyle?: "flat" | "nested"` option to `ExportOptions` (and `--path-style` on `pgdelta schema export`) controlling the declarative export directory tree, and makes **flat** the new default:

```
# flat (new default)                 # nested (previous behavior)
<dir>/<schema>/tables/users.sql      <dir>/schemas/<schema>/tables/users.sql
<dir>/_cluster/roles.sql             <dir>/cluster/roles.sql
```

`pathStyle: "nested"` / `--path-style nested` restores the previous tree exactly.

## Why

Better default DX. The `schemas/` wrapper only existed to namespace schema dirs away from `cluster/`, and in the common Supabase setup (declarative dir at `supabase/schemas/`) it produced the stuttering `supabase/schemas/schemas/public/tables/users.sql`. The loader is structure-agnostic, so the wrapper carries no functional weight.

## How

- The style switch is centralized in `pathFor()` / `clusterRoot()` / `schemaRoot()` in `src/frontends/export-sql-files.ts`, so all three layouts (`by-object`, `ordered`, `grouped`) inherit it. `ordered` filenames get shorter for free (`0001_app_tables_users.sql`).
- **Reserved-name guard (flat only):** a schema literally named `_cluster` or `_custom` gets its leading underscore percent-encoded (`%5Fcluster/`). `_custom` is included because it is already a reserved root (`src/frontends/custom-dir.ts`) and the CLI hard-errors on exported paths inside it — under flat, a schema named `_custom` would otherwise break `pgdelta schema export`. Other underscore-prefixed schemas keep their natural names.
- A schema named `_CLUSTER` on case-insensitive filesystems is handled by the existing case-collision fold (directories fold, a warning is emitted, no file is ever overwritten) — pinned in `tests/export-case-collision.test.ts`.
- Loader / pruner / manifest need no changes (structure-agnostic); round-trip fidelity `load(export(db)) ≡ db` holds, including for a schema named `_cluster`.
- The CLI export summary now reports the style: `(layout: by-object, path style: flat)`.

## Reviewer notes

- **TDD split:** first commit (`test(pg-delta): add failing regressions for flat export path style`) contains only the failing regressions — check it out to watch them fail. RED excerpt:

  ```
  expect(names).toContain("_cluster/roles.sql")
  Received: [ "cluster/roles.sql", "schemas/app/schema.sql", "schemas/app/tables/t.sql", … ]

  expect(names).toContain("%5Fcluster/schema.sql")
  Received: [ "cluster/roles.sql", "schemas/_cluster/schema.sql", … ]
  ```

- **Default flip:** existing tests pinning the nested paths were updated deliberately — nested-specific pins now pass `pathStyle: "nested"` explicitly; layout-semantics tests moved to the new flat default.
- Changeset: `minor` (`.changeset/flat-declarative-export-layout.md`).

## Verification

- Full corpus (proof loop): **662/662 pass** on `postgres:17-alpine`
- Full unit suite: 1321/1321 pass
- Focused export/CLI/integration files (export, export-layout, export-grouped, export-case-collision, fidelity, ownership, cli, +9 adjacent): all green
- `format-and-lint` + `check-types`: clean; `knip` clean for pg-delta (a pre-existing pg-topo `Unused files` finding reproduces on a clean tree, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)