### PR TITLE
feat(pg-delta): keep user RLS policies on storage/realtime surfaces

### DIFF
--- a/.changeset/user-policy-surfaces.md
+++ b/.changeset/user-policy-surfaces.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-delta": minor
+---
+
+feat(pg-delta): keep user RLS policies on storage/realtime surfaces through the supabase filter
+
+RLS policies on `storage.objects`, `storage.buckets`, and `realtime.messages` were marked reference-only by the managed-schema exclude (assumed schema + Rule 4) and silently dropped from diffs and declarative exports. The supabase profile now includes policies on those surfaces — the platform seeds none, so any policy present is user-authored. `auth` policies and other managed-schema tables stay excluded.

--- a/packages/pg-delta/src/policy/supabase-user-policies.test.ts
+++ b/packages/pg-delta/src/policy/supabase-user-policies.test.ts
@@ -1,0 +1,110 @@
+/**
+ * User RLS policies on an explicit allowlist of managed-schema tables
+ * (storage.objects / storage.buckets / realtime.messages) are user intent, not
+ * platform state. Policies have no owner — the discriminator is the surface,
+ * not expression inspection. An include rule must win before Rule 4 (system
+ * schema exclude); otherwise the policy is marked reference-only (assumed
+ * schema) and silently dropped from diffs and exports.
+ *
+ * Pure policy level — no DB.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import { encodeId, type StableId } from "../core/stable-id.ts";
+import { resolveView } from "./policy.ts";
+import { SUPABASE_USER_POLICY_SURFACES, supabasePolicy } from "./supabase.ts";
+
+const schema = (name: string): Fact => ({
+  id: { kind: "schema", name },
+  payload: {},
+});
+
+const table = (schemaName: string, name: string): Fact => ({
+  id: { kind: "table", schema: schemaName, name },
+  parent: { kind: "schema", name: schemaName },
+  payload: { persistence: "p" },
+});
+
+const policy = (schemaName: string, tableName: string, name: string): Fact => ({
+  id: { kind: "policy", schema: schemaName, table: tableName, name },
+  parent: { kind: "table", schema: schemaName, name: tableName },
+  payload: {
+    cmd: "r",
+    permissive: true,
+    usingExpr: "true",
+    checkExpr: null,
+    roles: ["authenticated"],
+  },
+});
+
+const id = (fact: Fact): StableId => fact.id;
+
+const objectsPolicy = policy(
+  "storage",
+  "objects",
+  "Users can read own objects",
+);
+const bucketsPolicy = policy("storage", "buckets", "public buckets");
+const messagesPolicy = policy("realtime", "messages", "can presence");
+const authUsersPolicy = policy("auth", "users", "users cannot do this");
+const migrationsPolicy = policy("storage", "migrations", "no user policies");
+const publicPolicy = policy("public", "t", "public is unmanaged");
+
+function world(): Fact[] {
+  return [
+    schema("storage"),
+    schema("realtime"),
+    schema("auth"),
+    schema("public"),
+    table("storage", "objects"),
+    table("storage", "buckets"),
+    table("storage", "migrations"),
+    table("realtime", "messages"),
+    table("auth", "users"),
+    table("public", "t"),
+    objectsPolicy,
+    bucketsPolicy,
+    messagesPolicy,
+    authUsersPolicy,
+    migrationsPolicy,
+    publicPolicy,
+  ];
+}
+
+describe("supabase policy — user RLS on managed-schema surfaces", () => {
+  const view = resolveView(buildFactBase(world(), []), supabasePolicy);
+
+  test("allowlist covers the documented Storage / Realtime policy surfaces", () => {
+    expect([...SUPABASE_USER_POLICY_SURFACES]).toEqual([
+      { schema: "storage", table: "objects" },
+      { schema: "storage", table: "buckets" },
+      { schema: "realtime", table: "messages" },
+    ]);
+  });
+
+  test("keeps allowlist policies managed, not reference-only", () => {
+    for (const fact of [objectsPolicy, bucketsPolicy, messagesPolicy]) {
+      expect(view.get(id(fact))).toBeDefined();
+      expect(view.referenceOnly.has(encodeId(id(fact)))).toBe(false);
+    }
+  });
+
+  test("still projects policies off the allowlist as reference-only", () => {
+    // assumed-schema + Rule 4: present so dependents resolve, never diffed
+    expect(view.get(id(authUsersPolicy))).toBeDefined();
+    expect(view.referenceOnly.has(encodeId(id(authUsersPolicy)))).toBe(true);
+    expect(view.get(id(migrationsPolicy))).toBeDefined();
+    expect(view.referenceOnly.has(encodeId(id(migrationsPolicy)))).toBe(true);
+  });
+
+  test("keeps an ordinary public-schema policy managed", () => {
+    expect(view.get(id(publicPolicy))).toBeDefined();
+    expect(view.referenceOnly.has(encodeId(id(publicPolicy)))).toBe(false);
+  });
+
+  test("platform tables stay reference-only so export cannot recreate them", () => {
+    const objects = table("storage", "objects");
+    expect(view.get(id(objects))).toBeDefined();
+    expect(view.referenceOnly.has(encodeId(id(objects)))).toBe(true);
+  });
+});

--- a/packages/pg-delta/src/policy/supabase.ts
+++ b/packages/pg-delta/src/policy/supabase.ts
@@ -178,6 +178,18 @@ const SUPABASE_SYSTEM_PUBLICATIONS = [
   "supabase_realtime_messages_publication",
 ] as const;
 
+/** Managed-schema tables whose RLS policies are user intent, not platform state.
+ *  The platform seeds none on these surfaces (pinned by the full-stack fixture
+ *  in `tests/supabase-base-init.test.ts` and by the pristine guard in
+ *  `tests/supabase-managed-policies.test.ts` after `applySupabaseBaseInit`);
+ *  any policy present is user-authored. Policies have no owner — do not
+ *  inspect `usingExpr`. */
+export const SUPABASE_USER_POLICY_SURFACES = [
+  { schema: "storage", table: "objects" },
+  { schema: "storage", table: "buckets" },
+  { schema: "realtime", table: "messages" },
+] as const;
+
 // ---------------------------------------------------------------------------
 // The Supabase policy
 // ---------------------------------------------------------------------------
@@ -393,6 +405,34 @@ export const supabasePolicy: Policy = {
         ],
       },
       action: "include",
+    },
+
+    // User RLS on an explicit allowlist of managed-schema tables. Policies
+    // have no owner, so the discriminator is the surface, not provenance.
+    // MUST precede Rule 4 (first-match-wins): a policy's id.schema is the
+    // table schema, so Rule 4 would otherwise exclude it. Because that
+    // schema is also assumed, the exclusion is reference-only — the policy
+    // stays in the view but never diffs or exports. Rule 10 does not match
+    // kind:"policy" (satellites only); placement vs Rule 10 is not the game.
+    {
+      match: {
+        all: [
+          { kind: "policy" },
+          {
+            any: SUPABASE_USER_POLICY_SURFACES.map((s) => ({
+              all: [
+                { schema: s.schema },
+                { idField: { field: "table", glob: s.table } },
+              ],
+            })),
+          },
+        ],
+      },
+      action: "include",
+      audit: {
+        reasonCode: "supabase.user-policy-surface",
+        classification: "acknowledged",
+      },
     },
 
     // -------------------------------------------------------------------------

--- a/packages/pg-delta/tests/supabase-base-init.test.ts
+++ b/packages/pg-delta/tests/supabase-base-init.test.ts
@@ -7,8 +7,9 @@
  * without booting the Supabase stack.
  */
 import { describe, expect, test } from "bun:test";
-import { getSupabaseBaseInitSql } from "./supabase-base-init.ts";
+import { SUPABASE_USER_POLICY_SURFACES } from "../src/policy/supabase.ts";
 import { SUPABASE_BARE_MAJOR } from "./containers.ts";
+import { getSupabaseBaseInitSql } from "./supabase-base-init.ts";
 
 describe(`supabase base-init fixture (pg${SUPABASE_BARE_MAJOR})`, () => {
   test("is committed, non-empty, and carries the preamble + generated header", async () => {
@@ -71,5 +72,18 @@ describe(`supabase base-init fixture (pg${SUPABASE_BARE_MAJOR})`, () => {
     expect(sql).toContain(
       'REVOKE ALL ON FUNCTION "net"."http_get"(text, jsonb, jsonb, integer) FROM PUBLIC',
     );
+  });
+
+  test("creates the user-policy surfaces with no platform CREATE POLICY", async () => {
+    const sql = await getSupabaseBaseInitSql();
+    for (const { schema, table } of SUPABASE_USER_POLICY_SURFACES) {
+      expect(sql).toContain(`CREATE TABLE "${schema}"."${table}"`);
+      expect(sql).not.toMatch(
+        new RegExp(
+          `CREATE POLICY[\\s\\S]{0,400}ON "${schema}"\\."${table}"`,
+          "i",
+        ),
+      );
+    }
   });
 });

--- a/packages/pg-delta/tests/supabase-managed-policies.test.ts
+++ b/packages/pg-delta/tests/supabase-managed-policies.test.ts
@@ -1,0 +1,303 @@
+/**
+ * User RLS policies on storage.objects / storage.buckets / realtime.messages
+ * must survive the supabase managed-schema filter, export as TABLE_SCOPED
+ * satellites of a reference-only parent (no CREATE TABLE), and round-trip
+ * through plan → apply → re-diff.
+ *
+ * `createDb()` on the shared supabase cluster is an empty database (template1),
+ * not a copy of the image's `postgres` catalog — stand-in tables named like the
+ * platform surfaces exercise the policy the same way the auth.users trigger
+ * tests do. The pristine guard boots a standalone bare image and replays
+ * `applySupabaseBaseInit` there — `createDb()` is empty template1, so the
+ * fixture (a bare→full-stack delta) cannot replay into it, and extracting the
+ * shared cluster `postgres` catalog is vacuous (those tables are not created
+ * until service migrations).
+ *
+ * Self-gated via runSupabaseBareTests.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import pg from "pg";
+import { apply } from "../src/apply/apply.ts";
+import type { StableId } from "../src/core/stable-id.ts";
+import { extract } from "../src/extract/extract.ts";
+import { exportSqlFiles } from "../src/frontends/export-sql-files.ts";
+import { plan } from "../src/plan/plan.ts";
+import { flattenPolicy, resolveView } from "../src/policy/policy.ts";
+import {
+  SUPABASE_USER_POLICY_SURFACES,
+  supabasePolicy,
+} from "../src/policy/supabase.ts";
+import {
+  runSupabaseBareTests,
+  startStandaloneSupabase,
+  supabaseCluster,
+  type TestDb,
+} from "./containers.ts";
+import { applySupabaseBaseInit } from "./supabase-base-init.ts";
+
+const dbs: TestDb[] = [];
+afterAll(async () => {
+  await Promise.all(dbs.map((d) => d.drop().catch(() => {})));
+});
+
+const ALLOWLIST = SUPABASE_USER_POLICY_SURFACES;
+
+const STANDIN_SURFACES = `
+  CREATE SCHEMA IF NOT EXISTS storage;
+  CREATE TABLE IF NOT EXISTS storage.objects (
+    id uuid PRIMARY KEY,
+    bucket_id text,
+    name text,
+    owner uuid
+  );
+  ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+  CREATE TABLE IF NOT EXISTS storage.buckets (
+    id text PRIMARY KEY,
+    name text
+  );
+  ALTER TABLE storage.buckets ENABLE ROW LEVEL SECURITY;
+  CREATE SCHEMA IF NOT EXISTS realtime;
+  CREATE TABLE IF NOT EXISTS realtime.messages (
+    id uuid PRIMARY KEY,
+    topic text
+  );
+  ALTER TABLE realtime.messages ENABLE ROW LEVEL SECURITY;
+  CREATE SCHEMA IF NOT EXISTS auth;
+  CREATE FUNCTION auth.uid() RETURNS uuid
+    LANGUAGE sql STABLE AS $$ SELECT NULL::uuid $$;
+`;
+
+const OBJECTS_POLICY = `
+  CREATE POLICY "Users can read own objects" ON storage.objects
+    FOR SELECT TO authenticated
+    USING (bucket_id = 'x');
+`;
+
+const OBJECTS_POLICY_EDITED = `
+  DROP POLICY "Users can read own objects" ON storage.objects;
+  CREATE POLICY "Users can read own objects" ON storage.objects
+    FOR SELECT TO authenticated
+    USING (bucket_id = 'y');
+`;
+
+const MESSAGES_POLICY = `
+  CREATE POLICY "authenticated can read messages" ON realtime.messages
+    FOR SELECT TO authenticated
+    USING (true);
+`;
+
+const AUTH_UID_POLICY = `
+  CREATE POLICY "owner can read" ON storage.objects
+    FOR SELECT TO authenticated
+    USING (owner = auth.uid());
+`;
+
+const flat = flattenPolicy(supabasePolicy);
+
+async function makeDb(prefix: string, sql?: string): Promise<TestDb> {
+  const cluster = await supabaseCluster();
+  const db = await cluster.createDb(prefix);
+  dbs.push(db);
+  await db.pool.query(STANDIN_SURFACES);
+  if (sql !== undefined) await db.pool.query(sql);
+  return db;
+}
+
+function planSql(source: TestDb, desired: TestDb) {
+  return Promise.all([extract(source.pool), extract(desired.pool)]).then(
+    ([s, d]) =>
+      plan(s.factBase, d.factBase, { policy: supabasePolicy }).actions.map(
+        (a) => a.sql,
+      ),
+  );
+}
+
+function isAllowlistPolicy(id: StableId): boolean {
+  return (
+    id.kind === "policy" &&
+    ALLOWLIST.some((s) => s.schema === id.schema && s.table === id.table)
+  );
+}
+
+function isAllowlistTable(id: StableId): boolean {
+  return (
+    id.kind === "table" &&
+    ALLOWLIST.some((s) => s.schema === id.schema && s.table === id.name)
+  );
+}
+
+describe.skipIf(!runSupabaseBareTests)(
+  "supabase profile: user RLS on managed-schema surfaces",
+  () => {
+    test("pristine image seeds no policies on the allowlist surfaces", async () => {
+      const stack = await startStandaloneSupabase();
+      const pool = new pg.Pool({
+        connectionString: stack.connectionUri("postgres"),
+        max: 3,
+      });
+      try {
+        await applySupabaseBaseInit(pool);
+        const { factBase } = await extract(pool);
+        const tables = factBase
+          .facts()
+          .filter((fct) => isAllowlistTable(fct.id))
+          .map((fct) =>
+            fct.id.kind === "table" ? `${fct.id.schema}.${fct.id.name}` : "",
+          )
+          .sort();
+        expect(tables).toEqual(
+          [...ALLOWLIST].map((s) => `${s.schema}.${s.table}`).sort(),
+        );
+        const seeded = factBase
+          .facts()
+          .filter((fct) => isAllowlistPolicy(fct.id))
+          .map((fct) => fct.id);
+        expect(seeded).toEqual([]);
+      } finally {
+        await pool.end();
+        await stack.stop();
+      }
+    }, 180_000);
+
+    test("diff/apply/converge creates and drops a storage.objects policy", async () => {
+      const without = await makeDb("pol_obj_wo");
+      const withPolicy = await makeDb("pol_obj_w", OBJECTS_POLICY);
+
+      const [withoutState, withState] = await Promise.all([
+        extract(without.pool),
+        extract(withPolicy.pool),
+      ]);
+      const createPlan = plan(withoutState.factBase, withState.factBase, {
+        policy: supabasePolicy,
+      });
+      const createSql = createPlan.actions.map((a) => a.sql);
+      expect(createSql.some((s) => /CREATE TABLE/i.test(s))).toBe(false);
+      expect(createSql.some((s) => /ENABLE ROW LEVEL SECURITY/i.test(s))).toBe(
+        false,
+      );
+      expect(createSql).toMatchInlineSnapshot(`
+        [
+          "CREATE POLICY "Users can read own objects" ON "storage"."objects" FOR SELECT TO "authenticated" USING ((bucket_id = 'x'::text))",
+        ]
+      `);
+
+      const created = await apply(createPlan, without.pool, {
+        fingerprintGate: false,
+      });
+      expect(created.status).toBe("applied");
+      expect(
+        plan((await extract(without.pool)).factBase, withState.factBase, {
+          policy: supabasePolicy,
+        }).actions,
+      ).toEqual([]);
+
+      const empty = await makeDb("pol_obj_empty");
+      const dropPlan = plan(
+        (await extract(withPolicy.pool)).factBase,
+        (await extract(empty.pool)).factBase,
+        { policy: supabasePolicy },
+      );
+      expect(dropPlan.actions.some((a) => /DROP POLICY/i.test(a.sql))).toBe(
+        true,
+      );
+      const dropped = await apply(dropPlan, withPolicy.pool, {
+        fingerprintGate: false,
+      });
+      expect(dropped.status).toBe("applied");
+      expect(
+        plan(
+          (await extract(withPolicy.pool)).factBase,
+          (await extract(empty.pool)).factBase,
+          { policy: supabasePolicy },
+        ).actions,
+      ).toEqual([]);
+    }, 180_000);
+
+    test("a usingExpr edit rebuilds the policy (DROP + CREATE)", async () => {
+      const before = await makeDb("pol_edit_a", OBJECTS_POLICY);
+      const after = await makeDb("pol_edit_b", OBJECTS_POLICY);
+      await after.pool.query(OBJECTS_POLICY_EDITED);
+
+      const sql = await planSql(before, after);
+      expect(sql.some((s) => s.startsWith("DROP POLICY"))).toBe(true);
+      expect(sql.some((s) => s.startsWith("CREATE POLICY"))).toBe(true);
+      expect(sql.some((s) => /bucket_id = 'y'/.test(s))).toBe(true);
+    }, 180_000);
+
+    test("export files the policy under the table without recreating it", async () => {
+      const db = await makeDb("pol_export", OBJECTS_POLICY);
+      const { factBase } = await extract(db.pool);
+      const view = resolveView(factBase, supabasePolicy);
+      const files = exportSqlFiles(view, {
+        assumedSchemas: flat.assumedSchemas,
+        assumedRoles: flat.assumedRoles,
+      });
+      const allSql = files.map((f) => f.sql).join("\n");
+      expect(allSql).not.toMatch(/CREATE TABLE[^;]*"?objects"?/i);
+      expect(allSql).not.toMatch(/ENABLE ROW LEVEL SECURITY/i);
+
+      const objectsFile = files.find(
+        (f) =>
+          f.name === "storage/tables/objects.sql" ||
+          f.name === "schemas/storage/tables/objects.sql",
+      );
+      expect(objectsFile).toBeDefined();
+      expect(objectsFile?.sql).toMatch(/CREATE POLICY/);
+      expect(objectsFile?.sql).toMatchInlineSnapshot(`
+        "CREATE POLICY "Users can read own objects" ON "storage"."objects" FOR SELECT TO "authenticated" USING ((bucket_id = 'x'::text));
+        "
+      `);
+    }, 180_000);
+
+    test("diff/apply/converge a realtime.messages policy", async () => {
+      const without = await makeDb("pol_msg_wo");
+      const withPolicy = await makeDb("pol_msg_w", MESSAGES_POLICY);
+      const sql = await planSql(without, withPolicy);
+      expect(sql.some((s) => /CREATE POLICY/.test(s))).toBe(true);
+      expect(sql.some((s) => /realtime"\."messages/.test(s))).toBe(true);
+
+      const thePlan = plan(
+        (await extract(without.pool)).factBase,
+        (await extract(withPolicy.pool)).factBase,
+        { policy: supabasePolicy },
+      );
+      const report = await apply(thePlan, without.pool, {
+        fingerprintGate: false,
+      });
+      expect(report.status).toBe("applied");
+      expect(
+        plan(
+          (await extract(without.pool)).factBase,
+          (await extract(withPolicy.pool)).factBase,
+          { policy: supabasePolicy },
+        ).actions,
+      ).toEqual([]);
+    }, 180_000);
+
+    test("a storage.objects policy calling auth.uid() plans and applies", async () => {
+      const without = await makeDb("pol_uid_wo");
+      const withPolicy = await makeDb("pol_uid_w", AUTH_UID_POLICY);
+      const sql = await planSql(without, withPolicy);
+      expect(sql.some((s) => /CREATE POLICY "owner can read"/.test(s))).toBe(
+        true,
+      );
+
+      const thePlan = plan(
+        (await extract(without.pool)).factBase,
+        (await extract(withPolicy.pool)).factBase,
+        { policy: supabasePolicy },
+      );
+      const report = await apply(thePlan, without.pool, {
+        fingerprintGate: false,
+      });
+      expect(report.status).toBe("applied");
+      expect(
+        plan(
+          (await extract(without.pool)).factBase,
+          (await extract(withPolicy.pool)).factBase,
+          { policy: supabasePolicy },
+        ).actions,
+      ).toEqual([]);
+    }, 180_000);
+  },
+);


### PR DESCRIPTION
## Summary

User RLS on `storage.objects`, `storage.buckets`, and `realtime.messages` was marked reference-only by the supabase assumed-schema exclude (Rule 4), so diffs and declarative exports silently dropped those policies. Policies have no owner — the discriminator is an explicit surface allowlist, placed before Rule 4.

The platform seeds none of these policies. The pristine guard now replays `applySupabaseBaseInit` on a standalone bare image so the three tables actually exist (extracting the bare `postgres` catalog was vacuous). The committed full-stack fixture is also pinned to create those tables with no `CREATE POLICY`.

Out of scope: grants (Unit B), publications (already shipped), `COMMENT ON POLICY` on allowlist tables (still Rule 10), `auth` RLS.

## Linked issue

Refs CLI-1385 (Phase 5, Unit A).

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Test plan

- [x] Unit: `packages/pg-delta/src/policy/supabase-user-policies.test.ts` (allowlist managed; off-allowlist reference-only)
- [x] Fixture pin: `tests/supabase-base-init.test.ts` (tables exist, no platform `CREATE POLICY`)
- [x] Integration (supabase image): create/drop/converge, usingExpr rebuild, export without `CREATE TABLE`, `realtime.messages`, `auth.uid()`
- [x] RED on the vacuous guard: asserting allowlist tables on bare `adminPool` yielded `[]` vs `storage.objects` / `storage.buckets` / `realtime.messages`
- [x] Dogfood on copied atomic-crm / CMSaasStarter / dbdev select policies: managed + `storage/tables/objects.sql`