### PR TITLE
fix(pg-delta): omit supabase platform parameter ACLs from coverage

### DIFF
--- a/.changeset/supabase-platform-parameter-acl.md
+++ b/.changeset/supabase-platform-parameter-acl.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+The supabase profile now drops the platform `log_min_messages` parameter ACL grants (`supabase_admin` SET/ALTER SYSTEM, `supabase_realtime_admin` SET) from `unmodeled_kind` coverage. User parameter ACLs are still reported. Raw extract is unchanged.

--- a/packages/pg-delta/src/extract/unmodeled.ts
+++ b/packages/pg-delta/src/extract/unmodeled.ts
@@ -369,19 +369,31 @@ export async function detectUnmodeledKinds(
   const diagnostics: Diagnostic[] = [];
   for (const row of rows) {
     if (row.count <= 0) continue;
-    const samples = row.samples ?? [];
-    const more = row.count > samples.length ? ", …" : "";
-    diagnostics.push({
-      code: "unmodeled_kind",
-      severity: "warning",
-      message:
-        `${row.count} unmodeled "${row.kind}" object${row.count === 1 ? "" : "s"} ` +
-        `not managed by this engine (e.g. ${samples.join(", ")}${more}) — ` +
-        `v1 detects but does not model this kind; ${remediationFor(row.kind)}`,
-      context: { kind: row.kind, count: row.count, samples },
-    });
+    diagnostics.push(
+      unmodeledKindDiagnostic(row.kind, row.count, row.samples ?? []),
+    );
   }
   return diagnostics;
+}
+
+/** Shared `unmodeled_kind` shape so coverage filters can rewrite samples
+ *  without re-templating the message. */
+export function unmodeledKindDiagnostic(
+  kind: string,
+  count: number,
+  samples: readonly string[],
+): Diagnostic {
+  const shown = samples.slice(0, 5);
+  const more = count > shown.length ? ", …" : "";
+  return {
+    code: "unmodeled_kind",
+    severity: "warning",
+    message:
+      `${count} unmodeled "${kind}" object${count === 1 ? "" : "s"} ` +
+      `not managed by this engine (e.g. ${shown.join(", ")}${more}) — ` +
+      `v1 detects but does not model this kind; ${remediationFor(kind)}`,
+    context: { kind, count, samples: shown },
+  };
 }
 
 /**

--- a/packages/pg-delta/src/integrations/profile.ts
+++ b/packages/pg-delta/src/integrations/profile.ts
@@ -34,6 +34,17 @@ import { probeApplierCapability } from "../policy/capability.ts";
 import { filterSupabasePlatformParameterAclDiagnostics } from "../policy/parameter-acl.ts";
 import { flattenPolicy, type Policy } from "../policy/policy.ts";
 
+function policyOrAncestorHasId(
+  policy: Policy | undefined,
+  id: string,
+): boolean {
+  if (policy === undefined) return false;
+  if (policy.id === id) return true;
+  return (policy.extends ?? []).some((parent) =>
+    policyOrAncestorHasId(parent, id),
+  );
+}
+
 /** Static, declarative profile: the handlers and policy that define a managed
  *  view. Pure data — no live connection. Compose your own, or use the presets
  *  (`supabaseProfile`, `rawProfile`). */
@@ -220,7 +231,9 @@ export async function resolveProfile(
     extractOptions: ExtractOptions = {},
   ): Promise<ExtractResult> => {
     const result = await extract(p, { ...extractOptions, handlers });
-    if (profile.id !== "supabase" && policy?.id !== "supabase") return result;
+    if (profile.id !== "supabase" && !policyOrAncestorHasId(policy, "supabase")) {
+      return result;
+    }
     return {
       ...result,
       diagnostics: await filterSupabasePlatformParameterAclDiagnostics(

--- a/packages/pg-delta/src/integrations/profile.ts
+++ b/packages/pg-delta/src/integrations/profile.ts
@@ -231,7 +231,10 @@ export async function resolveProfile(
     extractOptions: ExtractOptions = {},
   ): Promise<ExtractResult> => {
     const result = await extract(p, { ...extractOptions, handlers });
-    if (profile.id !== "supabase" && !policyOrAncestorHasId(policy, "supabase")) {
+    if (
+      profile.id !== "supabase" &&
+      !policyOrAncestorHasId(policy, "supabase")
+    ) {
       return result;
     }
     return {

--- a/packages/pg-delta/src/integrations/profile.ts
+++ b/packages/pg-delta/src/integrations/profile.ts
@@ -31,6 +31,7 @@ import {
   resolveBaseline,
 } from "../policy/baseline.ts";
 import { probeApplierCapability } from "../policy/capability.ts";
+import { filterSupabasePlatformParameterAclDiagnostics } from "../policy/parameter-acl.ts";
 import { flattenPolicy, type Policy } from "../policy/policy.ts";
 
 /** Static, declarative profile: the handlers and policy that define a managed
@@ -214,10 +215,20 @@ export async function resolveProfile(
   // separately (planOptions.baselineMeta + ResolvedProfile.baseline).
   const baseline = loaded?.factBase;
 
-  const profileExtract = (
+  const profileExtract = async (
     p: Pool,
     extractOptions: ExtractOptions = {},
-  ): Promise<ExtractResult> => extract(p, { ...extractOptions, handlers });
+  ): Promise<ExtractResult> => {
+    const result = await extract(p, { ...extractOptions, handlers });
+    if (profile.id !== "supabase" && policy?.id !== "supabase") return result;
+    return {
+      ...result,
+      diagnostics: await filterSupabasePlatformParameterAclDiagnostics(
+        p,
+        result.diagnostics,
+      ),
+    };
+  };
 
   // fold the handlers' intent replay rules (pg_cron jobs, …) into a resolver
   // index. Only `plan()` needs it (prove never re-plans; apply only replays

--- a/packages/pg-delta/src/policy/parameter-acl.test.ts
+++ b/packages/pg-delta/src/policy/parameter-acl.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { Diagnostic } from "../core/diagnostic.ts";
+import {
+  filterPlatformParameterAclDiagnostics,
+  userOwnedParameterAclNames,
+} from "./parameter-acl.ts";
+
+const platformOnly = [
+  {
+    name: "log_min_messages",
+    grantee: "supabase_admin",
+    privilege: "ALTER SYSTEM",
+  },
+  { name: "log_min_messages", grantee: "supabase_admin", privilege: "SET" },
+  {
+    name: "log_min_messages",
+    grantee: "supabase_realtime_admin",
+    privilege: "SET",
+  },
+] as const;
+
+const parameterAclDiagnostic: Diagnostic = {
+  code: "unmodeled_kind",
+  severity: "warning",
+  message:
+    '1 unmodeled "parameter ACL" object not managed by this engine (e.g. log_min_messages) — v1 detects but does not model this kind; this kind lives in a catalog shared by every database in the cluster',
+  context: { kind: "parameter ACL", count: 1, samples: ["log_min_messages"] },
+};
+
+describe("userOwnedParameterAclNames", () => {
+  test("platform triples alone yield no user names", () => {
+    expect(userOwnedParameterAclNames(platformOnly)).toEqual([]);
+  });
+
+  test("a user grant on another GUC is kept", () => {
+    expect(
+      userOwnedParameterAclNames([
+        ...platformOnly,
+        { name: "work_mem", grantee: "app", privilege: "SET" },
+      ]),
+    ).toEqual(["work_mem"]);
+  });
+
+  test("a user grant on log_min_messages is kept", () => {
+    expect(
+      userOwnedParameterAclNames([
+        ...platformOnly,
+        { name: "log_min_messages", grantee: "app", privilege: "SET" },
+      ]),
+    ).toEqual(["log_min_messages"]);
+  });
+});
+
+describe("filterPlatformParameterAclDiagnostics", () => {
+  test("drops the diagnostic when only platform grants remain", () => {
+    expect(
+      filterPlatformParameterAclDiagnostics([parameterAclDiagnostic], []),
+    ).toEqual([]);
+  });
+
+  test("rewrites samples to user-owned GUC names", () => {
+    const [next] = filterPlatformParameterAclDiagnostics(
+      [parameterAclDiagnostic],
+      ["work_mem"],
+    );
+    expect(next?.context).toEqual({
+      kind: "parameter ACL",
+      count: 1,
+      samples: ["work_mem"],
+    });
+    expect(next?.message).toContain("work_mem");
+    expect(next?.message).not.toContain("e.g. log_min_messages)");
+    expect(next?.message).toContain("cluster");
+  });
+
+  test("leaves unrelated diagnostics intact", () => {
+    const other: Diagnostic = {
+      code: "unmodeled_kind",
+      severity: "warning",
+      message: "cast",
+      context: { kind: "cast", count: 1, samples: ["x"] },
+    };
+    expect(filterPlatformParameterAclDiagnostics([other], [])).toEqual([other]);
+  });
+});

--- a/packages/pg-delta/src/policy/parameter-acl.ts
+++ b/packages/pg-delta/src/policy/parameter-acl.ts
@@ -1,0 +1,93 @@
+/**
+ * Platform `pg_parameter_acl` grants are cluster-wide (PG 15+) and are not
+ * user schema. The supabase extract wrapper drops the exact bootstrap triples
+ * from `unmodeled_kind`; any other grant stays a coverage gap.
+ */
+import type { Pool } from "pg";
+import type { Diagnostic } from "../core/diagnostic.ts";
+import { unmodeledKindDiagnostic } from "../extract/unmodeled.ts";
+
+interface ParameterAclGrant {
+  readonly name: string;
+  readonly grantee: string;
+  readonly privilege: string;
+}
+
+const PLATFORM_PARAMETER_ACLS = new Set([
+  "log_min_messages\u0000supabase_admin\u0000ALTER SYSTEM",
+  "log_min_messages\u0000supabase_admin\u0000SET",
+  "log_min_messages\u0000supabase_realtime_admin\u0000SET",
+]);
+
+function grantKey(grant: ParameterAclGrant): string {
+  return `${grant.name}\u0000${grant.grantee}\u0000${grant.privilege}`;
+}
+
+export function userOwnedParameterAclNames(
+  grants: readonly ParameterAclGrant[],
+): string[] {
+  return [
+    ...new Set(
+      grants
+        .filter((grant) => !PLATFORM_PARAMETER_ACLS.has(grantKey(grant)))
+        .map((grant) => grant.name),
+    ),
+  ].sort();
+}
+
+function isParameterAclDiagnostic(diagnostic: Diagnostic): boolean {
+  return (
+    diagnostic.code === "unmodeled_kind" &&
+    diagnostic.context?.["kind"] === "parameter ACL"
+  );
+}
+
+/** Drop platform-only parameter ACL coverage; keep user-owned GUC names. */
+export function filterPlatformParameterAclDiagnostics(
+  diagnostics: readonly Diagnostic[],
+  userOwnedNames: readonly string[],
+): Diagnostic[] {
+  const names = [...new Set(userOwnedNames)].sort();
+  const out: Diagnostic[] = [];
+  for (const diagnostic of diagnostics) {
+    if (!isParameterAclDiagnostic(diagnostic)) {
+      out.push(diagnostic);
+      continue;
+    }
+    if (names.length === 0) continue;
+    out.push(unmodeledKindDiagnostic("parameter ACL", names.length, names));
+  }
+  return out;
+}
+
+async function fetchParameterAclGrants(
+  pool: Pool,
+): Promise<ParameterAclGrant[]> {
+  try {
+    const { rows } = await pool.query<ParameterAclGrant>(
+      `SELECT DISTINCT pa.parname AS name,
+              COALESCE(grantee.rolname, 'PUBLIC') AS grantee,
+              acl.privilege_type AS privilege
+         FROM pg_parameter_acl pa
+         CROSS JOIN LATERAL aclexplode(pa.paracl) acl
+         LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
+        ORDER BY pa.parname, grantee, privilege`,
+    );
+    return rows;
+  } catch (error) {
+    // PG 14 has no pg_parameter_acl (undefined_table).
+    if ((error as { code?: string }).code === "42P01") return [];
+    throw error;
+  }
+}
+
+export async function filterSupabasePlatformParameterAclDiagnostics(
+  pool: Pool,
+  diagnostics: readonly Diagnostic[],
+): Promise<Diagnostic[]> {
+  if (!diagnostics.some(isParameterAclDiagnostic)) return [...diagnostics];
+  return filterPlatformParameterAclDiagnostics(
+    diagnostics,
+    userOwnedParameterAclNames(await fetchParameterAclGrants(pool)),
+  );
+}

--- a/packages/pg-delta/src/policy/parameter-acl.ts
+++ b/packages/pg-delta/src/policy/parameter-acl.ts
@@ -68,9 +68,9 @@ async function fetchParameterAclGrants(
       `SELECT DISTINCT pa.parname AS name,
               COALESCE(grantee.rolname, 'PUBLIC') AS grantee,
               acl.privilege_type AS privilege
-         FROM pg_parameter_acl pa
-         CROSS JOIN LATERAL aclexplode(pa.paracl) acl
-         LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
+         FROM pg_catalog.pg_parameter_acl pa
+         CROSS JOIN LATERAL pg_catalog.aclexplode(pa.paracl) acl
+         LEFT JOIN pg_catalog.pg_roles grantee ON grantee.oid = acl.grantee
         ORDER BY pa.parname, grantee, privilege`,
     );
     return rows;

--- a/packages/pg-delta/tests/supabase-parameter-acl-coverage.test.ts
+++ b/packages/pg-delta/tests/supabase-parameter-acl-coverage.test.ts
@@ -13,6 +13,7 @@ import type { Diagnostic } from "../src/core/diagnostic.ts";
 import { extract } from "../src/extract/extract.ts";
 import { rawProfile, resolveProfile } from "../src/integrations/profile.ts";
 import { supabaseProfile } from "../src/integrations/supabase.ts";
+import { supabasePolicy } from "../src/policy/supabase.ts";
 import { classifyPlanHazards } from "../src/plan/hazards.ts";
 import { createTestDb } from "./containers.ts";
 
@@ -107,6 +108,18 @@ describe.skipIf(PG_MAJOR < 15)(
         });
         const viaRawProfile = await rawProfileResolved.extract(db.pool);
         expect(parameterAcl(viaRawProfile.diagnostics)).toBeDefined();
+
+        const inherited = await resolveProfile(
+          db.pool,
+          {
+            id: "custom",
+            handlers: supabaseProfile.handlers,
+            policy: { id: "custom", extends: [supabasePolicy] },
+          },
+          { skipBaseline: true },
+        );
+        const viaInherited = await inherited.extract(db.pool);
+        expect(parameterAcl(viaInherited.diagnostics)).toBeUndefined();
       } finally {
         await revokePlatformParameterAcls(db.pool).catch(() => {});
         for (const name of created) {

--- a/packages/pg-delta/tests/supabase-parameter-acl-coverage.test.ts
+++ b/packages/pg-delta/tests/supabase-parameter-acl-coverage.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Platform `pg_parameter_acl` grants (PG 15+) are cluster-wide and show up on
+ * every supabase-shaped extract as `unmodeled_kind`. The supabase profile must
+ * drop the exact bootstrap triples and keep any other parameter ACL as a
+ * coverage gap. Raw extract is unchanged.
+ *
+ * Grants are revoked in `finally` so they cannot leak into another file's
+ * extract on the shared test cluster.
+ */
+import { describe, expect, test } from "bun:test";
+import type { Pool } from "pg";
+import type { Diagnostic } from "../src/core/diagnostic.ts";
+import { extract } from "../src/extract/extract.ts";
+import { rawProfile, resolveProfile } from "../src/integrations/profile.ts";
+import { supabaseProfile } from "../src/integrations/supabase.ts";
+import { classifyPlanHazards } from "../src/plan/hazards.ts";
+import { createTestDb } from "./containers.ts";
+
+const PG_MAJOR = Number(
+  /postgres:(\d+)/.exec(
+    process.env["PGDELTA_TEST_IMAGE"] ?? "postgres:17-alpine",
+  )?.[1] ?? "17",
+);
+
+const PLATFORM_ROLES = ["supabase_admin", "supabase_realtime_admin"] as const;
+
+function parameterAcl(diagnostics: readonly Diagnostic[]) {
+  return diagnostics.find(
+    (d) =>
+      d.code === "unmodeled_kind" && d.context?.["kind"] === "parameter ACL",
+  );
+}
+
+async function ensureRole(pool: Pool, name: string): Promise<boolean> {
+  const { rows } = await pool.query(
+    `SELECT 1 FROM pg_roles WHERE rolname = $1`,
+    [name],
+  );
+  if (rows.length > 0) return false;
+  await pool.query(`CREATE ROLE "${name}"`);
+  return true;
+}
+
+async function grantPlatformParameterAcls(pool: Pool): Promise<void> {
+  await pool.query(
+    `GRANT SET, ALTER SYSTEM ON PARAMETER log_min_messages TO supabase_admin`,
+  );
+  await pool.query(
+    `GRANT SET ON PARAMETER log_min_messages TO supabase_realtime_admin`,
+  );
+  // GRANT as the test superuser also records that role on paracl. A real
+  // platform catalog is owned by supabase_admin, whose triples are already
+  // allowlisted — strip the fixture grantor so the row matches production.
+  await pool.query(
+    `REVOKE SET, ALTER SYSTEM ON PARAMETER log_min_messages FROM CURRENT_USER`,
+  );
+}
+
+async function revokePlatformParameterAcls(pool: Pool): Promise<void> {
+  await pool.query(
+    `REVOKE SET, ALTER SYSTEM ON PARAMETER log_min_messages FROM supabase_admin`,
+  );
+  await pool.query(
+    `REVOKE SET ON PARAMETER log_min_messages FROM supabase_realtime_admin`,
+  );
+}
+
+describe.skipIf(PG_MAJOR < 15)(
+  "supabase profile: platform parameter ACL coverage",
+  () => {
+    test("raw extract names the platform ACL; supabase extract omits it", async () => {
+      const db = await createTestDb("plat_acl");
+      const created: string[] = [];
+      try {
+        for (const name of PLATFORM_ROLES) {
+          if (await ensureRole(db.pool, name)) created.push(name);
+        }
+        await grantPlatformParameterAcls(db.pool);
+
+        const raw = await extract(db.pool);
+        const rawAcl = parameterAcl(raw.diagnostics);
+        expect(rawAcl).toBeDefined();
+        expect(rawAcl?.severity).toBe("warning");
+        expect(rawAcl?.subject).toBeUndefined();
+        expect(rawAcl?.context).toMatchObject({
+          kind: "parameter ACL",
+          count: 1,
+        });
+        expect(
+          (rawAcl?.context?.["samples"] as string[] | undefined) ?? [],
+        ).toContain("log_min_messages");
+        expect(
+          classifyPlanHazards({ actions: [] }, raw.diagnostics).coverage,
+        ).toEqual(["unmodeled_kind"]);
+
+        const supabase = await resolveProfile(db.pool, supabaseProfile, {
+          skipBaseline: true,
+        });
+        const filtered = await supabase.extract(db.pool);
+        expect(parameterAcl(filtered.diagnostics)).toBeUndefined();
+        expect(
+          classifyPlanHazards({ actions: [] }, filtered.diagnostics).coverage,
+        ).toEqual([]);
+
+        const rawProfileResolved = await resolveProfile(db.pool, rawProfile, {
+          skipBaseline: true,
+        });
+        const viaRawProfile = await rawProfileResolved.extract(db.pool);
+        expect(parameterAcl(viaRawProfile.diagnostics)).toBeDefined();
+      } finally {
+        await revokePlatformParameterAcls(db.pool).catch(() => {});
+        for (const name of created) {
+          await db.pool.query(`DROP ROLE "${name}"`).catch(() => {});
+        }
+        await db.drop();
+      }
+    }, 120_000);
+
+    test("a user parameter ACL remains a coverage gap under supabase", async () => {
+      const db = await createTestDb("user_acl");
+      const created: string[] = [];
+      const userRole = `user_acl_${db.name}`;
+      try {
+        for (const name of PLATFORM_ROLES) {
+          if (await ensureRole(db.pool, name)) created.push(name);
+        }
+        await db.pool.query(`CREATE ROLE ${userRole}`);
+        await grantPlatformParameterAcls(db.pool);
+        await db.pool.query(`GRANT SET ON PARAMETER work_mem TO ${userRole}`);
+
+        const supabase = await resolveProfile(db.pool, supabaseProfile, {
+          skipBaseline: true,
+        });
+        const result = await supabase.extract(db.pool);
+        const acl = parameterAcl(result.diagnostics);
+        expect(acl).toBeDefined();
+        expect(
+          ((acl?.context?.["samples"] ?? []) as string[]).join(" "),
+        ).toContain("work_mem");
+        expect(
+          ((acl?.context?.["samples"] ?? []) as string[]).join(" "),
+        ).not.toContain("log_min_messages");
+        expect(acl?.context?.["count"]).toBe(1);
+        expect(
+          classifyPlanHazards({ actions: [] }, result.diagnostics).coverage,
+        ).toEqual(["unmodeled_kind"]);
+      } finally {
+        await db.pool
+          .query(`REVOKE SET ON PARAMETER work_mem FROM ${userRole}`)
+          .catch(() => {});
+        await db.pool
+          .query(`REVOKE SET ON PARAMETER work_mem FROM CURRENT_USER`)
+          .catch(() => {});
+        await revokePlatformParameterAcls(db.pool).catch(() => {});
+        await db.pool.query(`DROP ROLE ${userRole}`).catch(() => {});
+        for (const name of created) {
+          await db.pool.query(`DROP ROLE "${name}"`).catch(() => {});
+        }
+        await db.drop();
+      }
+    }, 120_000);
+
+    test("a user grant on log_min_messages is still reported", async () => {
+      const db = await createTestDb("user_lmm");
+      const created: string[] = [];
+      const userRole = `user_lmm_${db.name}`;
+      try {
+        for (const name of PLATFORM_ROLES) {
+          if (await ensureRole(db.pool, name)) created.push(name);
+        }
+        await db.pool.query(`CREATE ROLE ${userRole}`);
+        await grantPlatformParameterAcls(db.pool);
+        await db.pool.query(
+          `GRANT SET ON PARAMETER log_min_messages TO ${userRole}`,
+        );
+
+        const supabase = await resolveProfile(db.pool, supabaseProfile, {
+          skipBaseline: true,
+        });
+        const result = await supabase.extract(db.pool);
+        const acl = parameterAcl(result.diagnostics);
+        expect(acl).toBeDefined();
+        expect(
+          ((acl?.context?.["samples"] ?? []) as string[]).join(" "),
+        ).toContain("log_min_messages");
+        expect(acl?.context?.["count"]).toBe(1);
+      } finally {
+        await db.pool
+          .query(`REVOKE SET ON PARAMETER log_min_messages FROM ${userRole}`)
+          .catch(() => {});
+        await db.pool
+          .query(
+            `REVOKE SET, ALTER SYSTEM ON PARAMETER log_min_messages FROM CURRENT_USER`,
+          )
+          .catch(() => {});
+        await revokePlatformParameterAcls(db.pool).catch(() => {});
+        await db.pool.query(`DROP ROLE ${userRole}`).catch(() => {});
+        for (const name of created) {
+          await db.pool.query(`DROP ROLE "${name}"`).catch(() => {});
+        }
+        await db.drop();
+      }
+    }, 120_000);
+  },
+);


### PR DESCRIPTION
## Summary

- The supabase profile now explodes `pg_parameter_acl` and drops only the platform bootstrap triples (`log_min_messages` / `supabase_admin` SET+ALTER SYSTEM, `supabase_realtime_admin` SET).
- User parameter ACLs (including a user grant on `log_min_messages`) stay `unmodeled_kind`. Raw extract is unchanged.
- `classifyPlanHazards` stays a dumb view of diagnostics.

Stack (merge bottom-up): this PR → #438 → #439.

## Test plan

- [x] Unit: `src/policy/parameter-acl.test.ts`
- [x] Integration (PG 17): `tests/supabase-parameter-acl-coverage.test.ts`, `tests/unmodeled-parameter-acl.test.ts`
- [x] `bun run format-and-lint` and `bun run check-types`

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added (`supabase-platform-parameter-acl.md`)
- [x] `bun run format-and-lint` and `bun run check-types` pass
- [x] Supabase maintainer (no tracked issue; schema-first dogfood follow-up)