### PR TITLE
fix(pg-delta): file sequence OWNED BY with the owning table

### DIFF
--- a/.changeset/serial-owned-by-table-file.md
+++ b/.changeset/serial-owned-by-table-file.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Declarative export now files `ALTER SEQUENCE … OWNED BY` with the owning table instead of the sequence file, so a file-atomic shadow load can create the sequence before `CREATE TABLE … nextval`.

--- a/packages/pg-delta/src/frontends/export-sql-files.ts
+++ b/packages/pg-delta/src/frontends/export-sql-files.ts
@@ -1008,7 +1008,10 @@ export function exportSqlFiles(
       name: clampFileName(
         `${String(index).padStart(4, "0")}_${run.path.replaceAll("/", "_")}`,
       ),
-      sql: renderFileSql(placeOwnedSequenceOwner(run.statements), options.format),
+      sql: renderFileSql(
+        placeOwnedSequenceOwner(run.statements),
+        options.format,
+      ),
     }));
   }
 

--- a/packages/pg-delta/src/frontends/export-sql-files.ts
+++ b/packages/pg-delta/src/frontends/export-sql-files.ts
@@ -123,8 +123,18 @@ function renderFileSql(
   return `${statements.map((s) => `${s};`).join("\n\n")}\n`;
 }
 
-/** The subject deciding an action's file: produced fact, else consumed. */
+/**
+ * File-placement subject. OWNED BY is a sequence follow-up whose first
+ * consume is the sequence (so it would otherwise land in sequences/), but
+ * it must sit with the owning table so the file-atomic loader can apply
+ * CREATE SEQUENCE before CREATE TABLE … nextval.
+ */
 function subjectOf(action: Action): StableId | undefined {
+  const column = action.consumes.find((id) => id.kind === "column");
+  const sequence =
+    action.produces.find((id) => id.kind === "sequence") ??
+    action.consumes.find((id) => id.kind === "sequence");
+  if (column !== undefined && sequence !== undefined) return column;
   return action.produces[0] ?? action.consumes[0];
 }
 

--- a/packages/pg-delta/src/frontends/export-sql-files.ts
+++ b/packages/pg-delta/src/frontends/export-sql-files.ts
@@ -123,19 +123,56 @@ function renderFileSql(
   return `${statements.map((s) => `${s};`).join("\n\n")}\n`;
 }
 
+function ownedTableOfSequence(
+  fb: FactBase,
+  sequence: StableId,
+): StableId | undefined {
+  if (sequence.kind !== "sequence") return undefined;
+  const ownedBy = fb.get(sequence)?.payload["ownedBy"] as
+    | { schema?: string; table?: string }
+    | null
+    | undefined;
+  if (ownedBy?.schema == null || ownedBy.table == null) return undefined;
+  return { kind: "table", schema: ownedBy.schema, name: ownedBy.table };
+}
+
 /**
  * File-placement subject. OWNED BY is a sequence follow-up whose first
  * consume is the sequence (so it would otherwise land in sequences/), but
  * it must sit with the owning table so the file-atomic loader can apply
- * CREATE SEQUENCE before CREATE TABLE … nextval.
+ * CREATE SEQUENCE before CREATE TABLE … nextval. Sequence OWNER TO follows
+ * the table too: PostgreSQL requires matching owners at OWNED BY time.
  */
-function subjectOf(action: Action): StableId | undefined {
+function subjectOf(action: Action, fb: FactBase): StableId | undefined {
   const column = action.consumes.find((id) => id.kind === "column");
   const sequence =
     action.produces.find((id) => id.kind === "sequence") ??
     action.consumes.find((id) => id.kind === "sequence");
   if (column !== undefined && sequence !== undefined) return column;
+  if (sequence !== undefined && /\bOWNER\s+TO\b/i.test(action.sql)) {
+    const table = ownedTableOfSequence(fb, sequence);
+    if (table !== undefined) return table;
+  }
   return action.produces[0] ?? action.consumes[0];
+}
+
+/** After OWNED BY, ALTER SEQUENCE OWNER TO must follow ALTER TABLE OWNER TO
+ *  (or the owners diverge and PostgreSQL rejects the owned sequence). */
+function placeOwnedSequenceOwner(statements: string[]): string[] {
+  const isSeqOwner = (s: string): boolean =>
+    /^\s*ALTER\s+SEQUENCE\b/i.test(s) && /\bOWNER\s+TO\b/i.test(s);
+  const seqOwner = statements.filter(isSeqOwner);
+  if (seqOwner.length === 0) return statements;
+  const rest = statements.filter((s) => !isSeqOwner(s));
+  const tableOwnerAt = rest.findLastIndex(
+    (s) => /^\s*ALTER\s+TABLE\b/i.test(s) && /\bOWNER\s+TO\b/i.test(s),
+  );
+  if (tableOwnerAt === -1) return [...rest, ...seqOwner];
+  return [
+    ...rest.slice(0, tableOwnerAt + 1),
+    ...seqOwner,
+    ...rest.slice(tableOwnerAt + 1),
+  ];
 }
 
 /** Satellite facts (comment/acl) file with their target. */
@@ -946,7 +983,7 @@ export function exportSqlFiles(
   // Each action's file path, in plan order (shared by both layouts below).
   const miscPath = `${clusterRoot(pathStyle)}/misc.sql`;
   const actionPaths = rendered.actions.map((action) => {
-    const subject = subjectOf(action);
+    const subject = subjectOf(action, fb);
     return subject === undefined ? miscPath : pathFor(subject, pathContext);
   });
 
@@ -971,7 +1008,7 @@ export function exportSqlFiles(
       name: clampFileName(
         `${String(index).padStart(4, "0")}_${run.path.replaceAll("/", "_")}`,
       ),
-      sql: renderFileSql(run.statements, options.format),
+      sql: renderFileSql(placeOwnedSequenceOwner(run.statements), options.format),
     }));
   }
 
@@ -1011,7 +1048,7 @@ export function exportSqlFiles(
     name: path,
     sql:
       (path.endsWith(".fk.sql") ? FK_SPLIT_HEADER : "") +
-      renderFileSql(entry.statements, options.format),
+      renderFileSql(placeOwnedSequenceOwner(entry.statements), options.format),
   }));
 }
 
@@ -1142,7 +1179,7 @@ function exportGrouped(
   // layout (issue #365) — regrouping cannot re-split them because the fold is
   // computed on the final grouped paths.
   const actionPaths = actions.map((action) => {
-    const subject = subjectOf(action);
+    const subject = subjectOf(action, fb);
     return subject === undefined
       ? `${clusterRoot(style)}/misc.sql`
       : groupedPath(subject);
@@ -1163,7 +1200,7 @@ function exportGrouped(
   );
   const files = new Map<string, GroupedFile>();
   actions.forEach((action, at) => {
-    const subject = subjectOf(action);
+    const subject = subjectOf(action, fb);
     const folded = foldedPaths[at]!;
     const path = cycleMerges.get(folded) ?? folded;
     const category = subject === undefined ? "misc" : categoryFor(subject);
@@ -1196,7 +1233,7 @@ function exportGrouped(
       name: path,
       sql:
         (path.endsWith(".fk.sql") ? FK_SPLIT_HEADER : "") +
-        renderFileSql(statements, options.format),
+        renderFileSql(placeOwnedSequenceOwner(statements), options.format),
     };
   });
 }

--- a/packages/pg-delta/src/frontends/export-sql-files.ts
+++ b/packages/pg-delta/src/frontends/export-sql-files.ts
@@ -149,7 +149,11 @@ function subjectOf(action: Action, fb: FactBase): StableId | undefined {
     action.produces.find((id) => id.kind === "sequence") ??
     action.consumes.find((id) => id.kind === "sequence");
   if (column !== undefined && sequence !== undefined) return column;
-  if (sequence !== undefined && /\bOWNER\s+TO\b/i.test(action.sql)) {
+  if (
+    sequence !== undefined &&
+    /^\s*ALTER\s+SEQUENCE\b/i.test(action.sql) &&
+    /\bOWNER\s+TO\b/i.test(action.sql)
+  ) {
     const table = ownedTableOfSequence(fb, sequence);
     if (table !== undefined) return table;
   }
@@ -167,7 +171,7 @@ function placeOwnedSequenceOwner(statements: string[]): string[] {
   const tableOwnerAt = rest.findLastIndex(
     (s) => /^\s*ALTER\s+TABLE\b/i.test(s) && /\bOWNER\s+TO\b/i.test(s),
   );
-  if (tableOwnerAt === -1) return [...rest, ...seqOwner];
+  if (tableOwnerAt === -1) return statements;
   return [
     ...rest.slice(0, tableOwnerAt + 1),
     ...seqOwner,

--- a/packages/pg-delta/tests/export-identity-sequence-name.test.ts
+++ b/packages/pg-delta/tests/export-identity-sequence-name.test.ts
@@ -43,6 +43,7 @@ describe("export: identity backing-sequence name fidelity", () => {
       const fb = (await extract(src.pool)).factBase;
 
       const files = forLoad(exportSqlFiles(fb));
+      expect(files.some((f) => f.name.includes("/sequences/"))).toBe(false);
       const all = files.map((f) => f.sql).join("\n");
       // the renamed sequence name must be reproduced explicitly
       expect(all.toLowerCase()).toContain("sequence name");
@@ -69,6 +70,7 @@ describe("export: identity backing-sequence name fidelity", () => {
       const fb = (await extract(src.pool)).factBase;
 
       const files = forLoad(exportSqlFiles(fb));
+      expect(files.some((f) => f.name.includes("/sequences/"))).toBe(false);
       const all = files.map((f) => f.sql).join("\n");
       // default `<table>_<column>_seq` name → export stays minimal
       expect(all.toLowerCase()).not.toContain("sequence name");

--- a/packages/pg-delta/tests/export-serial-owned-by.test.ts
+++ b/packages/pg-delta/tests/export-serial-owned-by.test.ts
@@ -1,0 +1,80 @@
+/**
+ * SERIAL / explicit OWNED BY must export CREATE SEQUENCE (+ grants) in
+ * sequences/ and ALTER SEQUENCE … OWNED BY in the owning table file, so the
+ * file-atomic loader can apply the sequence file before the table file.
+ */
+import { describe, expect, test } from "bun:test";
+import { extract } from "../src/extract/extract.ts";
+import { exportSqlFiles } from "../src/frontends/export-sql-files.ts";
+import { loadSqlFiles } from "../src/frontends/load-sql-files.ts";
+import { sharedCluster } from "./containers.ts";
+
+describe("export: serial OWNED BY files with the table", () => {
+  test("bigserial puts OWNED BY in the table file; load is file-atomic", async () => {
+    const cluster = await sharedCluster();
+    const source = await cluster.createDb("ser_src");
+    const shadow = await cluster.createDb("ser_shadow");
+    try {
+      await source.pool.query(`
+        CREATE SCHEMA app;
+        CREATE TABLE app.pages (
+          id bigserial PRIMARY KEY,
+          path text NOT NULL
+        );
+        GRANT USAGE ON SEQUENCE app.pages_id_seq TO PUBLIC;
+      `);
+      const fb = (await extract(source.pool)).factBase;
+      const files = exportSqlFiles(fb).filter(
+        (f) => !f.name.startsWith("_cluster/roles"),
+      );
+      const seq = files.find((f) => f.name.includes("/sequences/"));
+      const table = files.find((f) => f.name === "app/tables/pages.sql");
+      expect(seq).toBeDefined();
+      expect(table).toBeDefined();
+      expect(seq!.sql).toMatch(/CREATE SEQUENCE/i);
+      expect(seq!.sql).not.toMatch(/OWNED BY/i);
+      expect(seq!.sql).toMatch(/GRANT USAGE/i);
+      expect(table!.sql).toMatch(/CREATE TABLE/i);
+      expect(table!.sql).toMatch(/OWNED BY/i);
+      expect(table!.sql).not.toMatch(/GRANT USAGE ON SEQUENCE/i);
+
+      const loaded = await loadSqlFiles(files, shadow.pool);
+      expect(loaded.factBase.rootHash).toBe(fb.rootHash);
+    } finally {
+      await Promise.all([source.drop(), shadow.drop()]);
+    }
+  }, 120_000);
+
+  test("a well-ordered one-file serial pair still loads", async () => {
+    const cluster = await sharedCluster();
+    const shadow = await cluster.createDb("ser_one");
+    try {
+      const loaded = await loadSqlFiles(
+        [
+          {
+            name: "app.sql",
+            sql: `
+              CREATE SCHEMA app;
+              CREATE SEQUENCE app.pages_id_seq AS bigint;
+              CREATE TABLE app.pages (
+                id bigint NOT NULL DEFAULT nextval('app.pages_id_seq'::regclass),
+                PRIMARY KEY (id)
+              );
+              ALTER SEQUENCE app.pages_id_seq OWNED BY app.pages.id;
+            `,
+          },
+        ],
+        shadow.pool,
+      );
+      expect(
+        loaded.factBase.has({
+          kind: "table",
+          schema: "app",
+          name: "pages",
+        }),
+      ).toBe(true);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+});

--- a/packages/pg-delta/tests/export-serial-owned-by.test.ts
+++ b/packages/pg-delta/tests/export-serial-owned-by.test.ts
@@ -34,6 +34,7 @@ describe("export: serial OWNED BY files with the table", () => {
       expect(seq!.sql).toMatch(/CREATE SEQUENCE/i);
       expect(seq!.sql).not.toMatch(/OWNED BY/i);
       expect(seq!.sql).toMatch(/GRANT USAGE/i);
+      expect(seq!.sql).not.toMatch(/OWNER TO/i);
       expect(table!.sql).toMatch(/CREATE TABLE/i);
       expect(table!.sql).toMatch(/OWNED BY/i);
       expect(table!.sql).not.toMatch(/GRANT USAGE ON SEQUENCE/i);
@@ -42,6 +43,48 @@ describe("export: serial OWNED BY files with the table", () => {
       expect(loaded.factBase.rootHash).toBe(fb.rootHash);
     } finally {
       await Promise.all([source.drop(), shadow.drop()]);
+    }
+  }, 120_000);
+
+  test("non-default owner: sequence OWNER TO files with the table after table OWNER TO", async () => {
+    const cluster = await sharedCluster();
+    const role = `ser_own_${crypto.randomUUID().slice(0, 8)}`;
+    const source = await cluster.createDb("ser_own_src");
+    const shadow = await cluster.createDb("ser_own_shadow");
+    try {
+      await source.pool.query(`CREATE ROLE "${role}" NOLOGIN`);
+      await source.pool.query(`
+        CREATE SCHEMA app;
+        CREATE TABLE app.pages (
+          id bigserial PRIMARY KEY,
+          path text NOT NULL
+        );
+        ALTER TABLE app.pages OWNER TO "${role}";
+      `);
+      const fb = (await extract(source.pool)).factBase;
+      const files = exportSqlFiles(fb).filter(
+        (f) => !f.name.startsWith("_cluster/roles"),
+      );
+      const seq = files.find((f) => f.name.includes("/sequences/"));
+      const table = files.find((f) => f.name === "app/tables/pages.sql");
+      expect(seq).toBeDefined();
+      expect(table).toBeDefined();
+      expect(seq!.sql).toMatch(/CREATE SEQUENCE/i);
+      expect(seq!.sql).not.toMatch(/OWNED BY/i);
+      expect(seq!.sql).not.toMatch(/OWNER TO/i);
+      expect(table!.sql).toMatch(/OWNED BY/i);
+      expect(table!.sql).toMatch(/ALTER TABLE[\s\S]*OWNER TO/i);
+      expect(table!.sql).toMatch(/ALTER SEQUENCE[\s\S]*OWNER TO/i);
+      const tableOwnerAt = table!.sql.search(/ALTER TABLE[\s\S]*OWNER TO/i);
+      const seqOwnerAt = table!.sql.search(/ALTER SEQUENCE[\s\S]*OWNER TO/i);
+      expect(tableOwnerAt).toBeGreaterThan(-1);
+      expect(seqOwnerAt).toBeGreaterThan(tableOwnerAt);
+
+      const loaded = await loadSqlFiles(files, shadow.pool);
+      expect(loaded.factBase.rootHash).toBe(fb.rootHash);
+    } finally {
+      await Promise.all([source.drop(), shadow.drop()]);
+      await cluster.adminPool.query(`DROP ROLE IF EXISTS "${role}"`);
     }
   }, 120_000);
 


### PR DESCRIPTION
## Summary

- `subjectOf` files `ALTER SEQUENCE … OWNED BY` with the owning table so a file-atomic shadow load can create the sequence before `CREATE TABLE … nextval`.
- Sequence grants stay on the sequence file. IDENTITY still has no `sequences/` file.
- Loader contract is unchanged in this PR.

Stack (merge bottom-up): #437 → this PR → #439.

## Test plan

- [x] Integration (PG 17): `tests/export-serial-owned-by.test.ts`, `tests/export-identity-sequence-name.test.ts`, `tests/export.test.ts`
- [x] PG 17 corpus: 662 pass
- [x] `bun run format-and-lint` and `bun run check-types`

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added (`serial-owned-by-table-file.md`)
- [x] `bun run format-and-lint` and `bun run check-types` pass
- [x] Supabase maintainer (no tracked issue; schema-first dogfood follow-up)