### PR TITLE
fix(pg-delta): fall back to per-statement shadow load

### DIFF
--- a/.changeset/statement-fallback-shadow-load.md
+++ b/.changeset/statement-fallback-shadow-load.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+`loadSqlFiles` / `planSchemaFiles` now fall back to per-statement apply when a file cannot commit atomically (`statementFallback` defaults to on). Pass `false` to restore whole-file rollback. `LoadResult.splitFiles` names files demoted this load.

--- a/packages/pg-delta/MIGRATION.md
+++ b/packages/pg-delta/MIGRATION.md
@@ -132,6 +132,19 @@ the rebuild initially did not, which regressed `sslmode=require` connections.
   pass through untouched (legacy forced `ssl: false`), so node-postgres
   defaults — including `PGSSLMODE` env handling — keep applying.
 
+## `loadSqlFiles` statement fallback (default on)
+
+`loadSqlFiles` and `planSchemaFiles` now keep a file's already-accepted
+statements when the rest cannot apply in the same transaction (the old
+`CREATE SEQUENCE` + `OWNED BY` vs `CREATE TABLE … nextval` split, mixed
+`ALTER PUBLICATION … ADD TABLE`). Authored order is unchanged — the remainder
+retries after other files land; this is not an intra-file reorder.
+`LoadResult.splitFiles` names files demoted this load. Pass
+`{ statementFallback: false }` to restore
+whole-file rollback and whole-file retry. Files that contain session-setting
+statements (`SET search_path`, `SET ROLE`, `SET LOCAL`, …) are never split,
+because those settings would otherwise expire after the prefix commit.
+
 ## Known gaps
 
 Object kinds the new engine does not model — casts, operators, text-search

--- a/packages/pg-delta/MIGRATION.md
+++ b/packages/pg-delta/MIGRATION.md
@@ -142,8 +142,10 @@ retries after other files land; this is not an intra-file reorder.
 `LoadResult.splitFiles` names files demoted this load. Pass
 `{ statementFallback: false }` to restore
 whole-file rollback and whole-file retry. Files that contain session-setting
-statements (`SET search_path`, `SET ROLE`, `SET LOCAL`, …) are never split,
-because those settings would otherwise expire after the prefix commit.
+statements (`SET search_path`, `SET ROLE`, any `SET LOCAL`, …) or
+`ALTER DEFAULT PRIVILEGES` are never split, because those settings would
+otherwise expire after the prefix commit or apply to objects created by
+sibling files.
 
 ## Known gaps
 

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -221,9 +221,17 @@ stamped on plan and export artifacts and reconciled at apply/prove, so
 ## Statement reordering assist (opt-in)
 
 `loadSqlFiles` is parser-free: it sequences whole *files* into the shadow, so it
-tolerates cross-file disorder but cannot reorder statements *within* a file. The
-opt-in reordering assist splits files into one-statement units and topologically
-pre-sorts them via [`@supabase/pg-topo`](https://www.npmjs.com/package/@supabase/pg-topo).
+tolerates cross-file disorder. It never permutes statements inside a file.
+When a file cannot commit atomically, `statementFallback` (default on) keeps
+the prefix Postgres already accepted and retries the **remaining** statements
+in authored order after other files have progressed — it does not sort the
+file. Pass `false` for whole-file rollback. Files that contain session-setting
+statements (`SET search_path`, `SET ROLE`, …) stay file-atomic so `SET LOCAL`
+cannot expire between statements.
+
+The opt-in reordering assist is what actually reorders within a file: it
+splits files into one-statement units and topologically pre-sorts them via
+[`@supabase/pg-topo`](https://www.npmjs.com/package/@supabase/pg-topo).
 
 - **Subpath:** `@supabase/pg-delta/sql-order` exposes `orderForShadow(files)` /
   `analyzeForShadow(files)`, `canReorder()`, and the typed

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -226,8 +226,9 @@ When a file cannot commit atomically, `statementFallback` (default on) keeps
 the prefix Postgres already accepted and retries the **remaining** statements
 in authored order after other files have progressed — it does not sort the
 file. Pass `false` for whole-file rollback. Files that contain session-setting
-statements (`SET search_path`, `SET ROLE`, …) stay file-atomic so `SET LOCAL`
-cannot expire between statements.
+statements (`SET search_path`, `SET ROLE`, any `SET LOCAL`, …) or
+`ALTER DEFAULT PRIVILEGES` stay file-atomic so those settings cannot expire
+or apply to sibling files' objects.
 
 The opt-in reordering assist is what actually reorders within a file: it
 splits files into one-statement units and topologically pre-sorts them via

--- a/packages/pg-delta/src/frontends/load-sql-files.test.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.test.ts
@@ -216,6 +216,9 @@ describe("findSessionSettingStatements — detects search_path / role barriers",
     expect(
       findSessionSettingStatements(`SET statement_timeout = '5s';`),
     ).toEqual([]);
+    expect(
+      findSessionSettingStatements(`SET LOCAL statement_timeout = 0;`),
+    ).toContain("SET LOCAL");
     // keyword in a literal or comment is ignored
     expect(
       findSessionSettingStatements(

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -2,7 +2,10 @@
  * Stage 7: the shadow-DB frontend — SQL files → fact base
  * (target-architecture §3.2). Parser-free by design:
  * - ordering: bounded retry rounds at FILE granularity against the shadow
- *   (fail-safe — errors surface before anything is extracted)
+ *   (fail-safe — errors surface before anything is extracted). When a file
+ *   cannot commit atomically, `statementFallback` (default on) keeps the
+ *   prefix Postgres accepted and retries only the remaining statements.
+ *   Pass `{ statementFallback: false }` for whole-file rollback + retry.
  * - body validation: routines re-validated with checks ON after loading
  * - shared-object isolation: pg_roles + pg_auth_members snapshot before/after;
  *   leakage fails in "databaseScratch" mode (skipped in "isolatedCluster" mode)
@@ -150,6 +153,48 @@ async function applyFile(client: PoolClient, sql: string): Promise<void> {
       return;
     }
     throw error;
+  }
+}
+
+function joinStatements(stmts: string[]): string {
+  return stmts
+    .map((s) => {
+      const t = s.trim();
+      // Semicolon on its own line so a trailing `--` comment cannot swallow it.
+      return /;\s*$/.test(t) ? t : `${t}\n;`;
+    })
+    .join("\n\n");
+}
+
+/**
+ * After a whole-file apply rolled back, replay statements one at a time so
+ * the prefix that Postgres accepts stays committed and only the rest is
+ * queued. Policy {@link ShadowLoadError}s still abort immediately.
+ */
+async function applyStatementFallback(
+  client: PoolClient,
+  sql: string,
+): Promise<
+  | { status: "done" }
+  | { status: "prefix"; remainder: string; error: unknown }
+  | { status: "none" }
+> {
+  const stmts = splitSqlStatements(sql);
+  if (stmts.length <= 1) return { status: "none" };
+  let i = 0;
+  try {
+    for (; i < stmts.length; i++) {
+      await applyFile(client, joinStatements([stmts[i]!]));
+    }
+    return { status: "done" };
+  } catch (error) {
+    if (error instanceof ShadowLoadError) throw error;
+    if (i === 0) return { status: "none" };
+    return {
+      status: "prefix",
+      remainder: joinStatements(stmts.slice(i)),
+      error,
+    };
   }
 }
 
@@ -471,6 +516,10 @@ export interface LoadResult {
    *  observation. Empty unless `allowPreExistingRows` is in effect (it defaults
    *  to true in `"isolatedCluster"` mode). */
   preExistingPopulatedTables: string[];
+  /** Files that could not commit atomically and were demoted to per-statement
+   *  apply this load. Empty when `statementFallback` is off or every file
+   *  committed as a unit. */
+  splitFiles: string[];
 }
 
 export class ShadowLoadError extends Error {
@@ -674,6 +723,13 @@ export interface LoadSqlFilesOptions {
    *  CLI adapter must pass `true` so declarative DML is rejected rather than
    *  warned. */
   strictDataStatements?: boolean;
+  /** After a file-atomic apply fails with a Postgres error, replay statements
+   *  one at a time and retry only the remainder (default `true`). `false`
+   *  restores whole-file rollback + whole-file retry. Policy
+   *  {@link ShadowLoadError}s are never split. Files with session-setting
+   *  statements (`SET search_path`, `SET ROLE`, `SET LOCAL`, …) stay
+   *  file-atomic so those settings cannot expire between statements. */
+  statementFallback?: boolean;
 }
 
 export async function loadSqlFiles(
@@ -693,6 +749,7 @@ export async function loadSqlFiles(
   const maxRounds = options.maxRounds ?? Math.max(files.length + 1, 25);
   const mode = options.mode ?? "databaseScratch";
   const extractShadow = options.extract ?? extract;
+  const statementFallback = options.statementFallback ?? true;
 
   // the shadow must be empty — verify by observation. Schemas the caller
   // pre-seeded (Phase 2b assumed schemas) are exempt: they were deliberately
@@ -818,6 +875,7 @@ export async function loadSqlFiles(
   // a file whose error never changes is a genuine missing dependency (or cycle),
   // not something more rounds will resolve.
   const failStreak = new Map<string, { message: string; count: number }>();
+  const splitFiles = new Set<string>();
   let bootstrapMembershipStrip: {
     roles: ReadonlySet<string>;
     member: string;
@@ -871,9 +929,12 @@ export async function loadSqlFiles(
       rounds++;
       const failures: Array<{ file: SqlFile; message: string }> = [];
       const next: SqlFile[] = [];
+      let progressed = false;
       for (const file of pending) {
         try {
           await applyFile(client, file.sql);
+          progressed = true;
+          failStreak.delete(file.name);
         } catch (error) {
           // A ShadowLoadError from applyFile is a deterministic policy refusal
           // (mixed non-transactional file, or a non-allowlisted non-transactional
@@ -881,6 +942,41 @@ export async function loadSqlFiles(
           // surface it immediately with its own message instead of deferring it
           // until the round budget or a "stuck" round wraps it.
           if (error instanceof ShadowLoadError) throw error;
+          // SET LOCAL / SET search_path / SET ROLE apply to the rest of the
+          // file only inside the atomic transaction. Per-statement replay
+          // would commit them alone and change where later DDL lands.
+          if (
+            statementFallback &&
+            findSessionSettingStatements(file.sql).length === 0
+          ) {
+            const split = await applyStatementFallback(client, file.sql);
+            if (split.status === "done") {
+              progressed = true;
+              splitFiles.add(file.name);
+              failStreak.delete(file.name);
+              continue;
+            }
+            if (split.status === "prefix") {
+              progressed = true;
+              splitFiles.add(file.name);
+              const remainder: SqlFile = {
+                name: file.name,
+                sql: split.remainder,
+              };
+              const message = describeFileFailure(remainder.sql, split.error);
+              const prev = failStreak.get(file.name);
+              failStreak.set(file.name, {
+                message,
+                count:
+                  prev !== undefined && prev.message === message
+                    ? prev.count + 1
+                    : 1,
+              });
+              failures.push({ file: remainder, message });
+              next.push(remainder);
+              continue;
+            }
+          }
           const message = describeFileFailure(file.sql, error);
           const prev = failStreak.get(file.name);
           failStreak.set(file.name, {
@@ -894,7 +990,7 @@ export async function loadSqlFiles(
           next.push(file);
         }
       }
-      if (next.length === pending.length) {
+      if (!progressed) {
         // no progress: stuck — inspect for mutual-FK situation, then fail loud
         const mutualFkHint = detectMutualFk(failures)
           ? " Tip: if two tables reference each other with inline REFERENCES clauses, split one foreign key into a separate ALTER TABLE … ADD CONSTRAINT statement."
@@ -1267,6 +1363,7 @@ export async function loadSqlFiles(
     ],
     rounds,
     preExistingPopulatedTables,
+    splitFiles: [...splitFiles].sort(),
   };
 }
 

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -341,13 +341,12 @@ export function findTransactionControl(sql: string): string[] {
   return found;
 }
 
-/** Statement-leading session-setting forms that change object resolution or
- *  ownership for every statement that follows them on the same session:
- *  `SET search_path` (where unqualified names resolve), `SET ROLE` /
- *  `SET SESSION AUTHORIZATION` (who owns created objects), and the matching
- *  RESETs. `SET LOCAL`/`SET SESSION` modifiers are tolerated. Unrelated GUCs
- *  (e.g. `SET statement_timeout`) are NOT flagged — they don't affect the
- *  extracted schema. */
+/** Statement-leading session-setting forms that must stay file-atomic:
+ *  `SET search_path` / `SET SCHEMA` (where unqualified names resolve),
+ *  `SET ROLE` / `SET SESSION AUTHORIZATION` (who owns created objects),
+ *  the matching RESETs, and any `SET LOCAL` (dies at COMMIT, so a prefix
+ *  commit would drop it before later statements). Session-level unrelated
+ *  GUCs (e.g. `SET statement_timeout`) are not flagged. */
 const SESSION_SETTING_RULES: ReadonlyArray<{ re: RegExp; label: string }> = [
   {
     re: /^set\s+(?:session\s+|local\s+)?search_path\b/i,
@@ -367,6 +366,7 @@ const SESSION_SETTING_RULES: ReadonlyArray<{ re: RegExp; label: string }> = [
     re: /^reset\s+(?:role|search_path|session\s+authorization|all)\b/i,
     label: "RESET session setting",
   },
+  { re: /^set\s+local\b/i, label: "SET LOCAL" },
 ];
 
 /**
@@ -945,9 +945,12 @@ export async function loadSqlFiles(
           // SET LOCAL / SET search_path / SET ROLE apply to the rest of the
           // file only inside the atomic transaction. Per-statement replay
           // would commit them alone and change where later DDL lands.
+          // ALTER DEFAULT PRIVILEGES is the same: committing it early would
+          // grant later objects created by sibling files.
           if (
             statementFallback &&
-            findSessionSettingStatements(file.sql).length === 0
+            findSessionSettingStatements(file.sql).length === 0 &&
+            findDefaultPrivilegeStatements(file.sql).length === 0
           ) {
             const split = await applyStatementFallback(client, file.sql);
             if (split.status === "done") {

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -304,6 +304,9 @@ export interface PlanSchemaFilesOptions {
   allowSameDatabaseIdentity?: boolean;
   /** Statement-reorder assist. Default: true. */
   reorder?: boolean;
+  /** Forwarded to {@link loadSqlFiles}. Default: true (per-statement fallback
+   *  after a file-atomic failure). `false` restores whole-file rollback. */
+  statementFallback?: boolean;
   /** Soft warnings (reorder fallback, ADP caveat, …). */
   onWarning?: (message: string) => void;
   /** Optional rewrite of a ShadowLoadError after reorder (CLI attaches file:line). */
@@ -670,6 +673,9 @@ export async function planSchemaFiles(
         : {}),
       ...(options.isolatedShadow === true
         ? { mode: "isolatedCluster" as const }
+        : {}),
+      ...(options.statementFallback !== undefined
+        ? { statementFallback: options.statementFallback }
         : {}),
     });
   } catch (error) {

--- a/packages/pg-delta/tests/load-sql-files-atomicity.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-atomicity.test.ts
@@ -32,6 +32,8 @@ describe("loadSqlFiles — per-file transactional apply", () => {
           },
         ],
         shadow.pool,
+        // whole-file rollback: a must not leak from the failed first attempt
+        { statementFallback: false },
       );
       expect(result.rounds).toBeGreaterThan(1);
       expect(

--- a/packages/pg-delta/tests/load-sql-files-statement-fallback.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-statement-fallback.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Per-statement shadow-load fallback: when a whole file cannot commit, keep
+ * the prefix that Postgres already accepted and retry only the rest.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  loadSqlFiles,
+  ShadowLoadError,
+} from "../src/frontends/load-sql-files.ts";
+import { createTestDb } from "./containers.ts";
+
+const OLD_SERIAL_SPLIT = [
+  { name: "app/schema.sql", sql: `CREATE SCHEMA app;` },
+  {
+    name: "app/sequences/pages_id_seq.sql",
+    sql: `
+      CREATE SEQUENCE app.pages_id_seq AS bigint;
+      ALTER SEQUENCE app.pages_id_seq OWNED BY app.pages.id;
+    `,
+  },
+  {
+    name: "app/tables/pages.sql",
+    sql: `
+      CREATE TABLE app.pages (
+        id bigint NOT NULL DEFAULT nextval('app.pages_id_seq'::regclass),
+        PRIMARY KEY (id)
+      );
+    `,
+  },
+];
+
+describe("loadSqlFiles — statementFallback", () => {
+  test("old serial split (CREATE+OWNED BY vs nextval) loads; splitFiles names the sequence file", async () => {
+    const shadow = await createTestDb("sf_serial");
+    try {
+      const result = await loadSqlFiles(OLD_SERIAL_SPLIT, shadow.pool);
+      expect(
+        result.factBase.has({ kind: "table", schema: "app", name: "pages" }),
+      ).toBe(true);
+      expect(
+        result.factBase.has({
+          kind: "sequence",
+          schema: "app",
+          name: "pages_id_seq",
+        }),
+      ).toBe(true);
+      expect(result.splitFiles).toEqual(["app/sequences/pages_id_seq.sql"]);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("table-before-sequence names still converge (prefix progress with same pending count)", async () => {
+    const shadow = await createTestDb("sf_serial_rev");
+    try {
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "00_table.sql",
+            sql: `
+              CREATE SCHEMA app;
+              CREATE TABLE app.pages (
+                id bigint NOT NULL DEFAULT nextval('app.pages_id_seq'::regclass),
+                PRIMARY KEY (id)
+              );
+            `,
+          },
+          {
+            name: "01_seq.sql",
+            sql: `
+              CREATE SEQUENCE app.pages_id_seq AS bigint;
+              ALTER SEQUENCE app.pages_id_seq OWNED BY app.pages.id;
+            `,
+          },
+        ],
+        shadow.pool,
+      );
+      expect(
+        result.factBase.has({ kind: "table", schema: "app", name: "pages" }),
+      ).toBe(true);
+      expect(result.splitFiles).toEqual(["00_table.sql", "01_seq.sql"]);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("opt-out restores the old-split deadlock", async () => {
+    const shadow = await createTestDb("sf_serial_off");
+    try {
+      let error: unknown;
+      try {
+        await loadSqlFiles(OLD_SERIAL_SPLIT, shadow.pool, {
+          statementFallback: false,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeInstanceOf(ShadowLoadError);
+      expect(
+        (error as ShadowLoadError).details.some(
+          (d) => d.code === "stuck_statement",
+        ),
+      ).toBe(true);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("mixed publications.sql keeps applied ADD TABLE; missing ADD retries", async () => {
+    const shadow = await createTestDb("sf_pub");
+    try {
+      let error: unknown;
+      try {
+        await loadSqlFiles(
+          [
+            {
+              name: "public/tables/t1.sql",
+              sql: `CREATE TABLE public.t1 (id integer PRIMARY KEY);`,
+            },
+            {
+              name: "_cluster/publications.sql",
+              sql: `
+                CREATE PUBLICATION p;
+                ALTER PUBLICATION p ADD TABLE public.t1;
+                ALTER PUBLICATION p ADD TABLE public.missing;
+              `,
+            },
+          ],
+          shadow.pool,
+        );
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeInstanceOf(ShadowLoadError);
+      expect(
+        (error as ShadowLoadError).details.some(
+          (d) => d.code === "stuck_statement",
+        ),
+      ).toBe(true);
+      const { rows } = await shadow.pool.query<{ n: number }>(`
+        SELECT count(*)::int AS n
+        FROM pg_publication_rel pr
+        JOIN pg_publication p ON p.oid = pr.prpubid
+        JOIN pg_class c ON c.oid = pr.prrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE p.pubname = 'p' AND n.nspname = 'public' AND c.relname = 't1'
+      `);
+      expect(rows[0]!.n).toBe(1);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("default on: CREATE TABLE a + VIEW va FROM b leaves a and retries only va", async () => {
+    const shadow = await createTestDb("sf_view");
+    try {
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "1_a.sql",
+            sql: `CREATE TABLE public.a (id integer PRIMARY KEY);
+                  CREATE VIEW public.va AS SELECT id FROM public.b;`,
+          },
+          {
+            name: "2_b.sql",
+            sql: `CREATE TABLE public.b (id integer PRIMARY KEY);`,
+          },
+        ],
+        shadow.pool,
+      );
+      expect(
+        result.factBase.has({ kind: "table", schema: "public", name: "a" }),
+      ).toBe(true);
+      expect(
+        result.factBase.has({ kind: "view", schema: "public", name: "va" }),
+      ).toBe(true);
+      expect(result.splitFiles).toEqual(["1_a.sql"]);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("trailing -- comments cannot swallow the statement separator", async () => {
+    const shadow = await createTestDb("sf_comment");
+    try {
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "1_a.sql",
+            sql: `
+              CREATE TABLE public.a (id integer PRIMARY KEY)
+              -- keep a
+              ;
+              CREATE VIEW public.va AS SELECT id FROM public.b
+              -- needs b
+              ;
+              CREATE VIEW public.vb AS SELECT id FROM public.a;
+            `,
+          },
+          {
+            name: "2_b.sql",
+            sql: `CREATE TABLE public.b (id integer PRIMARY KEY);`,
+          },
+        ],
+        shadow.pool,
+      );
+      expect(
+        result.factBase.has({ kind: "table", schema: "public", name: "a" }),
+      ).toBe(true);
+      expect(
+        result.factBase.has({ kind: "view", schema: "public", name: "va" }),
+      ).toBe(true);
+      expect(
+        result.factBase.has({ kind: "view", schema: "public", name: "vb" }),
+      ).toBe(true);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("session-setting files stay file-atomic so SET LOCAL still scopes later DDL", async () => {
+    const shadow = await createTestDb("sf_setlocal");
+    try {
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "1_a.sql",
+            sql: `
+              CREATE SCHEMA app;
+              SET LOCAL search_path TO app;
+              CREATE TABLE t (id integer PRIMARY KEY);
+              CREATE VIEW va AS SELECT id FROM public.b;
+            `,
+          },
+          {
+            name: "2_b.sql",
+            sql: `CREATE TABLE public.b (id integer PRIMARY KEY);`,
+          },
+        ],
+        shadow.pool,
+      );
+      expect(
+        result.factBase.has({ kind: "table", schema: "app", name: "t" }),
+      ).toBe(true);
+      expect(
+        result.factBase.has({ kind: "table", schema: "public", name: "t" }),
+      ).toBe(false);
+      expect(result.splitFiles).toEqual([]);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("splitFiles is empty when fallback is off or every file commits atomically", async () => {
+    const shadowA = await createTestDb("sf_empty_off");
+    const shadowB = await createTestDb("sf_empty_ok");
+    try {
+      const off = await loadSqlFiles(
+        [
+          {
+            name: "1_a.sql",
+            sql: `CREATE TABLE public.a (id integer PRIMARY KEY);
+                  CREATE VIEW public.va AS SELECT id FROM public.b;`,
+          },
+          {
+            name: "2_b.sql",
+            sql: `CREATE TABLE public.b (id integer PRIMARY KEY);`,
+          },
+        ],
+        shadowA.pool,
+        { statementFallback: false },
+      );
+      expect(off.splitFiles).toEqual([]);
+
+      const ok = await loadSqlFiles(
+        [
+          { name: "schema.sql", sql: `CREATE SCHEMA app;` },
+          { name: "table.sql", sql: `CREATE TABLE app.t (id integer);` },
+        ],
+        shadowB.pool,
+      );
+      expect(ok.splitFiles).toEqual([]);
+    } finally {
+      await Promise.all([shadowA.drop(), shadowB.drop()]);
+    }
+  }, 60_000);
+});

--- a/packages/pg-delta/tests/load-sql-files-statement-fallback.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-statement-fallback.test.ts
@@ -218,6 +218,74 @@ describe("loadSqlFiles — statementFallback", () => {
     }
   }, 60_000);
 
+  test("any SET LOCAL keeps the file atomic, including unrelated GUCs", async () => {
+    const shadow = await createTestDb("sf_setlocal_guc");
+    try {
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "1_a.sql",
+            sql: `
+              SET LOCAL statement_timeout TO 0;
+              CREATE TABLE public.a (id integer PRIMARY KEY);
+              CREATE VIEW public.va AS SELECT id FROM public.b;
+            `,
+          },
+          {
+            name: "2_b.sql",
+            sql: `CREATE TABLE public.b (id integer PRIMARY KEY);`,
+          },
+        ],
+        shadow.pool,
+      );
+      expect(
+        result.factBase.has({ kind: "table", schema: "public", name: "a" }),
+      ).toBe(true);
+      expect(result.splitFiles).toEqual([]);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("ALTER DEFAULT PRIVILEGES files stay file-atomic so sibling tables miss the grant", async () => {
+    const shadow = await createTestDb("sf_adp");
+    try {
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "1_adp.sql",
+            sql: `
+              ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT ON TABLES TO PUBLIC;
+              CREATE VIEW app.va AS SELECT id FROM app.b;
+            `,
+          },
+          {
+            name: "2_tables.sql",
+            sql: `
+              CREATE SCHEMA app;
+              CREATE TABLE app.t (id integer PRIMARY KEY);
+              CREATE TABLE app.b (id integer PRIMARY KEY);
+            `,
+          },
+        ],
+        shadow.pool,
+      );
+      expect(
+        result.factBase.has({ kind: "table", schema: "app", name: "t" }),
+      ).toBe(true);
+      expect(result.splitFiles).toEqual([]);
+      expect(
+        result.factBase.has({
+          kind: "acl",
+          target: { kind: "table", schema: "app", name: "t" },
+          grantee: "PUBLIC",
+        }),
+      ).toBe(false);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
   test("session-setting files stay file-atomic so SET LOCAL still scopes later DDL", async () => {
     const shadow = await createTestDb("sf_setlocal");
     try {

--- a/packages/pg-delta/tests/load-sql-files-statement-fallback.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-statement-fallback.test.ts
@@ -253,6 +253,10 @@ describe("loadSqlFiles — statementFallback", () => {
       const result = await loadSqlFiles(
         [
           {
+            name: "0_schema.sql",
+            sql: `CREATE SCHEMA app;`,
+          },
+          {
             name: "1_adp.sql",
             sql: `
               ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT ON TABLES TO PUBLIC;
@@ -262,7 +266,6 @@ describe("loadSqlFiles — statementFallback", () => {
           {
             name: "2_tables.sql",
             sql: `
-              CREATE SCHEMA app;
               CREATE TABLE app.t (id integer PRIMARY KEY);
               CREATE TABLE app.b (id integer PRIMARY KEY);
             `,


### PR DESCRIPTION
## Summary

- `loadSqlFiles` / `planSchemaFiles` default `statementFallback: true`: after a file-atomic failure, keep the prefix Postgres accepted and retry the remainder **in authored order**. This is not an intra-file reorder.
- `LoadResult.splitFiles` names files demoted this load. Pass `{ statementFallback: false }` for whole-file rollback.
- Session-setting files (`SET search_path`, `SET ROLE`, `SET LOCAL`, …) stay file-atomic so `SET LOCAL` cannot expire between statements.

Stack (merge bottom-up): #437 → #438 → this PR.

## Test plan

- [x] Integration (PG 17): `tests/load-sql-files-statement-fallback.test.ts` (old serial split, mixed publications, SET LOCAL, trailing `--` comments)
- [x] `tests/load-sql-files-atomicity.test.ts` keeps the `statementFallback: false` path
- [x] PG 17 corpus: 662 pass
- [x] `bun run format-and-lint` and `bun run check-types`

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added (`statement-fallback-shadow-load.md`)
- [x] `bun run format-and-lint` and `bun run check-types` pass
- [x] Supabase maintainer (no tracked issue; schema-first dogfood follow-up)