### PR TITLE
fix: map statement_timeout on jit-disable to ExtractionTimeoutError

### DIFF
--- a/.changeset/heavy-taxis-shave.md
+++ b/.changeset/heavy-taxis-shave.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix: a `statement_timeout` that fires on extraction's jit-disable round trip now surfaces as the typed `ExtractionTimeoutError` (with query label and budget) instead of the raw SQLSTATE 57014 pg error

--- a/packages/pg-delta/src/extract/extract.ts
+++ b/packages/pg-delta/src/extract/extract.ts
@@ -455,8 +455,12 @@ async function extractOnClient(
   // which does not exist on 14, so it cannot be sent speculatively alongside the
   // probe that reveals the version. It is overlapped with worker setup below, so
   // it costs one RTT for the whole extraction, not one per connection.
-  const settingJitOff = client
-    .query(jitOffSql(ctx.pgMajor))
+  //
+  // Sent through the timeout-aware runner, not the raw client: this round trip
+  // runs under the caller's statement_timeout like every other, so a budget
+  // that fires HERE must surface as the same ExtractionTimeoutError (via the
+  // rethrow below), never as the raw 57014 pg error.
+  const settingJitOff = q(jitOffSql(ctx.pgMajor))
     // deliberately non-rejecting: a rejection here must not leave half-built
     // workers unreleased in the Promise.all below
     .then(

--- a/packages/pg-delta/tests/containers.ts
+++ b/packages/pg-delta/tests/containers.ts
@@ -464,21 +464,48 @@ const ALPINE_TAG_FOR_PG_MAJOR: Record<number, string> = {
   18: "3.23",
 };
 
+/** The dummy_seclabel image build reaches three networks (the Docker registry
+ *  for the base images, the Alpine CDN for `apk add`, raw.githubusercontent.com
+ *  for the module source), and any of them flakes transiently on shared CI
+ *  egress — observed as testcontainers' bare "Failed to build image" taking
+ *  four security-label test files down in one CI run. Retry with backoff;
+ *  Docker's layer cache makes a retry resume from the last good layer. */
+async function buildSeclabelImage(major: number) {
+  const delaysMs = [0, 5_000, 15_000];
+  let lastError: unknown;
+  for (const delayMs of delaysMs) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    try {
+      return await GenericContainer.fromDockerfile(
+        import.meta.dir,
+        "dummy-seclabel.Dockerfile",
+      )
+        .withBuildArgs({
+          PG_MAJOR: String(major),
+          PG_BRANCH: `REL_${major}_STABLE`,
+          ALPINE_TAG: ALPINE_TAG_FOR_PG_MAJOR[major] ?? "3.23",
+        })
+        .withCache(true)
+        .build(`pg-delta-next-seclabel:${major}`, { deleteOnExit: false });
+    } catch (error) {
+      lastError = error;
+      console.error(
+        `dummy_seclabel image build failed (attempt ${delaysMs.indexOf(delayMs) + 1}/${delaysMs.length}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  throw lastError;
+}
+
 async function startSeclabelCluster(): Promise<Cluster> {
   const major = SECLABEL_PG_MAJOR;
   // build-or-reuse the dummy_seclabel image (Docker layer cache makes repeat
   // runs cheap; the first build compiles the module from PG source)
-  const built = await GenericContainer.fromDockerfile(
-    import.meta.dir,
-    "dummy-seclabel.Dockerfile",
-  )
-    .withBuildArgs({
-      PG_MAJOR: String(major),
-      PG_BRANCH: `REL_${major}_STABLE`,
-      ALPINE_TAG: ALPINE_TAG_FOR_PG_MAJOR[major] ?? "3.23",
-    })
-    .withCache(true)
-    .build(`pg-delta-next-seclabel:${major}`, { deleteOnExit: false });
+  const built = await buildSeclabelImage(major);
   const container = await built
     .withEnvironment({
       POSTGRES_USER: "test",
@@ -516,7 +543,14 @@ async function startSeclabelCluster(): Promise<Cluster> {
 
 let seclabelShared: Promise<Cluster> | null = null;
 export async function seclabelCluster(): Promise<Cluster> {
-  seclabelShared ??= startSeclabelCluster();
+  // Never cache a REJECTED start: the singleton exists to share one healthy
+  // cluster, and memoizing a transient failure (image build flake, slow
+  // startup) would instantly fail every later seclabel test in the process
+  // instead of letting the next caller try again.
+  seclabelShared ??= startSeclabelCluster().catch((error: unknown) => {
+    seclabelShared = null;
+    throw error;
+  });
   return seclabelShared;
 }
 

--- a/packages/pg-delta/tests/extract-jit-off.test.ts
+++ b/packages/pg-delta/tests/extract-jit-off.test.ts
@@ -36,7 +36,7 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import pg from "pg";
-import { extract } from "../src/extract/extract.ts";
+import { extract, ExtractionTimeoutError } from "../src/extract/extract.ts";
 import { createTestDb, sharedCluster, type TestDb } from "./containers.ts";
 
 // Synchronous, derived from the same env var containers.ts keys the container
@@ -95,15 +95,17 @@ async function withQueryLog<T>(
 }
 
 /** Wrap the next-checked-out client so any query whose text matches `pattern`
- *  rejects with a synthetic Postgres permission-denied error (SQLSTATE 42501)
- *  instead of reaching the database — every other statement passes through
- *  untouched. Used to simulate a REVOKEd SET privilege: real PostgreSQL
- *  cannot reproduce that condition for `jit` (see the module comment), so this
- *  exercises the real failure SHAPE — a rejected statement inside the
- *  extraction transaction — directly. */
+ *  rejects with the synthetic Postgres error `makeError` builds instead of
+ *  reaching the database — every other statement passes through untouched.
+ *  Used to simulate error conditions real PostgreSQL cannot reproduce on
+ *  demand for `jit` (a REVOKEd SET privilege — see the module comment) or
+ *  cannot reproduce deterministically (a statement_timeout firing on exactly
+ *  this statement), so the tests exercise the real failure SHAPE — a rejected
+ *  statement inside the extraction transaction — directly. */
 async function withRejectedStatement<T>(
   pool: pg.Pool,
   pattern: RegExp,
+  makeError: () => Error,
   fn: () => Promise<T>,
 ): Promise<T> {
   const origConnect = pool.connect.bind(pool);
@@ -115,11 +117,7 @@ async function withRejectedStatement<T>(
     (client as { query: unknown }).query = (...qa: unknown[]) => {
       const sql = typeof qa[0] === "string" ? qa[0] : String(qa[0]);
       if (pattern.test(sql)) {
-        const error = new Error(
-          'permission denied to set parameter "jit"',
-        ) as Error & { code: string };
-        error.code = "42501";
-        return Promise.reject(error);
+        return Promise.reject(makeError());
       }
       return origQuery(...qa);
     };
@@ -130,6 +128,16 @@ async function withRejectedStatement<T>(
   } finally {
     (pool as { connect: unknown }).connect = origConnect;
   }
+}
+
+/** Synthetic SQLSTATE builder: the message/shape node-pg produces for a server
+ *  error with that code, minus the server round trip. */
+function pgError(message: string, code: string): () => Error {
+  return () => {
+    const error = new Error(message) as Error & { code: string };
+    error.code = code;
+    return error;
+  };
 }
 
 /** The exact jit-disable statement text for the running cluster's major
@@ -172,13 +180,45 @@ describe.skipIf(PG_MAJOR < 15)(
       // comment), and this synthetic interception would fail there too,
       // which is expected and not a regression.
       const pattern = /^SET LOCAL jit = off$/i;
-      const result = await withRejectedStatement(db.pool, pattern, () =>
-        extract(db.pool),
+      const result = await withRejectedStatement(
+        db.pool,
+        pattern,
+        pgError('permission denied to set parameter "jit"', "42501"),
+        () => extract(db.pool),
       );
       expect(result.factBase.facts().length).toBeGreaterThan(0);
     }, 60_000);
   },
 );
+
+describe("extract: a statement_timeout firing on the jit-disable statement", () => {
+  test("surfaces as ExtractionTimeoutError, never as the raw 57014 pg error", async () => {
+    // The coordinator's jit-disable is its own round trip (see extract.ts) and
+    // runs INSIDE the transaction whose opening batch set the caller's
+    // statement_timeout — so a tight budget can fire on exactly this
+    // statement. Every other extraction query goes through the timeout-aware
+    // runner that maps SQLSTATE 57014 to ExtractionTimeoutError; this pins
+    // that the jit-disable round trip gets the identical mapping. A real
+    // timeout cannot be aimed at this statement deterministically (which query
+    // a 1ms budget cancels first is a race — the CI flake that motivated this
+    // test), so the 57014 rejection is injected at the client seam instead.
+    let err: unknown;
+    try {
+      await withRejectedStatement(
+        db.pool,
+        jitOffPattern(),
+        pgError("canceling statement due to statement timeout", "57014"),
+        () => extract(db.pool, { statementTimeoutMs: 60_000 }),
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ExtractionTimeoutError);
+    const timeout = err as ExtractionTimeoutError;
+    expect(timeout.timeoutMs).toBe(60_000);
+    expect(timeout.queryLabel.length).toBeGreaterThan(0);
+  }, 60_000);
+});
 
 describe.skipIf(PG_MAJOR < 15)(
   "extract: jit disable as a plain non-superuser (has_parameter_privilege is false by default)",

--- a/packages/pg-delta/tests/extract-jit-off.test.ts
+++ b/packages/pg-delta/tests/extract-jit-off.test.ts
@@ -109,11 +109,18 @@ async function withRejectedStatement<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   const origConnect = pool.connect.bind(pool);
+  // Patched clients go BACK into the pool when extract() releases them, so the
+  // patch must be undone on exit or a later checkout of the same client would
+  // still inject errors into an unrelated test.
+  const patched = new Map<pg.PoolClient, unknown>();
   (pool as { connect: unknown }).connect = async (...args: unknown[]) => {
     const client = await (
       origConnect as (...a: unknown[]) => Promise<pg.PoolClient>
     )(...args);
     const origQuery = client.query.bind(client) as (...a: unknown[]) => unknown;
+    if (!patched.has(client)) {
+      patched.set(client, (client as { query: unknown }).query);
+    }
     (client as { query: unknown }).query = (...qa: unknown[]) => {
       const sql = typeof qa[0] === "string" ? qa[0] : String(qa[0]);
       if (pattern.test(sql)) {
@@ -127,6 +134,9 @@ async function withRejectedStatement<T>(
     return await fn();
   } finally {
     (pool as { connect: unknown }).connect = origConnect;
+    for (const [client, query] of patched) {
+      (client as { query: unknown }).query = query;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

When a `statement_timeout` fires on the jit-disable round trip during extraction, it now surfaces as the typed `ExtractionTimeoutError` (with query label and timeout budget) instead of the raw SQLSTATE 57014 pg error.

The jit-disable statement is sent through the timeout-aware query runner (`q()`) rather than the raw client, ensuring consistent error handling across all extraction queries. This fixes a gap where a tight statement timeout budget could fire on this specific round trip and produce an untyped error, breaking caller error handling that expects `ExtractionTimeoutError`.

## Changes

**packages/pg-delta/src/extract/extract.ts:**
- Route the jit-disable query through the timeout-aware runner (`q()`) instead of the raw client
- Add clarifying comments explaining why this round trip must use the same timeout mapping as other extraction queries

**packages/pg-delta/tests/extract-jit-off.test.ts:**
- Export `ExtractionTimeoutError` from the extract module
- Refactor `withRejectedStatement()` to accept a `makeError` factory function, enabling injection of different error types
- Add `pgError()` helper to construct synthetic pg errors matching node-pg's shape
- Add new test case: "extract: a statement_timeout firing on the jit-disable statement" verifies that SQLSTATE 57014 on the jit-disable statement is mapped to `ExtractionTimeoutError` with correct timeout budget and query label

**packages/pg-delta/tests/containers.ts:**
- Extract image build logic into `buildSeclabelImage()` with exponential backoff retry (0ms, 5s, 15s) to handle transient network flakes on shared CI egress
- Update `seclabelCluster()` to never cache rejected starts, allowing later callers to retry transient failures instead of failing instantly

**.changeset/heavy-taxis-shave.md:**
- Add changeset documenting the fix

## Test Plan

The new test case in `extract-jit-off.test.ts` directly validates the fix by injecting a SQLSTATE 57014 error on the jit-disable statement and verifying it surfaces as `ExtractionTimeoutError` with the correct timeout budget and query label. Existing extraction tests continue to pass.

https://claude.ai/code/session_019SNjDykNCCWyms2HnuhHXt