### PR TITLE
feat(pg-delta): opt-in CREATE EXTENSION IF NOT EXISTS on schema export

### DIFF
--- a/.changeset/export-extension-if-not-exists.md
+++ b/.changeset/export-extension-if-not-exists.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Add an opt-in `schema export --create-extension-if-not-exists` flag (and matching library option) that renders `CREATE EXTENSION IF NOT EXISTS`. Default export, plan, and apply still emit plain `CREATE`.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1473,3 +1473,16 @@ in the wild:
   #434. A shared fix must retain quote delimiters for every shadow precheck,
   accept exact lowercase quoted API names, and keep PostgreSQL's case-folding
   behavior for unquoted names.
+
+## PR #444 review triage (Codex) — idempotent export is CREATE EXTENSION only
+
+- **Deferred — `CREATE SCHEMA IF NOT EXISTS` for managed install schemas.**
+  `--create-extension-if-not-exists` only rewrites `CREATE EXTENSION`. A
+  managed non-public install schema (`partman`, a user `app` schema, …) still
+  exports as plain `CREATE SCHEMA`, so replaying the whole directory onto a
+  cluster that already has that schema fails before the extension no-op.
+  `schema apply` does not need this: it diffs and only emits CREATE when the
+  object is absent. A general idempotent-DDL export (schema / table / type
+  `IF NOT EXISTS`, `DROP IF EXISTS`) was an explicit non-goal of #444. If a
+  later flag wants full-tree bootstrap replay, start with the schemas that
+  `CREATE EXTENSION … SCHEMA` consumes.

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -148,11 +148,12 @@ These flags shape this tree, and they compose:
   files: one file per object (default), numbered files in dependency order, or
   the category-ordered "nice" export with opt-in grouping.
 - `--create-extension-if-not-exists` — emit `CREATE EXTENSION IF NOT EXISTS`
-  instead of plain `CREATE`. Opt-in for bootstrap replay against a cluster that
-  already has the extension. If the name is already installed, PostgreSQL
-  notices and no-ops — it does not relocate or change version. `schema apply`
-  does not need this: the planner only emits `CREATE EXTENSION` when the
-  extension is absent.
+  instead of plain `CREATE`. Only that statement is guarded: a managed
+  `CREATE SCHEMA` in the same export stays plain `CREATE` and will fail if
+  the schema already exists. If the extension name is already installed,
+  PostgreSQL notices and no-ops — it does not relocate or change version.
+  `schema apply` does not need this: the planner only emits `CREATE EXTENSION`
+  when the extension is absent.
 
 The loader is structure-agnostic — `schema apply --dir` reads every `.sql`
 under the directory recursively — so the layout is purely a readability

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -134,7 +134,7 @@ schema/
     functions/add.sql
 ```
 
-Two flags shape this tree, and they compose:
+These flags shape this tree, and they compose:
 
 - `--path-style flat|nested` — where the two **root** segments live. `flat` is
   the default (shown above). `nested` reproduces the historical
@@ -147,6 +147,12 @@ Two flags shape this tree, and they compose:
 - `--layout by-object|ordered|grouped` — how statements are distributed across
   files: one file per object (default), numbered files in dependency order, or
   the category-ordered "nice" export with opt-in grouping.
+- `--create-extension-if-not-exists` — emit `CREATE EXTENSION IF NOT EXISTS`
+  instead of plain `CREATE`. Opt-in for bootstrap replay against a cluster that
+  already has the extension. If the name is already installed, PostgreSQL
+  notices and no-ops — it does not relocate or change version. `schema apply`
+  does not need this: the planner only emits `CREATE EXTENSION` when the
+  extension is absent.
 
 The loader is structure-agnostic — `schema apply --dir` reads every `.sql`
 under the directory recursively — so the layout is purely a readability

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -434,7 +434,7 @@ export async function cmdSchemaExport(args: string[]): Promise<void> {
           `  [--path-style flat|nested] (flat, the default: <schema>/tables/t.sql + _cluster/roles.sql; nested: the historical schemas/<schema>/… + cluster/…)\n` +
           `  [--default-owner <role|none>] (which owner stays implicit; default: profile default or the database owner; "none" emits every OWNER TO)\n` +
           `  [--prune-unmanaged] (delete .sql files in --out-dir this export does not own; refuse otherwise)\n` +
-          `  [--create-extension-if-not-exists] (emit CREATE EXTENSION IF NOT EXISTS; no-op if already installed)\n` +
+          `  [--create-extension-if-not-exists] (CREATE EXTENSION only; other statements stay plain CREATE)\n` +
           `  [--format-options '{"keywordCase":"upper","maxWidth":180}'] [--no-format]\n` +
           `    (SQL is pretty-printed by default: lowercase keywords, width 180; any layout)\n` +
           `  Grouped-layout options (only with --layout grouped):\n` +

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -424,15 +424,17 @@ export async function cmdSchemaExport(args: string[]): Promise<void> {
       scope: { type: "value" },
       "default-owner": { type: "value" },
       "prune-unmanaged": { type: "boolean" },
+      "create-extension-if-not-exists": { type: "boolean" },
     });
   } catch (err) {
     if (err instanceof UsageError) {
       throw new UsageError(
         `${err.message}\nUsage: pgdelta schema export --source <pg-url> --out-dir <dir> ` +
-          `[--layout by-object|ordered|grouped] [--path-style flat|nested] [--profile ${PROFILE_IDS}] [--strict-coverage] [--unsafe-show-secrets] [--scope database|cluster] [--prune-unmanaged]\n` +
+          `[--layout by-object|ordered|grouped] [--path-style flat|nested] [--profile ${PROFILE_IDS}] [--strict-coverage] [--unsafe-show-secrets] [--scope database|cluster] [--prune-unmanaged] [--create-extension-if-not-exists]\n` +
           `  [--path-style flat|nested] (flat, the default: <schema>/tables/t.sql + _cluster/roles.sql; nested: the historical schemas/<schema>/… + cluster/…)\n` +
           `  [--default-owner <role|none>] (which owner stays implicit; default: profile default or the database owner; "none" emits every OWNER TO)\n` +
           `  [--prune-unmanaged] (delete .sql files in --out-dir this export does not own; refuse otherwise)\n` +
+          `  [--create-extension-if-not-exists] (emit CREATE EXTENSION IF NOT EXISTS; no-op if already installed)\n` +
           `  [--format-options '{"keywordCase":"upper","maxWidth":180}'] [--no-format]\n` +
           `    (SQL is pretty-printed by default: lowercase keywords, width 180; any layout)\n` +
           `  Grouped-layout options (only with --layout grouped):\n` +
@@ -576,6 +578,9 @@ export async function cmdSchemaExport(args: string[]): Promise<void> {
         : flags["default-owner"] !== undefined && flags["default-owner"] !== ""
           ? { defaultOwner: flags["default-owner"] }
           : {}),
+      ...(flags["create-extension-if-not-exists"]
+        ? { createExtensionIfNotExists: true }
+        : {}),
       onWarning: (message) => process.stderr.write(`  WARNING: ${message}\n`),
     });
     printDiagnostics(result.diagnostics);

--- a/packages/pg-delta/src/cli/main.test.ts
+++ b/packages/pg-delta/src/cli/main.test.ts
@@ -28,6 +28,13 @@ describe("schema help", () => {
     expect(stdout).toContain("--verbose");
     expect(stdout).toContain("--out-plan");
   });
+
+  test("lists schema export create-extension-if-not-exists", async () => {
+    const { stdout, stderr, exitCode } = await runHelp("schema", "--help");
+
+    expect({ exitCode, stderr }).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(stdout).toContain("--create-extension-if-not-exists");
+  });
 });
 
 describe("top-level help", () => {

--- a/packages/pg-delta/src/cli/main.ts
+++ b/packages/pg-delta/src/cli/main.ts
@@ -76,6 +76,7 @@ Commands:
   snapshot       --source <pg-url> --out <file>
   schema export  --source <pg-url> --out-dir <dir> [--layout by-object|ordered|grouped]
                  [--path-style flat|nested]   (flat: <schema>/…, _cluster/…)
+                 [--create-extension-if-not-exists]
                  [--format-options <json>]   (pretty-print SQL; any layout)
                  grouped adds: [--grouping-mode single-file|subdirectory]
                  [--group-patterns <json>] [--flat-schemas <csv>] [--no-group-partitions]
@@ -206,6 +207,7 @@ pgdelta schema <subcommand> [options]
 Subcommands:
   schema export  --source <pg-url> --out-dir <dir> [--layout by-object|ordered|grouped]
                  [--path-style flat|nested]   (flat: <schema>/…, _cluster/…)
+                 [--create-extension-if-not-exists]
                  [--format-options <json>]   (pretty-print SQL; any layout)
                  grouped adds: [--grouping-mode single-file|subdirectory]
                  [--group-patterns <json>] [--flat-schemas <csv>] [--no-group-partitions]

--- a/packages/pg-delta/src/frontends/export-extension-if-not-exists.test.ts
+++ b/packages/pg-delta/src/frontends/export-extension-if-not-exists.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import { exportSqlFiles } from "./export-sql-files.ts";
+
+const publicSchema = { kind: "schema" as const, name: "public" };
+
+function dump(facts: Fact[], createExtensionIfNotExists?: boolean): string {
+  const options =
+    createExtensionIfNotExists === true
+      ? { createExtensionIfNotExists: true }
+      : {};
+  return exportSqlFiles(buildFactBase(facts, []), options)
+    .map((f) => f.sql)
+    .join("\n");
+}
+
+describe("export CREATE EXTENSION IF NOT EXISTS", () => {
+  test("default export stays plain CREATE (SCHEMA into public)", () => {
+    const sql = dump([
+      { id: publicSchema, payload: {} },
+      {
+        id: { kind: "extension", name: "pgcrypto" },
+        payload: { schema: "public", _relocatable: true },
+      },
+    ]);
+    expect(sql).toContain(`CREATE EXTENSION "pgcrypto" SCHEMA "public"`);
+    expect(sql).not.toContain("IF NOT EXISTS");
+  });
+
+  test("option emits IF NOT EXISTS on SCHEMA form", () => {
+    const sql = dump(
+      [
+        { id: publicSchema, payload: {} },
+        {
+          id: { kind: "extension", name: "pgcrypto" },
+          payload: { schema: "public", _relocatable: true },
+        },
+      ],
+      true,
+    );
+    expect(sql).toContain(
+      `CREATE EXTENSION IF NOT EXISTS "pgcrypto" SCHEMA "public"`,
+    );
+  });
+
+  test("option emits IF NOT EXISTS on bare form", () => {
+    const sql = dump(
+      [
+        { id: publicSchema, payload: {} },
+        {
+          id: { kind: "extension", name: "pgmq" },
+          payload: { schema: "pgmq", _relocatable: false },
+        },
+      ],
+      true,
+    );
+    expect(sql).toContain(`CREATE EXTENSION IF NOT EXISTS "pgmq"`);
+    expect(sql).not.toContain(`SCHEMA "pgmq"`);
+  });
+});

--- a/packages/pg-delta/src/frontends/export-sql-files.ts
+++ b/packages/pg-delta/src/frontends/export-sql-files.ts
@@ -91,6 +91,11 @@ export interface ExportOptions {
    *  instead of throwing "no intent rule registered". Omit for profiles with no
    *  intent handlers. */
   intentRules?: IntentRuleIndex;
+  /** Render `CREATE EXTENSION IF NOT EXISTS` instead of bare `CREATE`.
+   *  Export-only: bootstrap replay against a pre-installed extension is a
+   *  no-op. Off by default so plan/apply stay fail-loud. Does not relocate
+   *  or change version if the extension already exists. */
+  createExtensionIfNotExists?: boolean;
 }
 
 /** Longest filename COMPONENT most filesystems accept (ext4/APFS/NTFS). The
@@ -956,6 +961,9 @@ export function exportSqlFiles(
       : {}),
     ...(options.intentRules !== undefined
       ? { intentRules: options.intentRules }
+      : {}),
+    ...(options.createExtensionIfNotExists === true
+      ? { params: { createExtensionIfNotExists: true } }
       : {}),
   });
 

--- a/packages/pg-delta/src/frontends/schema-export.ts
+++ b/packages/pg-delta/src/frontends/schema-export.ts
@@ -49,6 +49,8 @@ export interface BuildSchemaExportOptions {
   defaultOwner?: string | null;
   /** Soft warnings (e.g. default-owner vs connection-role mismatch). */
   onWarning?: (message: string) => void;
+  /** Render `CREATE EXTENSION IF NOT EXISTS`. Off by default. */
+  createExtensionIfNotExists?: boolean;
 }
 
 export interface SchemaExportResult {
@@ -155,6 +157,9 @@ export async function buildSchemaExport(
       : {}),
     ...(options.onWarning !== undefined
       ? { onWarning: options.onWarning }
+      : {}),
+    ...(options.createExtensionIfNotExists === true
+      ? { createExtensionIfNotExists: true }
       : {}),
   });
 

--- a/packages/pg-delta/src/plan/rules.ts
+++ b/packages/pg-delta/src/plan/rules.ts
@@ -73,7 +73,10 @@ export interface ActionSpec {
 /** Named serialize parameters the rule table consumes. Policies (stage 8)
  *  set them; referencing an unknown name is a plan-time error, not a
  *  silent no-op. */
-export const KNOWN_PARAMS: ReadonlySet<string> = new Set(["concurrentIndexes"]);
+export const KNOWN_PARAMS: ReadonlySet<string> = new Set([
+  "concurrentIndexes",
+  "createExtensionIfNotExists",
+]);
 export type PlanParams = Record<string, unknown>;
 
 export type AttributeRule =

--- a/packages/pg-delta/src/plan/rules/extension-create.test.ts
+++ b/packages/pg-delta/src/plan/rules/extension-create.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, test } from "bun:test";
 import type { Fact } from "../../core/fact.ts";
 import type { Payload } from "../../core/hash.ts";
 import { encodeId, type StableId } from "../../core/stable-id.ts";
-import type { FactView } from "../rules.ts";
+import type { FactView, PlanParams } from "../rules.ts";
 import { schemaRules } from "./schemas.ts";
 
 /** Minimal FactView: `present` ids resolve via get(); `refOnly` ids report
@@ -43,12 +43,13 @@ function createSql(
   payload: Payload,
   sourceView: FactView,
   desiredView: FactView = EMPTY,
+  params?: PlanParams,
 ): string {
   const fact: Fact = { id: { kind: "extension", name: "x" }, payload };
   return schemaRules.extension!.create(
     fact,
     desiredView,
-    undefined,
+    params,
     sourceView,
   )[0]!.sql;
 }
@@ -109,5 +110,42 @@ describe("CREATE EXTENSION schema clause (presence-based)", () => {
         EMPTY,
       ),
     ).toBe(`CREATE EXTENSION "x"`);
+  });
+});
+
+describe("CREATE EXTENSION IF NOT EXISTS (serialize param)", () => {
+  const ifNotExists: PlanParams = { createExtensionIfNotExists: true };
+
+  test("flag on → IF NOT EXISTS, SCHEMA form unchanged", () => {
+    expect(
+      createSql(
+        { schema: "extensions", _relocatable: true },
+        view([sch("extensions")], [sch("extensions")]),
+        EMPTY,
+        ifNotExists,
+      ),
+    ).toBe(`CREATE EXTENSION IF NOT EXISTS "x" SCHEMA "extensions"`);
+  });
+
+  test("flag on → IF NOT EXISTS, bare form unchanged", () => {
+    expect(
+      createSql(
+        { schema: "pgmq", _relocatable: false, _schemaIsMember: false },
+        EMPTY,
+        view([sch("pgmq")], [sch("pgmq")]),
+        ifNotExists,
+      ),
+    ).toBe(`CREATE EXTENSION IF NOT EXISTS "x"`);
+  });
+
+  test("flag false stays plain CREATE", () => {
+    expect(
+      createSql(
+        { schema: "extensions", _relocatable: true },
+        view([sch("extensions")], [sch("extensions")]),
+        EMPTY,
+        { createExtensionIfNotExists: false },
+      ),
+    ).toBe(`CREATE EXTENSION "x" SCHEMA "extensions"`);
   });
 });

--- a/packages/pg-delta/src/plan/rules/schemas.ts
+++ b/packages/pg-delta/src/plan/rules/schemas.ts
@@ -61,20 +61,24 @@ export const schemaRules: Record<string, KindRules> = {
     // express this — the `deptype='e'` schema→extension edge never exists, so
     // `_schemaIsMember` was always false and the rule always emitted the clause
     // (da8ce04 regression). See docs/architecture/managed-view-architecture.md.
-    create: (fact, view, _params, sourceView) => {
+    create: (fact, view, params, sourceView) => {
       const schemaName = str(p(fact, "schema"));
       const schemaId: StableId = { kind: "schema", name: schemaName };
       const schemaPresent =
         sourceView?.get(schemaId) !== undefined ||
         (view.get(schemaId) !== undefined && !view.isReferenceOnly(schemaId));
       const name = qid((fact.id as { name: string }).name);
+      // IF NOT EXISTS no-ops if the name is already installed (no relocate,
+      // no version change). Off by default so plan/apply stay fail-loud.
+      const ifNotExists =
+        params?.["createExtensionIfNotExists"] === true ? " IF NOT EXISTS" : "";
       return [
         schemaPresent
           ? {
-              sql: `CREATE EXTENSION ${name} SCHEMA ${qid(schemaName)}`,
+              sql: `CREATE EXTENSION${ifNotExists} ${name} SCHEMA ${qid(schemaName)}`,
               consumes: [schemaId],
             }
-          : { sql: `CREATE EXTENSION ${name}` },
+          : { sql: `CREATE EXTENSION${ifNotExists} ${name}` },
       ];
     },
     // DROP EXTENSION cascades to its member objects (pg_depend deptype 'e'), but

--- a/packages/pg-delta/tests/export-extension-if-not-exists.test.ts
+++ b/packages/pg-delta/tests/export-extension-if-not-exists.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Live bootstrap for `--create-extension-if-not-exists`: export an installed
+ * extension and replay the tree onto a database that already has it. Public
+ * install only — a managed CREATE SCHEMA stays plain CREATE (PR #444 triage).
+ *
+ * Docker required.
+ */
+import { describe, expect, test } from "bun:test";
+import type { Pool } from "pg";
+import type { FactBase } from "../src/core/fact.ts";
+import { extract } from "../src/extract/extract.ts";
+import { exportSqlFiles } from "../src/frontends/export-sql-files.ts";
+import type { SqlFile } from "../src/frontends/load-sql-files.ts";
+import { sharedCluster } from "./containers.ts";
+
+function schemaFiles(
+  fb: FactBase,
+  createExtensionIfNotExists?: boolean,
+): SqlFile[] {
+  const options =
+    createExtensionIfNotExists === true
+      ? { createExtensionIfNotExists: true }
+      : {};
+  return exportSqlFiles(fb, options).filter(
+    (f) => !f.name.startsWith("_cluster/roles"),
+  );
+}
+
+async function applyFiles(pool: Pool, files: SqlFile[]): Promise<void> {
+  for (const file of files) {
+    if (file.sql.trim() === "") continue;
+    await pool.query(file.sql);
+  }
+}
+
+describe("export CREATE EXTENSION IF NOT EXISTS (live replay)", () => {
+  test("replays onto a database that already has the extension", async () => {
+    const cluster = await sharedCluster();
+    const source = await cluster.createDb("ext_ine_src");
+    const targetOk = await cluster.createDb("ext_ine_ok");
+    const targetFail = await cluster.createDb("ext_ine_fail");
+    try {
+      await source.pool.query(`CREATE EXTENSION pgcrypto`);
+      const fb = (await extract(source.pool)).factBase;
+
+      const plain = schemaFiles(fb);
+      const guarded = schemaFiles(fb, true);
+      expect(guarded.map((f) => f.sql).join("\n")).toContain(
+        `CREATE EXTENSION IF NOT EXISTS "pgcrypto" SCHEMA "public"`,
+      );
+
+      await targetOk.pool.query(`CREATE EXTENSION pgcrypto`);
+      await applyFiles(targetOk.pool, guarded);
+
+      await targetFail.pool.query(`CREATE EXTENSION pgcrypto`);
+      // No `await`: bun's typings declare `.rejects.toThrow()` as void
+      // (oxlint await-thenable rejects it) and the runner tracks the
+      // pending assertion itself, failing this test if it resolves.
+      expect(applyFiles(targetFail.pool, plain)).rejects.toThrow(
+        /already exists/i,
+      );
+    } finally {
+      await Promise.all([source.drop(), targetOk.drop(), targetFail.drop()]);
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary

- Add `--create-extension-if-not-exists` on `schema export` (and `createExtensionIfNotExists` on `buildSchemaExport` / `exportSqlFiles`) so declarative files can replay as bootstrap SQL against a cluster that already has the extension.
- `CREATE EXTENSION IF NOT EXISTS` is constructed in the existing extension create rule. The SCHEMA-presence clause is unchanged. Default export, `plan`, and `apply` still emit plain `CREATE`.
- PostgreSQL no-ops if the name is already installed — it does not relocate or change version. The export manifest is not stamped.

## RED (before the rule change)

```
Expected: "CREATE EXTENSION IF NOT EXISTS "x" SCHEMA "extensions""
Received: "CREATE EXTENSION "x" SCHEMA "extensions""
```

## Test plan

- [ ] `cd packages/pg-delta && bun test src/plan/rules/extension-create.test.ts src/frontends/export-extension-if-not-exists.test.ts src/cli/main.test.ts`
- [ ] `pgdelta schema export --source <url> --out-dir /tmp/schema` still writes `CREATE EXTENSION "…"`
- [ ] `pgdelta schema export --source <url> --out-dir /tmp/schema --create-extension-if-not-exists` writes `CREATE EXTENSION IF NOT EXISTS "…"` (SCHEMA form when the install schema is present)
- [ ] Confirm `.pgdelta-export.json` has no new field