### PR TITLE
fix(pg-delta): try export order first, then reconnect and kind escalate

### DIFF
--- a/.changeset/shadow-load-order-escalate.md
+++ b/.changeset/shadow-load-order-escalate.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Shadow load uses export `loadOrder` (else caller/lex order) first, reconnects once on a stuck session, then `reorderOnFailure` file-kind / statement-kind with a warning so authors can fix the tree.

--- a/packages/pg-delta/src/cli/commands/collect-sql-files.test.ts
+++ b/packages/pg-delta/src/cli/commands/collect-sql-files.test.ts
@@ -92,6 +92,7 @@ describe("writeExportFiles", () => {
       redactSecrets: true,
       profile: "raw",
       files: [],
+      loadOrder: [],
     });
   });
 
@@ -112,6 +113,11 @@ describe("writeExportFiles", () => {
       "cluster/roles.sql",
       "schemas/app/a.sql",
       "schemas/app/b.sql",
+    ]);
+    expect(readExportManifest(target)?.loadOrder).toEqual([
+      "schemas/app/b.sql",
+      "schemas/app/a.sql",
+      "cluster/roles.sql",
     ]);
   });
 

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -57,16 +57,9 @@
  *   statement depending on one will fail on the target. Deliver it through your
  *   migration channel first. `--strict-coverage` makes it blocking.
  *
- *   By default the SQL files are passed through the statement-reordering assist
- *   (target-architecture §4.4.1): each file is split into one-statement units
- *   and topologically pre-sorted before loading, so authoring order within a
- *   file no longer matters and the shadow loader converges in fewer rounds. The
- *   assist is advisory — Postgres still elaborates the shadow — so it can only
- *   fail to BUILD the shadow (a visible error), never corrupt the desired state.
- *
- *   --no-reorder
- *     Skip the reordering assist and load the raw files at file granularity
- *     (the original behavior). Useful for debugging a stuck load.
+ *   Shadow load tries authored / export `loadOrder` first (then reconnects
+ *   once if the session looks poisoned). `--no-reorder` skips the later
+ *   file-kind / statement-kind escalate so a stuck load stays stuck.
  *
  *   --accept-rename <from>=<to>
  *     Confirm one rename candidate by the encoded stable-ids shown in a prior
@@ -391,8 +384,9 @@ export function writeExportFiles(
     written: scaffoldedCustomReadme,
     skippedSymlink: customReadmeSkippedSymlink,
   } = scaffoldCustomReadme(outRoot);
-  const ownedFiles = files.map((file) => file.name.split(sep).join("/")).sort();
-  writeExportManifest(outRoot, { ...manifest, files: ownedFiles });
+  const loadOrder = files.map((file) => file.name.split(sep).join("/"));
+  const ownedFiles = [...loadOrder].sort();
+  writeExportManifest(outRoot, { ...manifest, files: ownedFiles, loadOrder });
   return {
     removed,
     unmanaged,

--- a/packages/pg-delta/src/frontends/export-manifest.test.ts
+++ b/packages/pg-delta/src/frontends/export-manifest.test.ts
@@ -126,6 +126,13 @@ describe("export manifest", () => {
       "_cluster/publications.sql",
       "extra.sql",
     ]);
+    const collided = [
+      { name: "schema\\a.sql", sql: "-- win" },
+      { name: "schema/a.sql", sql: "-- posix" },
+    ];
+    expect(
+      applyManifestLoadOrder(collided, ["schema/a.sql"]).map((f) => f.sql),
+    ).toEqual(["-- posix", "-- win"]);
   });
 
   test("drops a wrong-typed files field (non-array or non-string members)", () => {

--- a/packages/pg-delta/src/frontends/export-manifest.test.ts
+++ b/packages/pg-delta/src/frontends/export-manifest.test.ts
@@ -115,6 +115,17 @@ describe("export manifest", () => {
     expect(applyManifestLoadOrder(files).map((f) => f.name)).toEqual(
       files.map((f) => f.name),
     );
+    expect(
+      applyManifestLoadOrder(files, [
+        "public/tables/t.sql",
+        "public/tables/t.sql",
+        "_cluster/publications.sql",
+      ]).map((f) => f.name),
+    ).toEqual([
+      "public/tables/t.sql",
+      "_cluster/publications.sql",
+      "extra.sql",
+    ]);
   });
 
   test("drops a wrong-typed files field (non-array or non-string members)", () => {

--- a/packages/pg-delta/src/frontends/export-manifest.test.ts
+++ b/packages/pg-delta/src/frontends/export-manifest.test.ts
@@ -7,6 +7,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  applyManifestLoadOrder,
   EXPORT_MANIFEST_FILE,
   readExportManifest,
   writeExportManifest,
@@ -82,6 +83,38 @@ describe("export manifest", () => {
       scope: "database",
       files,
     });
+  });
+
+  test("round-trips loadOrder (emission order, not sorted)", () => {
+    const loadOrder = ["schemas/app/tables/t.sql", "_cluster/publications.sql"];
+    writeExportManifest(dir, {
+      redactSecrets: true,
+      scope: "database",
+      files: ["_cluster/publications.sql", "schemas/app/tables/t.sql"],
+      loadOrder,
+    });
+    expect(readExportManifest(dir)?.loadOrder).toEqual(loadOrder);
+  });
+
+  test("applyManifestLoadOrder uses loadOrder then leftover names in caller order", () => {
+    const files = [
+      { name: "_cluster/publications.sql", sql: "-- pub" },
+      { name: "public/tables/t.sql", sql: "-- t" },
+      { name: "extra.sql", sql: "-- extra" },
+    ];
+    expect(
+      applyManifestLoadOrder(files, [
+        "public/tables/t.sql",
+        "_cluster/publications.sql",
+      ]).map((f) => f.name),
+    ).toEqual([
+      "public/tables/t.sql",
+      "_cluster/publications.sql",
+      "extra.sql",
+    ]);
+    expect(applyManifestLoadOrder(files).map((f) => f.name)).toEqual(
+      files.map((f) => f.name),
+    );
   });
 
   test("drops a wrong-typed files field (non-array or non-string members)", () => {

--- a/packages/pg-delta/src/frontends/export-manifest.ts
+++ b/packages/pg-delta/src/frontends/export-manifest.ts
@@ -167,6 +167,7 @@ export function applyManifestLoadOrder<T extends { name: string }>(
   }
   const byName = new Map(files.map((f) => [posixRelName(f.name), f]));
   const seen = new Set<string>();
+  const included = new Set<T>();
   const ordered: T[] = [];
   for (const path of loadOrder) {
     if (seen.has(path)) continue;
@@ -174,11 +175,13 @@ export function applyManifestLoadOrder<T extends { name: string }>(
     if (file !== undefined) {
       ordered.push(file);
       seen.add(path);
+      included.add(file);
     }
   }
   for (const file of files) {
-    if (!seen.has(posixRelName(file.name))) {
+    if (!included.has(file)) {
       ordered.push(file);
+      included.add(file);
     }
   }
   return ordered;

--- a/packages/pg-delta/src/frontends/export-manifest.ts
+++ b/packages/pg-delta/src/frontends/export-manifest.ts
@@ -50,6 +50,11 @@ export interface ExportManifest {
    *  authored) and refused rather than silently deleted. FIELD ABSENT → a
    *  pre-feature or hand-authored dir: every existing `.sql` is unmanaged. */
   files?: string[];
+  /** Emission order from `exportSqlFiles` (plan `firstAt`), POSIX paths.
+   *  Shadow load uses this as the default file order. Absent on older
+   *  manifests — callers fall back to lexicographic collect order. Distinct
+   *  from {@link files}, which is a sorted ownership set. */
+  loadOrder?: string[];
 }
 
 export function writeExportManifest(
@@ -61,6 +66,7 @@ export function writeExportManifest(
     baselineDigest?: string;
     defaultOwner?: string | null;
     files?: string[];
+    loadOrder?: string[];
   },
 ): void {
   const path = join(dir, EXPORT_MANIFEST_FILE);
@@ -133,5 +139,46 @@ export function readExportManifest(dir: string): ExportManifest | undefined {
   if (Array.isArray(files) && files.every((f) => typeof f === "string")) {
     manifest.files = files as string[];
   }
+  const loadOrder = doc["loadOrder"];
+  if (
+    Array.isArray(loadOrder) &&
+    loadOrder.every((f) => typeof f === "string")
+  ) {
+    manifest.loadOrder = loadOrder as string[];
+  }
   return manifest;
+}
+
+function posixRelName(name: string): string {
+  return name.split(/[\\/]/).join("/");
+}
+
+/**
+ * Reorder `files` to `loadOrder`. Unknown paths keep their relative order
+ * after the recorded prefix. Missing `loadOrder` leaves the array unchanged
+ * (in-memory export emission, or lex from `collectSqlFiles`).
+ */
+export function applyManifestLoadOrder<T extends { name: string }>(
+  files: readonly T[],
+  loadOrder?: readonly string[],
+): T[] {
+  if (loadOrder === undefined || loadOrder.length === 0) {
+    return [...files];
+  }
+  const byName = new Map(files.map((f) => [posixRelName(f.name), f]));
+  const seen = new Set<string>();
+  const ordered: T[] = [];
+  for (const path of loadOrder) {
+    const file = byName.get(path);
+    if (file !== undefined) {
+      ordered.push(file);
+      seen.add(path);
+    }
+  }
+  for (const file of files) {
+    if (!seen.has(posixRelName(file.name))) {
+      ordered.push(file);
+    }
+  }
+  return ordered;
 }

--- a/packages/pg-delta/src/frontends/export-manifest.ts
+++ b/packages/pg-delta/src/frontends/export-manifest.ts
@@ -169,6 +169,7 @@ export function applyManifestLoadOrder<T extends { name: string }>(
   const seen = new Set<string>();
   const ordered: T[] = [];
   for (const path of loadOrder) {
+    if (seen.has(path)) continue;
     const file = byName.get(path);
     if (file !== undefined) {
       ordered.push(file);

--- a/packages/pg-delta/src/frontends/index.ts
+++ b/packages/pg-delta/src/frontends/index.ts
@@ -26,6 +26,7 @@ export {
 } from "./ssl-config.ts";
 
 export {
+  applyManifestLoadOrder,
   EXPORT_MANIFEST_FILE,
   readExportManifest,
   writeExportManifest,

--- a/packages/pg-delta/src/frontends/load-sql-files.test.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.test.ts
@@ -16,6 +16,7 @@ import {
   findDefaultPrivilegeStatements,
   findSessionSettingStatements,
   findTransactionControl,
+  resolveReorderOnFailure,
   stripClusterDdl,
 } from "./load-sql-files.ts";
 
@@ -265,5 +266,22 @@ describe("findDefaultPrivilegeStatements — reorder barrier", () => {
         `CREATE FUNCTION f() RETURNS text LANGUAGE sql AS 'SELECT ''ALTER DEFAULT PRIVILEGES''';`,
       ),
     ).toEqual([]);
+  });
+});
+
+describe("resolveReorderOnFailure", () => {
+  test("reorderOnFailure wins when both aliases are set", () => {
+    expect(
+      resolveReorderOnFailure({ reorder: false, reorderOnFailure: true }),
+    ).toBe(true);
+    expect(
+      resolveReorderOnFailure({ reorder: true, reorderOnFailure: false }),
+    ).toBe(false);
+  });
+
+  test("either alias alone opts out, default is true", () => {
+    expect(resolveReorderOnFailure({ reorder: false })).toBe(false);
+    expect(resolveReorderOnFailure({ reorderOnFailure: false })).toBe(false);
+    expect(resolveReorderOnFailure({})).toBe(true);
   });
 });

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -758,7 +758,11 @@ export interface LoadSqlFilesOptions {
   splitFileByKind?: (file: SqlFile) => SqlFile[] | Promise<SqlFile[]>;
 }
 
-function resolveReorderOnFailure(options: LoadSqlFilesOptions): boolean {
+/** `reorderOnFailure` wins when both aliases are set. Default true. */
+export function resolveReorderOnFailure(options: {
+  reorderOnFailure?: boolean;
+  reorder?: boolean;
+}): boolean {
   if (options.reorderOnFailure !== undefined) return options.reorderOnFailure;
   if (options.reorder !== undefined) return options.reorder;
   return true;

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -1095,6 +1095,7 @@ export async function loadSqlFiles(
           await applyPreamble(client);
           reconnected = true;
           pending = next;
+          maxRounds = Math.max(maxRounds, rounds + pending.length + 1);
           continue;
         }
         if (
@@ -1105,7 +1106,7 @@ export async function loadSqlFiles(
           failuresBeforeReorder = failures;
           fileKindTried = true;
           pending = await options.reorderFilesByKind(next);
-          maxRounds = Math.max(maxRounds, pending.length + 1);
+          maxRounds = Math.max(maxRounds, rounds + pending.length + 1);
           continue;
         }
         if (
@@ -1137,7 +1138,7 @@ export async function loadSqlFiles(
             });
           }
           pending = split;
-          maxRounds = Math.max(maxRounds, pending.length + 1);
+          maxRounds = Math.max(maxRounds, rounds + pending.length + 1);
           continue;
         }
         const mutualFkHint = detectMutualFk(failures)

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -744,6 +744,54 @@ export interface LoadSqlFilesOptions {
    *  statements (`SET search_path`, `SET ROLE`, `SET LOCAL`, …) stay
    *  file-atomic so those settings cannot expire between statements. */
   statementFallback?: boolean;
+  /** Default `"reconnect-on-stuck"`. `"keep"` never opens a second connection. */
+  connectionReuse?: "keep" | "reconnect-on-stuck";
+  /** After default order (and reconnect) stick, allow file-kind then
+   *  statement-kind. Default true. */
+  reorderOnFailure?: boolean;
+  /** Same gate as {@link reorderOnFailure} (`false` opts out of escalate). */
+  reorder?: boolean;
+  onWarning?: (message: string) => void;
+  /** Assist: sort whole files by kind (stage 3). Loader does not parse SQL. */
+  reorderFilesByKind?: (files: SqlFile[]) => SqlFile[] | Promise<SqlFile[]>;
+  /** Assist: split one file into kind-ordered statement units (stage 4). */
+  splitFileByKind?: (file: SqlFile) => SqlFile[] | Promise<SqlFile[]>;
+}
+
+function resolveReorderOnFailure(options: LoadSqlFilesOptions): boolean {
+  if (options.reorderOnFailure !== undefined) return options.reorderOnFailure;
+  if (options.reorder !== undefined) return options.reorder;
+  return true;
+}
+
+function formatLoadFailures(
+  failures: Array<{ file: SqlFile; message: string }>,
+): string {
+  return failures.map((f) => `${f.file.name}: ${f.message}`).join("; ");
+}
+
+function sessionPollutionMessage(
+  stuck: Array<{ file: SqlFile; message: string }>,
+  earlier: Array<{ file: SqlFile; message: string }>,
+): string {
+  return (
+    `A new connection unblocked a stuck same-connection shadow load (session pollution). ` +
+    `Stuck pending files: ${formatLoadFailures(stuck)}. ` +
+    `Earlier failures on the poisoned connection (likely polluter, especially ALTER PUBLICATION): ${formatLoadFailures(earlier)}. ` +
+    `Please open an issue at https://github.com/supabase/postgres/issues with the failed ALTER PUBLICATION and the follow-on CREATE POLICY / owner error.`
+  );
+}
+
+function reorderOnFailureMessage(
+  kind: "file-kind" | "statement-kind",
+  stuck: Array<{ file: SqlFile; message: string }>,
+): string {
+  return (
+    `The default file order stuck, so the loader reordered on failure (${kind}). ` +
+    `Stuck files: ${formatLoadFailures(stuck)}. ` +
+    `You can permanently fix this by putting tables and extensions before policy-only and ALTER PUBLICATION files ` +
+    `(or by setting loadOrder on .pgdelta-export.json to that emission order) so the default order succeeds next time.`
+  );
 }
 
 export async function loadSqlFiles(
@@ -760,10 +808,12 @@ export async function loadSqlFiles(
   // backstop for non-deterministic SQL, NOT a depth limit — it must scale with
   // the file count (floor 25 preserves the small-schema default). A fixed 25
   // used to wrongly fail any chain deeper than 25 that was still making progress.
-  const maxRounds = options.maxRounds ?? Math.max(files.length + 1, 25);
+  let maxRounds = options.maxRounds ?? Math.max(files.length + 1, 25);
   const mode = options.mode ?? "databaseScratch";
   const extractShadow = options.extract ?? extract;
   const statementFallback = options.statementFallback ?? true;
+  const connectionReuse = options.connectionReuse ?? "reconnect-on-stuck";
+  const reorderOnFailure = resolveReorderOnFailure(options);
 
   // the shadow must be empty — verify by observation. Schemas the caller
   // pre-seeded (Phase 2b assumed schemas) are exempt: they were deliberately
@@ -873,14 +923,15 @@ export async function loadSqlFiles(
           ORDER BY 1, 2`)
       : null;
 
-  // bounded retry rounds at file granularity (fail-safe ordering)
-  let pending = [...files].sort((a, b) => (a.name < b.name ? -1 : 1));
+  // Caller array order is the default (export loadOrder or lex collect).
+  let pending = [...files];
   let rounds = 0;
   // body-validation warnings for SEEDED-schema routines (populated below,
   // outside the try/finally so the final result can merge them in).
   let seededBodyWarnings: Diagnostic[] = [];
   // non-fatal `data_statement` observations (same lifetime rationale).
   let dataStatementWarnings: Diagnostic[] = [];
+  let stageDiagnostics: Diagnostic[] = [];
   // the most recent round's per-file failures, retained so a budget-exhaustion
   // error can report WHY each still-pending file failed (review P1 #2).
   let lastFailures: Array<{ file: SqlFile; message: string }> = [];
@@ -894,9 +945,38 @@ export async function loadSqlFiles(
     roles: ReadonlySet<string>;
     member: string;
   } | null = null;
-  const client = await shadow.connect();
+  let reconnected = false;
+  let reconnectUnblocked = false;
+  let fileKindTried = false;
+  let statementKindTried = false;
+  let failuresBeforeReconnect: Array<{ file: SqlFile; message: string }> = [];
+  let failuresBeforeReorder: Array<{ file: SqlFile; message: string }> = [];
+  let client: PoolClient = await shadow.connect();
+  let clientOpen = true;
+  const releaseClient = async (discard = false): Promise<void> => {
+    if (!clientOpen) return;
+    clientOpen = false;
+    await client.query(`RESET ROLE`).catch(() => {});
+    await client.query(`RESET SESSION AUTHORIZATION`).catch(() => {});
+    await client.query(`RESET check_function_bodies`).catch(() => {});
+    if (discard) {
+      client.release(new Error("discard poisoned shadow-load session"));
+    } else {
+      client.release();
+    }
+  };
+  const applyPreamble = async (c: PoolClient): Promise<void> => {
+    await c.query(`SET check_function_bodies = off`);
+    try {
+      await c.query(
+        `SELECT set_config('createrole_self_grant', 'set, inherit', false)`,
+      );
+    } catch {
+      /* PG < 16 or GUC unavailable */
+    }
+  };
   try {
-    await client.query(`SET check_function_bodies = off`);
+    await applyPreamble(client);
     // PG 16+: CREATE ROLE no longer auto-grants the creator membership in the
     // new role. Supabase's non-superuser `postgres` (CREATEROLE) then fails
     // `CREATE SCHEMA … AUTHORIZATION new_role` with "must be able to SET ROLE"
@@ -1008,28 +1088,118 @@ export async function loadSqlFiles(
         }
       }
       if (!progressed) {
-        // no progress: stuck — inspect for mutual-FK situation, then fail loud
+        lastFailures = failures;
+        if (connectionReuse === "reconnect-on-stuck" && !reconnected) {
+          failuresBeforeReconnect = failures;
+          await releaseClient(true);
+          client = await shadow.connect();
+          clientOpen = true;
+          await applyPreamble(client);
+          reconnected = true;
+          pending = next;
+          continue;
+        }
+        if (
+          reorderOnFailure &&
+          !fileKindTried &&
+          options.reorderFilesByKind !== undefined
+        ) {
+          failuresBeforeReorder = failures;
+          fileKindTried = true;
+          pending = await options.reorderFilesByKind(next);
+          maxRounds = Math.max(maxRounds, pending.length + 1);
+          continue;
+        }
+        if (
+          reorderOnFailure &&
+          !statementKindTried &&
+          options.splitFileByKind !== undefined
+        ) {
+          if (failuresBeforeReorder.length === 0) {
+            failuresBeforeReorder = failures;
+          }
+          statementKindTried = true;
+          const split: SqlFile[] = [];
+          for (const file of next) {
+            if (
+              findSessionSettingStatements(file.sql).length > 0 ||
+              findDefaultPrivilegeStatements(file.sql).length > 0
+            ) {
+              split.push(file);
+              continue;
+            }
+            const units = await options.splitFileByKind(file);
+            if (units.length <= 1) {
+              split.push(units[0] ?? file);
+              continue;
+            }
+            split.push({
+              name: file.name,
+              sql: joinStatements(units.map((unit) => unit.sql)),
+            });
+          }
+          pending = split;
+          maxRounds = Math.max(maxRounds, pending.length + 1);
+          continue;
+        }
         const mutualFkHint = detectMutualFk(failures)
           ? " Tip: if two tables reference each other with inline REFERENCES clauses, split one foreign key into a separate ALTER TABLE … ADD CONSTRAINT statement."
           : "";
+        const details: Diagnostic[] = failures.map((f) => {
+          const streak = failStreak.get(f.file.name);
+          const streakNote =
+            streak !== undefined && streak.count > 1
+              ? ` (failed identically in ${streak.count} round(s) — likely a genuine missing dependency, not ordering)`
+              : "";
+          return {
+            code: "stuck_statement",
+            severity: "error" as const,
+            message: `${f.file.name}: ${f.message}${streakNote}`,
+          };
+        });
+        if (fileKindTried || statementKindTried) {
+          const kind = statementKindTried ? "statement-kind" : "file-kind";
+          const message = reorderOnFailureMessage(kind, failuresBeforeReorder);
+          details.push({
+            code: "reorder_on_failure",
+            severity: "warning",
+            message,
+          });
+          options.onWarning?.(message);
+        }
         throw new ShadowLoadError(
           `shadow load stuck after ${rounds} round(s): ${next.length} file(s) cannot apply${mutualFkHint}`,
-          failures.map((f) => {
-            const streak = failStreak.get(f.file.name);
-            const streakNote =
-              streak !== undefined && streak.count > 1
-                ? ` (failed identically in ${streak.count} round(s) — likely a genuine missing dependency, not ordering)`
-                : "";
-            return {
-              code: "stuck_statement",
-              severity: "error",
-              message: `${f.file.name}: ${f.message}${streakNote}`,
-            };
-          }),
+          details,
         );
+      }
+      if (reconnected && !fileKindTried && !statementKindTried) {
+        reconnectUnblocked = true;
       }
       lastFailures = failures;
       pending = next;
+    }
+
+    if (reconnectUnblocked) {
+      const message = sessionPollutionMessage(
+        failuresBeforeReconnect,
+        failuresBeforeReconnect,
+      );
+      stageDiagnostics.push({
+        code: "session_pollution",
+        severity: "warning",
+        message,
+      });
+      options.onWarning?.(message);
+    }
+    if (fileKindTried || statementKindTried) {
+      const kind = statementKindTried ? "statement-kind" : "file-kind";
+      const message = reorderOnFailureMessage(kind, failuresBeforeReorder);
+      stageDiagnostics.push({
+        code: "reorder_on_failure",
+        severity: "warning",
+        message,
+      });
+      options.onWarning?.(message);
     }
 
     // Capture createrole_self_grant bootstrap grants for post-extract stripping.
@@ -1325,7 +1495,7 @@ export async function loadSqlFiles(
     // on-success snapshot comparison above — survives an aborted load. Reverse it
     // BEFORE the finally releases the pooled client. `applyFile` ROLLBACKs on
     // failure, so `client` is in a clean transaction state here.
-    if (mode === "databaseScratch") {
+    if (mode === "databaseScratch" && clientOpen) {
       const restoreDiags = await restoreScratchClusterState(
         client,
         rolesBefore,
@@ -1337,11 +1507,7 @@ export async function loadSqlFiles(
     }
     throw err;
   } finally {
-    // restore the GUC even when load fails early (before the on-success reset
-    // at the body-validation step) — otherwise the pooled client returns with
-    // check_function_bodies still off (review P2).
-    await client.query(`RESET check_function_bodies`).catch(() => {});
-    client.release();
+    await releaseClient();
   }
 
   // provenance tag: mark the fact base as originating from SQL files. The
@@ -1377,6 +1543,7 @@ export async function loadSqlFiles(
       ...result.diagnostics,
       ...seededBodyWarnings,
       ...dataStatementWarnings,
+      ...stageDiagnostics,
     ],
     rounds,
     preExistingPopulatedTables,

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -764,20 +764,18 @@ function resolveReorderOnFailure(options: LoadSqlFilesOptions): boolean {
   return true;
 }
 
-function formatLoadFailures(
+function formatLoadFileNames(
   failures: Array<{ file: SqlFile; message: string }>,
 ): string {
-  return failures.map((f) => `${f.file.name}: ${f.message}`).join("; ");
+  return [...new Set(failures.map((f) => f.file.name))].join(", ");
 }
 
 function sessionPollutionMessage(
   stuck: Array<{ file: SqlFile; message: string }>,
-  earlier: Array<{ file: SqlFile; message: string }>,
 ): string {
   return (
     `A new connection unblocked a stuck same-connection shadow load (session pollution). ` +
-    `Stuck pending files: ${formatLoadFailures(stuck)}. ` +
-    `Earlier failures on the poisoned connection (likely polluter, especially ALTER PUBLICATION): ${formatLoadFailures(earlier)}. ` +
+    `Stuck pending files: ${formatLoadFileNames(stuck)}. ` +
     `Please open an issue at https://github.com/supabase/postgres/issues with the failed ALTER PUBLICATION and the follow-on CREATE POLICY / owner error.`
   );
 }
@@ -788,7 +786,7 @@ function reorderOnFailureMessage(
 ): string {
   return (
     `The default file order stuck, so the loader reordered on failure (${kind}). ` +
-    `Stuck files: ${formatLoadFailures(stuck)}. ` +
+    `Stuck files: ${formatLoadFileNames(stuck)}. ` +
     `You can permanently fix this by putting tables and extensions before policy-only and ALTER PUBLICATION files ` +
     `(or by setting loadOrder on .pgdelta-export.json to that emission order) so the default order succeeds next time.`
   );
@@ -1180,10 +1178,7 @@ export async function loadSqlFiles(
     }
 
     if (reconnectUnblocked) {
-      const message = sessionPollutionMessage(
-        failuresBeforeReconnect,
-        failuresBeforeReconnect,
-      );
+      const message = sessionPollutionMessage(failuresBeforeReconnect);
       stageDiagnostics.push({
         code: "session_pollution",
         severity: "warning",

--- a/packages/pg-delta/src/frontends/schema-export.ts
+++ b/packages/pg-delta/src/frontends/schema-export.ts
@@ -159,9 +159,11 @@ export async function buildSchemaExport(
   });
 
   const exportProfileId = ctx.planOptions.profile?.id;
+  const loadOrder = files.map((file) => file.name.split(/[\\/]/).join("/"));
   const manifest: SchemaExportResult["manifest"] = {
     redactSecrets,
     scope: exportScope,
+    loadOrder,
     ...(exportProfileId !== undefined ? { profile: exportProfileId } : {}),
     ...(ctx.baseline !== undefined
       ? { baselineDigest: ctx.baseline.digest }

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -34,16 +34,19 @@ import {
   findClusterDdlStatements,
   findDefaultPrivilegeStatements,
   findMatchingStatements,
-  findSessionSettingStatements,
   loadSqlFiles,
   ShadowLoadError,
   stripClusterDdl,
   type SqlFile,
 } from "./load-sql-files.ts";
+import { applyManifestLoadOrder } from "./export-manifest.ts";
 import { deriveAssumedSchemaSeed } from "./seed-assumed-schemas.ts";
 import {
   analyzeForShadow,
+  classesByFileFromAnalyzed,
+  preorderFilesByKind,
   ReorderUnavailableError,
+  splitAndReorderFile,
   type OrderedSqlFile,
   type ShadowLoadCycle,
 } from "./sql-order.ts";
@@ -302,8 +305,13 @@ export interface PlanSchemaFilesOptions {
    *  different database OID); that case still fails `isSameDatabase()` and the
    *  lineage guard still refuses it. */
   allowSameDatabaseIdentity?: boolean;
-  /** Statement-reorder assist. Default: true. */
+  /** After default order (and reconnect) stick, allow file-kind then
+   *  statement-kind. Default true. Same switch as {@link reorder}. */
+  reorderOnFailure?: boolean;
+  /** Statement-reorder assist. Default: true. Alias of {@link reorderOnFailure}. */
   reorder?: boolean;
+  /** Forwarded to {@link loadSqlFiles}. Default: reconnect-on-stuck. */
+  connectionReuse?: "keep" | "reconnect-on-stuck";
   /** Forwarded to {@link loadSqlFiles}. Default: true (per-statement fallback
    *  after a file-atomic failure). `false` restores whole-file rollback. */
   statementFallback?: boolean;
@@ -583,12 +591,13 @@ export async function planSchemaFiles(
     }
   }
 
-  const reorder = options.reorder !== false;
+  const reorderOnFailure =
+    options.reorderOnFailure !== false && options.reorder !== false;
   let orderedFiles: OrderedSqlFile[] | null = null;
   let cycles: ShadowLoadCycle[] = [];
-  let loadInput: SqlFile[] = files;
-  if (reorder) {
-    let analyzed: Awaited<ReturnType<typeof analyzeForShadow>> | null = null;
+  const loadInput = applyManifestLoadOrder(files, options.manifest?.loadOrder);
+  let analyzed: Awaited<ReturnType<typeof analyzeForShadow>> | null = null;
+  if (reorderOnFailure) {
     try {
       analyzed = await analyzeForShadow(files);
     } catch (err) {
@@ -598,67 +607,34 @@ export async function planSchemaFiles(
       );
     }
     if (analyzed !== null) {
+      orderedFiles = analyzed.files;
+      cycles = analyzed.cycles;
       const parseErrors = analyzed.diagnostics.filter(
         (d) => d.code === "PARSE_ERROR" || d.code === "DISCOVERY_ERROR",
       );
-      const sessionSettingFiles = files.filter(
-        (f) => findSessionSettingStatements(f.sql).length > 0,
-      );
-      const defaultPrivFiles =
-        options.manifest === undefined
-          ? files.filter(
-              (f) => findDefaultPrivilegeStatements(f.sql).length > 0,
-            )
-          : [];
-
-      if (
-        parseErrors.length > 0 ||
-        sessionSettingFiles.length > 0 ||
-        defaultPrivFiles.length > 0
-      ) {
-        const reasons: string[] = [];
-        if (parseErrors.length > 0) {
-          reasons.push(
-            `pg-topo could not parse ${parseErrors.length} input(s) — reordering would silently drop them`,
-          );
-        }
-        if (sessionSettingFiles.length > 0) {
-          reasons.push(
-            `session-setting statements in ${sessionSettingFiles
-              .map((f) => f.name)
-              .join(", ")} must not be reordered`,
-          );
-        }
-        if (defaultPrivFiles.length > 0) {
-          reasons.push(
-            `ALTER DEFAULT PRIVILEGES in ${defaultPrivFiles
-              .map((f) => f.name)
-              .join(", ")} must not be reordered past the objects it scopes`,
-          );
-        }
+      if (parseErrors.length > 0) {
         options.onWarning?.(
-          `reorder assist disabled — ${reasons.join("; ")}. Loading files raw at file granularity.`,
+          `pg-topo could not parse ${parseErrors.length} input(s) — file-kind escalate will use filename hints when a file has no class.`,
         );
-      } else {
-        orderedFiles = analyzed.files;
-        cycles = analyzed.cycles;
-        loadInput = analyzed.files;
       }
     }
   }
 
-  if (orderedFiles === null) {
-    const adpFiles = files.filter(
-      (f) => findDefaultPrivilegeStatements(f.sql).length > 0,
+  const adpFiles = files.filter(
+    (f) => findDefaultPrivilegeStatements(f.sql).length > 0,
+  );
+  if (adpFiles.length > 0) {
+    options.onWarning?.(
+      "raw loading may apply ALTER DEFAULT PRIVILEGES AFTER objects created in the same load, so objects relying on ADP-implicit default grants may not receive them. Grant those privileges explicitly (as schema export does).",
     );
-    if (adpFiles.length > 0) {
-      options.onWarning?.(
-        "raw loading may apply ALTER DEFAULT PRIVILEGES AFTER objects created in the same load, so objects relying on ADP-implicit default grants may not receive them. Grant those privileges explicitly (as schema export does).",
-      );
-    }
   }
 
   const originalSqlByName = new Map(files.map((f) => [f.name, f.sql]));
+  const filenameFallback =
+    analyzed !== null &&
+    analyzed.diagnostics.some(
+      (d) => d.code === "PARSE_ERROR" || d.code === "DISCOVERY_ERROR",
+    );
 
   let loadResult;
   try {
@@ -676,6 +652,25 @@ export async function planSchemaFiles(
         : {}),
       ...(options.statementFallback !== undefined
         ? { statementFallback: options.statementFallback }
+        : {}),
+      reorderOnFailure,
+      ...(options.connectionReuse !== undefined
+        ? { connectionReuse: options.connectionReuse }
+        : {}),
+      ...(options.onWarning !== undefined
+        ? { onWarning: options.onWarning }
+        : {}),
+      ...(analyzed !== null
+        ? {
+            reorderFilesByKind: (pending: SqlFile[]) =>
+              preorderFilesByKind(
+                pending,
+                classesByFileFromAnalyzed(analyzed),
+                { filenameFallback },
+              ),
+            splitFileByKind: (file: SqlFile) =>
+              splitAndReorderFile(file, analyzed),
+          }
         : {}),
     });
   } catch (error) {

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -35,6 +35,7 @@ import {
   findDefaultPrivilegeStatements,
   findMatchingStatements,
   loadSqlFiles,
+  resolveReorderOnFailure,
   ShadowLoadError,
   stripClusterDdl,
   type SqlFile,
@@ -591,8 +592,7 @@ export async function planSchemaFiles(
     }
   }
 
-  const reorderOnFailure =
-    options.reorderOnFailure !== false && options.reorder !== false;
+  const reorderOnFailure = resolveReorderOnFailure(options);
   let orderedFiles: OrderedSqlFile[] | null = null;
   let cycles: ShadowLoadCycle[] = [];
   const loadInput = applyManifestLoadOrder(files, options.manifest?.loadOrder);

--- a/packages/pg-delta/src/frontends/sql-order.test.ts
+++ b/packages/pg-delta/src/frontends/sql-order.test.ts
@@ -7,9 +7,9 @@
  * NEVER trusted for correctness — Postgres elaborates the shadow (principle P1)
  * — so the only hard guarantees it must keep are structural:
  *
- * - one statement per output `SqlFile`, fed straight into `loadSqlFiles`;
- * - a zero-padded ordinal name prefix so the loader's per-round lexicographic
- *   `name` sort reproduces topo order (D4 option `a`);
+ * - one statement per output `SqlFile`;
+ * - a zero-padded ordinal name prefix so a caller that lex-sorts by name
+ *   keeps topo order;
  * - every input statement preserved exactly once — including statements
  *   pg-topo cannot classify (`UNKNOWN`) and statements trapped in a cycle;
  * - statement text carried verbatim;
@@ -22,9 +22,12 @@ import {
   __setPgTopoImporterForTests,
   analyzeForShadow,
   canReorder,
+  classesByFileFromAnalyzed,
   orderForShadow,
+  preorderFilesByKind,
   ReorderParseError,
   ReorderUnavailableError,
+  splitAndReorderFile,
   type OrderedSqlFile,
 } from "./sql-order.ts";
 import type { SqlFile } from "./load-sql-files.ts";
@@ -323,5 +326,141 @@ describe("analyzeForShadow — pg-topo diagnostics (lint)", () => {
         (d) => d.code === "CYCLE_DETECTED" || d.code === "PARSE_ERROR",
       ),
     ).toBe(false);
+  });
+});
+
+describe("kind pre-order (file-kind / statement-kind escalate)", () => {
+  test("policy-only aaa.sql / _cluster/aaa.sql sorts after CREATE TABLE", async () => {
+    const files = [
+      file(
+        "_cluster/aaa.sql",
+        "CREATE POLICY p ON public.t FOR ALL USING (true);",
+      ),
+      file("aaa.sql", "CREATE POLICY q ON public.t FOR ALL USING (true);"),
+      file("public/tables/t.sql", "CREATE TABLE public.t (id int);"),
+    ];
+    const analyzed = await analyzeForShadow(files);
+    const ordered = preorderFilesByKind(
+      files,
+      classesByFileFromAnalyzed(analyzed),
+    );
+    expect(ordered.map((f) => f.name)).toEqual([
+      "public/tables/t.sql",
+      "_cluster/aaa.sql",
+      "aaa.sql",
+    ]);
+  });
+
+  test("publication-only _cluster/publications.sql sorts after the table file", async () => {
+    const files = [
+      file(
+        "_cluster/publications.sql",
+        "ALTER PUBLICATION p ADD TABLE public.t;",
+      ),
+      file("public/tables/t.sql", "CREATE TABLE public.t (id int);"),
+    ];
+    const analyzed = await analyzeForShadow(files);
+    const ordered = preorderFilesByKind(
+      files,
+      classesByFileFromAnalyzed(analyzed),
+    );
+    expect(ordered.map((f) => f.name)).toEqual([
+      "public/tables/t.sql",
+      "_cluster/publications.sql",
+    ]);
+  });
+
+  test("mixed CREATE TABLE + CREATE POLICY is not forced last", async () => {
+    const files = [
+      file(
+        "public/tables/t.sql",
+        "CREATE TABLE public.t (id int);\nCREATE POLICY p ON public.t FOR ALL USING (true);",
+      ),
+      file("zzz.sql", "CREATE TABLE public.u (id int);"),
+    ];
+    const analyzed = await analyzeForShadow(files);
+    const ordered = preorderFilesByKind(
+      files,
+      classesByFileFromAnalyzed(analyzed),
+    );
+    expect(ordered.map((f) => f.name)).toEqual([
+      "public/tables/t.sql",
+      "zzz.sql",
+    ]);
+  });
+
+  test("filename last-resort only when a file has no classes", () => {
+    const files = [
+      file("_cluster/publications.sql", "-- unparsed"),
+      file("public/tables/t.sql", "-- unparsed"),
+    ];
+    const empty = new Map<string, string[]>();
+    expect(preorderFilesByKind(files, empty).map((f) => f.name)).toEqual([
+      "_cluster/publications.sql",
+      "public/tables/t.sql",
+    ]);
+    expect(
+      preorderFilesByKind(files, empty, { filenameFallback: true }).map(
+        (f) => f.name,
+      ),
+    ).toEqual(["public/tables/t.sql", "_cluster/publications.sql"]);
+  });
+
+  test("splitAndReorderFile puts CREATE TABLE before ALTER PUBLICATION", async () => {
+    const mixed = file(
+      "mixed.sql",
+      "ALTER PUBLICATION p ADD TABLE public.t;\nCREATE TABLE public.t (id int);",
+    );
+    const analyzed = await analyzeForShadow([mixed]);
+    const split = splitAndReorderFile(mixed, analyzed);
+    expect(
+      split.map((f) => f.sql.toLowerCase().replace(/\s+/g, " ").trim()),
+    ).toEqual([
+      "create table public.t (id int);",
+      "alter publication p add table public.t;",
+    ]);
+  });
+
+  test("splitAndReorderFile puts CREATE POLICY before ALTER PUBLICATION", async () => {
+    const mixed = file(
+      "mixed.sql",
+      "ALTER PUBLICATION p ADD TABLE public.t;\nCREATE POLICY q ON public.t FOR ALL USING (true);",
+    );
+    const analyzed = await analyzeForShadow([mixed]);
+    const split = splitAndReorderFile(mixed, analyzed);
+    expect(
+      split.map((f) => f.sql.toLowerCase().replace(/\s+/g, " ").trim()),
+    ).toEqual([
+      "create policy q on public.t for all using (true);",
+      "alter publication p add table public.t;",
+    ]);
+  });
+
+  test("splitAndReorderFile leaves the file intact when classify is incomplete", async () => {
+    const mixed = file(
+      "mixed.sql",
+      "CREATE TABLE public.t (id int);\nCREATE TABEL public.u (id int;",
+    );
+    const analyzed = await analyzeForShadow([mixed]);
+    expect(splitAndReorderFile(mixed, analyzed)).toEqual([mixed]);
+  });
+
+  test("splitAndReorderFile matches remainder statements exactly", async () => {
+    const full = file(
+      "schemas.sql",
+      "CREATE SCHEMA a;\nCREATE SCHEMA app;\nALTER PUBLICATION p ADD TABLE public.t;",
+    );
+    const analyzed = await analyzeForShadow([full]);
+    const remainder = file(
+      "schemas.sql",
+      "CREATE SCHEMA app;\nALTER PUBLICATION p ADD TABLE public.t;",
+    );
+    const split = splitAndReorderFile(remainder, analyzed);
+    expect(
+      split.map((f) => f.sql.toLowerCase().replace(/\s+/g, " ").trim()),
+    ).toEqual([
+      "create schema app;",
+      "alter publication p add table public.t;",
+    ]);
   });
 });

--- a/packages/pg-delta/src/frontends/sql-order.ts
+++ b/packages/pg-delta/src/frontends/sql-order.ts
@@ -17,10 +17,9 @@
  *   the WASM parser; only calling into this subpath does.
  *
  * Structural guarantees (D4):
- * - exactly one statement per output `SqlFile`, so the existing `loadSqlFiles`
- *   becomes statement-granular with zero core change;
- * - a zero-padded ordinal `name` prefix (`0007__schema/users.sql`) so the
- *   loader's per-round lexicographic `name` sort reproduces topo order;
+ * - exactly one statement per output `SqlFile`;
+ * - a zero-padded ordinal `name` prefix (`0007__schema/users.sql`) so a
+ *   caller that lex-sorts by name keeps topo order;
  * - every input statement preserved **exactly once** — including statements
  *   pg-topo classes as `UNKNOWN` and statements trapped in a cycle (pg-topo's
  *   `ordered` is a total order, so cycle members arrive at a best-effort
@@ -30,6 +29,7 @@
  */
 import type { AnalyzeOptions, ObjectRef, StatementId } from "@supabase/pg-topo";
 import type { SqlFile } from "./load-sql-files.ts";
+import { splitSqlStatements } from "./sql-format/format-utils.ts";
 
 /** Provenance back to the authored source, so a caller can render
  *  `schema/users.sql:line:col` after stripping the ordinal name prefix. */
@@ -237,10 +237,8 @@ export async function analyzeForShadow(
     };
   };
 
-  // zero-pad ordinals to a fixed width so lexicographic name sort == topo order
-  // even past 9 / 99 statements (the loader re-sorts `pending` by name each
-  // round). `ordered` is already a total order (pg-topo never drops a statement,
-  // including UNKNOWN classes and cycle members), so this is a 1:1 remap.
+  // zero-pad ordinals so a caller that lex-sorts by name keeps topo order
+  // past 9 / 99 statements. `ordered` is already a total order.
   const width = String(Math.max(ordered.length - 1, 0)).length;
   const orderedFiles: OrderedSqlFile[] = ordered.map((node, index) => {
     const provenance = toProvenance(node.id);
@@ -324,4 +322,110 @@ export async function orderForShadow(
 function parseInputIndex(filePath: string): number | null {
   const match = /^<input:(\d+)>$/.exec(filePath);
   return match ? Number.parseInt(match[1] as string, 10) : null;
+}
+
+/** pg-topo classes that need relations to exist (and can poison a session). */
+export const LATE_KIND_CLASSES: ReadonlySet<string> = new Set([
+  "CREATE_POLICY",
+  "ALTER_PUBLICATION",
+  "CREATE_SUBSCRIPTION",
+  "ALTER_SUBSCRIPTION",
+]);
+
+export function isLateKindClass(statementClass: string | undefined): boolean {
+  return statementClass !== undefined && LATE_KIND_CLASSES.has(statementClass);
+}
+
+/** Within the late band, policies before publication/subscription DDL. */
+function lateKindRank(statementClass: string | undefined): number {
+  if (!isLateKindClass(statementClass)) return 0;
+  if (statementClass === "CREATE_POLICY") return 1;
+  return 2;
+}
+
+export function classesByFileFromAnalyzed(
+  analyzed: ShadowOrderResult,
+): Map<string, string[]> {
+  const byFile = new Map<string, string[]>();
+  for (const file of analyzed.files) {
+    const path = file.provenance.filePath;
+    const list = byFile.get(path) ?? [];
+    if (file.statementClass !== undefined) {
+      list.push(file.statementClass);
+    }
+    byFile.set(path, list);
+  }
+  return byFile;
+}
+
+function filenameLateHint(name: string): boolean {
+  const base = (name.split(/[\\/]/).pop() ?? "").toLowerCase();
+  return base === "publications.sql" || base === "subscriptions.sql";
+}
+
+function fileIsLate(
+  name: string,
+  classesByFile: ReadonlyMap<string, readonly string[]>,
+  filenameFallback: boolean,
+): boolean {
+  const classes = classesByFile.get(name) ?? [];
+  const classified = classes.filter((c) => c !== "UNKNOWN");
+  if (classified.length > 0) {
+    return classified.every((c) => isLateKindClass(c));
+  }
+  return filenameFallback && filenameLateHint(name);
+}
+
+/** Stable two-band sort: late-kind-only files last. */
+export function preorderFilesByKind(
+  files: SqlFile[],
+  classesByFile: ReadonlyMap<string, readonly string[]>,
+  options: { filenameFallback?: boolean } = {},
+): SqlFile[] {
+  const filenameFallback = options.filenameFallback === true;
+  return files
+    .map((file, index) => ({ file, index }))
+    .sort((a, b) => {
+      const lateA = fileIsLate(a.file.name, classesByFile, filenameFallback);
+      const lateB = fileIsLate(b.file.name, classesByFile, filenameFallback);
+      if (lateA !== lateB) {
+        return lateA ? 1 : -1;
+      }
+      return a.index - b.index;
+    })
+    .map((entry) => entry.file);
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim().replace(/;$/, "");
+}
+
+/** Split one file (or a fallback remainder) into statement units, late-kind last. */
+export function splitAndReorderFile(
+  file: SqlFile,
+  analyzed: ShadowOrderResult,
+): SqlFile[] {
+  const remainderStmts = splitSqlStatements(file.sql);
+  const remainderUnits = new Set(
+    remainderStmts.map((stmt) => normalizeSql(stmt)),
+  );
+  const stmts = analyzed.files
+    .filter((f) => f.provenance.filePath === file.name)
+    .filter((f) => remainderUnits.has(normalizeSql(f.sql)))
+    .sort((a, b) => a.provenance.statementIndex - b.provenance.statementIndex);
+  if (stmts.length === 0 || stmts.length !== remainderStmts.length) {
+    return [file];
+  }
+  const ordered = [...stmts].sort((a, b) => {
+    const rankA = lateKindRank(a.statementClass);
+    const rankB = lateKindRank(b.statementClass);
+    if (rankA !== rankB) {
+      return rankA - rankB;
+    }
+    return a.provenance.statementIndex - b.provenance.statementIndex;
+  });
+  return ordered.map((stmt) => ({
+    name: `${file.name}#${stmt.provenance.statementIndex}`,
+    sql: stmt.sql,
+  }));
 }

--- a/packages/pg-delta/src/index.ts
+++ b/packages/pg-delta/src/index.ts
@@ -104,6 +104,7 @@ export {
 } from "./frontends/export-sql-files.ts";
 export { saveSnapshot, loadSnapshot } from "./frontends/snapshot-file.ts";
 export {
+  applyManifestLoadOrder,
   EXPORT_MANIFEST_FILE,
   readExportManifest,
   writeExportManifest,

--- a/packages/pg-delta/src/public-api.test.ts
+++ b/packages/pg-delta/src/public-api.test.ts
@@ -60,8 +60,12 @@ describe("public API surface", () => {
     // Supabase CLI adapter contract without flipping the library default.
     const options = {
       strictDataStatements: true,
+      connectionReuse: "reconnect-on-stuck",
+      reorderOnFailure: true,
     } satisfies LoadSqlFilesOptions;
     expect(options.strictDataStatements).toBe(true);
+    expect(options.connectionReuse).toBe("reconnect-on-stuck");
+    expect(options.reorderOnFailure).toBe(true);
   });
 
   test("the integrations subpath exposes the full profile surface", () => {

--- a/packages/pg-delta/tests/cli.test.ts
+++ b/packages/pg-delta/tests/cli.test.ts
@@ -1415,7 +1415,7 @@ describe("CLI: schema apply reorder safety", () => {
 
       // RED before the fix: the bad file is dropped, the shadow builds from the
       // good file only, and apply exits 0 — silently ignoring 02_bad.sql.
-      expect(res.stderr).toContain("reorder assist disabled");
+      expect(res.stderr).toMatch(/pg-topo could not parse/i);
       expect(res.exitCode).not.toBe(0);
     } finally {
       await Promise.all([shadow.drop(), target.drop()]);
@@ -1453,9 +1453,7 @@ describe("CLI: schema apply reorder safety", () => {
       ]);
 
       expect(res.exitCode).toBe(0);
-      // ADP present → reorder disabled, raw load, and the caveat is surfaced (no
-      // silent limitation): objects relying on ADP-implicit grants may miss them.
-      expect(res.stderr).toContain("reorder assist disabled");
+      expect(res.stderr).not.toContain("reorder assist disabled");
       expect(res.stderr).toMatch(
         /raw loading may apply ALTER DEFAULT PRIVILEGES AFTER objects/i,
       );
@@ -1538,8 +1536,7 @@ describe("CLI: schema apply reorder safety", () => {
       expect({ code: res.exitCode, stderr: res.stderr }).toMatchObject({
         code: 0,
       });
-      expect(res.stderr).toContain("reorder assist disabled");
-      expect(res.stderr).toContain("session-setting");
+      expect(res.stderr).not.toContain("reorder assist disabled");
       expect(res.stderr).not.toContain("Reordered into");
 
       const { rows } = await target.pool.query<{ n: number }>(

--- a/packages/pg-delta/tests/load-sql-files-reorder-on-failure.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-reorder-on-failure.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Stages 3–4: reorderOnFailure after default order sticks.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  loadSqlFiles,
+  ShadowLoadError,
+} from "../src/frontends/load-sql-files.ts";
+import {
+  analyzeForShadow,
+  classesByFileFromAnalyzed,
+  preorderFilesByKind,
+  splitAndReorderFile,
+} from "../src/frontends/sql-order.ts";
+import { createTestDb } from "./containers.ts";
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => null,
+    (error: unknown) => error,
+  );
+}
+
+const MIXED_ADD_THEN_TABLE = [
+  { name: "00_pub.sql", sql: "CREATE PUBLICATION p;" },
+  {
+    name: "01_mixed.sql",
+    sql: "ALTER PUBLICATION p ADD TABLE public.t;\nCREATE TABLE public.t (id integer);",
+  },
+];
+
+describe("loadSqlFiles — reorderOnFailure", () => {
+  test("statement-kind unblocks ADD-then-CREATE TABLE and warns", async () => {
+    const shadow = await createTestDb("rof_stmt");
+    try {
+      const analyzed = await analyzeForShadow(MIXED_ADD_THEN_TABLE);
+      const warnings: string[] = [];
+      let fileKindCalls = 0;
+      const result = await loadSqlFiles(MIXED_ADD_THEN_TABLE, shadow.pool, {
+        connectionReuse: "keep",
+        reorderOnFailure: true,
+        onWarning: (m) => warnings.push(m),
+        reorderFilesByKind: (pending) => {
+          fileKindCalls++;
+          return preorderFilesByKind(
+            pending,
+            classesByFileFromAnalyzed(analyzed),
+          );
+        },
+        splitFileByKind: (file) => splitAndReorderFile(file, analyzed),
+      });
+      expect(fileKindCalls).toBe(1);
+      expect(
+        result.factBase.has({ kind: "table", schema: "public", name: "t" }),
+      ).toBe(true);
+      expect(
+        result.diagnostics.some((d) => d.code === "reorder_on_failure"),
+      ).toBe(true);
+      expect(warnings.join("\n")).toMatch(/statement-kind|statement kind/i);
+      expect(warnings.join("\n")).toMatch(/tables/i);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("reorderOnFailure false stays stuck with no warning", async () => {
+    const shadow = await createTestDb("rof_off");
+    try {
+      const err = await captureError(
+        loadSqlFiles(MIXED_ADD_THEN_TABLE, shadow.pool, {
+          connectionReuse: "keep",
+          reorderOnFailure: false,
+        }),
+      );
+      expect(err).toBeInstanceOf(ShadowLoadError);
+      expect(
+        (err as ShadowLoadError).details.some(
+          (d) => d.code === "stuck_statement",
+        ),
+      ).toBe(true);
+      expect(
+        (err as ShadowLoadError).details.some(
+          (d) => d.code === "reorder_on_failure",
+        ),
+      ).toBe(false);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("caller order is preserved: table before publication is one round", async () => {
+    const shadow = await createTestDb("rof_order");
+    try {
+      let fileKindCalls = 0;
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "public/tables/t.sql",
+            sql: "CREATE TABLE public.t (id integer); CREATE PUBLICATION p;",
+          },
+          {
+            name: "_cluster/publications.sql",
+            sql: "ALTER PUBLICATION p ADD TABLE public.t;",
+          },
+        ],
+        shadow.pool,
+        {
+          connectionReuse: "keep",
+          reorderOnFailure: true,
+          reorderFilesByKind: (pending) => {
+            fileKindCalls++;
+            return pending;
+          },
+        },
+      );
+      expect(result.rounds).toBe(1);
+      expect(fileKindCalls).toBe(0);
+      expect(
+        result.diagnostics.some((d) => d.code === "reorder_on_failure"),
+      ).toBe(false);
+      expect(
+        result.factBase.has({ kind: "table", schema: "public", name: "t" }),
+      ).toBe(true);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+});

--- a/packages/pg-delta/tests/load-sql-files-session-pollution.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-session-pollution.test.ts
@@ -16,16 +16,29 @@ async function captureError(promise: Promise<unknown>): Promise<unknown> {
   );
 }
 
+/** PG 14 still grants CREATE on `public` to PUBLIC; a locked schema fails
+ *  SET ROLE the same way on every supported version. */
+async function lockSchemaForRole(
+  pool: { query: (sql: string) => Promise<unknown> },
+  role: string,
+  schema: string,
+): Promise<void> {
+  await pool.query(`CREATE ROLE ${role} NOLOGIN`);
+  await pool.query(`CREATE SCHEMA ${schema}`);
+  await pool.query(`REVOKE ALL ON SCHEMA ${schema} FROM PUBLIC`);
+  await pool.query(`REVOKE ALL ON SCHEMA ${schema} FROM ${role}`);
+}
+
 describe("loadSqlFiles — connectionReuse", () => {
   test("reconnect-on-stuck warns and finishes after SET ROLE pollution", async () => {
     const shadow = await createTestDb("pollute_reconnect");
     try {
-      await shadow.pool.query(`CREATE ROLE load_weak NOLOGIN`);
+      await lockSchemaForRole(shadow.pool, "load_weak", "locked");
       const warnings: string[] = [];
       const result = await loadSqlFiles(
         [
           { name: "00_set.sql", sql: "SET ROLE load_weak;" },
-          { name: "01_table.sql", sql: "CREATE TABLE public.t (id integer);" },
+          { name: "01_table.sql", sql: "CREATE TABLE locked.t (id integer);" },
         ],
         shadow.pool,
         {
@@ -35,7 +48,7 @@ describe("loadSqlFiles — connectionReuse", () => {
         },
       );
       expect(
-        result.factBase.has({ kind: "table", schema: "public", name: "t" }),
+        result.factBase.has({ kind: "table", schema: "locked", name: "t" }),
       ).toBe(true);
       expect(
         result.diagnostics.some((d) => d.code === "session_pollution"),
@@ -53,14 +66,14 @@ describe("loadSqlFiles — connectionReuse", () => {
   test("connectionReuse keep throws stuck without a second connect", async () => {
     const shadow = await createTestDb("pollute_keep");
     try {
-      await shadow.pool.query(`CREATE ROLE load_weak_keep NOLOGIN`);
+      await lockSchemaForRole(shadow.pool, "load_weak_keep", "locked");
       const err = await captureError(
         loadSqlFiles(
           [
             { name: "00_set.sql", sql: "SET ROLE load_weak_keep;" },
             {
               name: "01_table.sql",
-              sql: "CREATE TABLE public.t (id integer);",
+              sql: "CREATE TABLE locked.t (id integer);",
             },
           ],
           shadow.pool,

--- a/packages/pg-delta/tests/load-sql-files-session-pollution.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-session-pollution.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Reconnect-on-stuck: a committed SET ROLE pollutes the session the way
+ * ROLLBACK cannot undo. Stock Postgres — no supautils.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  loadSqlFiles,
+  ShadowLoadError,
+} from "../src/frontends/load-sql-files.ts";
+import { createTestDb } from "./containers.ts";
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => null,
+    (error: unknown) => error,
+  );
+}
+
+describe("loadSqlFiles — connectionReuse", () => {
+  test("reconnect-on-stuck warns and finishes after SET ROLE pollution", async () => {
+    const shadow = await createTestDb("pollute_reconnect");
+    try {
+      await shadow.pool.query(`CREATE ROLE load_weak NOLOGIN`);
+      const warnings: string[] = [];
+      const result = await loadSqlFiles(
+        [
+          { name: "00_set.sql", sql: "SET ROLE load_weak;" },
+          { name: "01_table.sql", sql: "CREATE TABLE public.t (id integer);" },
+        ],
+        shadow.pool,
+        {
+          connectionReuse: "reconnect-on-stuck",
+          reorderOnFailure: false,
+          onWarning: (m) => warnings.push(m),
+        },
+      );
+      expect(
+        result.factBase.has({ kind: "table", schema: "public", name: "t" }),
+      ).toBe(true);
+      expect(
+        result.diagnostics.some((d) => d.code === "session_pollution"),
+      ).toBe(true);
+      expect(warnings.join("\n")).toMatch(/session pollution/i);
+      expect(warnings.join("\n")).toContain(
+        "https://github.com/supabase/postgres/issues",
+      );
+    } finally {
+      await shadow.pool.query(`DROP ROLE IF EXISTS load_weak`).catch(() => {});
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("connectionReuse keep throws stuck without a second connect", async () => {
+    const shadow = await createTestDb("pollute_keep");
+    try {
+      await shadow.pool.query(`CREATE ROLE load_weak_keep NOLOGIN`);
+      const err = await captureError(
+        loadSqlFiles(
+          [
+            { name: "00_set.sql", sql: "SET ROLE load_weak_keep;" },
+            {
+              name: "01_table.sql",
+              sql: "CREATE TABLE public.t (id integer);",
+            },
+          ],
+          shadow.pool,
+          { connectionReuse: "keep", reorderOnFailure: false },
+        ),
+      );
+      expect(err).toBeInstanceOf(ShadowLoadError);
+      expect(
+        (err as ShadowLoadError).details.some(
+          (d) => d.code === "stuck_statement",
+        ),
+      ).toBe(true);
+      expect(
+        (err as ShadowLoadError).details.some(
+          (d) => d.code === "session_pollution",
+        ),
+      ).toBe(false);
+    } finally {
+      await shadow.pool
+        .query(`DROP ROLE IF EXISTS load_weak_keep`)
+        .catch(() => {});
+      await shadow.drop();
+    }
+  }, 60_000);
+
+  test("does not reconnect while another file in the round still makes progress", async () => {
+    const shadow = await createTestDb("pollute_progress");
+    try {
+      const warnings: string[] = [];
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "01_view.sql",
+            sql: "CREATE VIEW public.v AS SELECT id FROM public.t;",
+          },
+          {
+            name: "02_table.sql",
+            sql: "CREATE TABLE public.t (id integer PRIMARY KEY);",
+          },
+        ],
+        shadow.pool,
+        {
+          connectionReuse: "reconnect-on-stuck",
+          reorderOnFailure: false,
+          onWarning: (m) => warnings.push(m),
+        },
+      );
+      expect(
+        result.factBase.has({ kind: "view", schema: "public", name: "v" }),
+      ).toBe(true);
+      expect(warnings.some((w) => /session pollution/i.test(w))).toBe(false);
+      expect(
+        result.diagnostics.some((d) => d.code === "session_pollution"),
+      ).toBe(false);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+});

--- a/packages/pg-delta/tests/reorder-manifest-adp.test.ts
+++ b/packages/pg-delta/tests/reorder-manifest-adp.test.ts
@@ -1,23 +1,10 @@
 /**
- * Manifest-gated ADP-bail exemption for the reorder assist.
+ * Default load order vs mixed view-before-table.
  *
- * The assist normally disables itself when a directory contains ALTER DEFAULT
- * PRIVILEGES: ADP applies to objects created AFTER it in authored order, so for
- * a HAND-AUTHORED dir the authored interleaving is semantics the assist must
- * not change (moving the ADP wrongly grants/ungrants objects). But an EXPORTED
- * dir (`.pgdelta-export.json` manifest present) never relies on that — the
- * exporter emits explicit per-object REVOKE/GRANT for every object (enforced
- * invariant, pinned across objtypes by tests/export-fidelity.test.ts) — so ADP
- * position is irrelevant there and the assist can stay on.
- *
- * Fixture: one file whose statements are internally MIS-ORDERED (view before
- * its table). File-granular loading can never apply it (the whole file rolls
- * back every round), while the statement-granular assist reorders and
- * converges. A second file carries an ADP statement:
- *   - WITH the manifest → assist stays on → applies (the exemption);
- *   - WITHOUT the manifest → conservative bail → raw file load → stuck.
- *
- * Docker + @supabase/pg-topo (workspace sibling) required.
+ * A hand-authored dir with VIEW-then-TABLE in one file stays stuck: late-band
+ * escalate does not move CREATE VIEW after CREATE TABLE. An exported dir
+ * records loadOrder (table file before view file) so stage 1 converges
+ * without reorderOnFailure.
  */
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -27,12 +14,9 @@ import { cmdSchemaApply } from "../src/cli/commands/schema.ts";
 import { writeExportManifest } from "../src/frontends/export-manifest.ts";
 import { sharedCluster } from "./containers.ts";
 
-function writeFixture(withManifest: boolean): string {
+function writeHandAuthoredStuck(): string {
   const dir = mkdtempSync(join(tmpdir(), "pgdelta-manifest-adp-"));
   mkdirSync(dir, { recursive: true });
-  // internally mis-ordered: the view precedes the table it selects from, so
-  // an atomic whole-file apply fails every retry round; only the
-  // statement-granular reorder assist can converge this.
   writeFileSync(
     join(dir, "01_view_first.sql"),
     `CREATE VIEW public.v AS SELECT id FROM public.t;\n\n` +
@@ -42,18 +26,49 @@ function writeFixture(withManifest: boolean): string {
     join(dir, "02_default_privileges.sql"),
     `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO PUBLIC;\n`,
   );
-  if (withManifest) writeExportManifest(dir, { redactSecrets: true });
   return dir;
 }
 
-describe("reorder assist: manifest-gated ADP exemption", () => {
-  test("an exported dir (manifest) with ADP keeps the assist and converges", async () => {
+function writeExportedLoadOrder(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pgdelta-manifest-adp-exp-"));
+  mkdirSync(join(dir, "public", "tables"), { recursive: true });
+  mkdirSync(join(dir, "_cluster"), { recursive: true });
+  writeFileSync(
+    join(dir, "public", "tables", "t.sql"),
+    `CREATE TABLE public.t (id integer);\n`,
+  );
+  writeFileSync(
+    join(dir, "_cluster", "zzz_view.sql"),
+    `CREATE VIEW public.v AS SELECT id FROM public.t;\n`,
+  );
+  writeFileSync(
+    join(dir, "public", "default_privileges.sql"),
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO PUBLIC;\n`,
+  );
+  writeExportManifest(dir, {
+    redactSecrets: true,
+    files: [
+      "_cluster/zzz_view.sql",
+      "public/default_privileges.sql",
+      "public/tables/t.sql",
+    ],
+    loadOrder: [
+      "public/tables/t.sql",
+      "_cluster/zzz_view.sql",
+      "public/default_privileges.sql",
+    ],
+  });
+  return dir;
+}
+
+describe("reorder assist: export loadOrder vs hand-authored mixed file", () => {
+  test("an exported dir uses loadOrder and converges with ADP present", async () => {
     const cluster = await sharedCluster();
     const target = await cluster.createDb("manifadp_tgt");
     try {
       await cmdSchemaApply([
         "--dir",
-        writeFixture(true),
+        writeExportedLoadOrder(),
         "--target",
         target.uri,
         "--renames",
@@ -69,7 +84,7 @@ describe("reorder assist: manifest-gated ADP exemption", () => {
     }
   }, 120_000);
 
-  test("a hand-authored dir (no manifest) with ADP keeps the conservative bail", async () => {
+  test("a hand-authored dir with view-before-table in one file stays stuck", async () => {
     const cluster = await sharedCluster();
     const target = await cluster.createDb("manifadp_bail_tgt");
     try {
@@ -77,7 +92,7 @@ describe("reorder assist: manifest-gated ADP exemption", () => {
       try {
         await cmdSchemaApply([
           "--dir",
-          writeFixture(false),
+          writeHandAuthoredStuck(),
           "--target",
           target.uri,
           "--renames",
@@ -86,7 +101,6 @@ describe("reorder assist: manifest-gated ADP exemption", () => {
       } catch (e) {
         err = e;
       }
-      // bail → raw file-granular load → the mis-ordered file can never apply
       expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toMatch(/stuck|cannot apply/);
     } finally {


### PR DESCRIPTION
## Summary

- Shadow load tries **export `loadOrder`** (or caller/lex order) first — no eager pg-topo pre-sort.
- If that sticks: reconnect once (`session_pollution` warning), then `reorderOnFailure` file-kind and statement-kind (`reorder_on_failure` warning) so authors can fix the tree.
- `--no-reorder` / `reorder: false` still opts out of stages 3–4. View-before-table in one file stays stuck (late-band does not move `CREATE VIEW`).

## Test plan

- [x] `bun test src/frontends/sql-order.test.ts src/frontends/export-manifest.test.ts src/public-api.test.ts`
- [x] `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/load-sql-files-reorder-on-failure.test.ts tests/load-sql-files-session-pollution.test.ts tests/reorder-manifest-adp.test.ts`
- [x] `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts` (662/662)
- [x] `bun run format-and-lint:fix && bun run check-types && bun run knip`

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass