### PR TITLE
fix(pg-delta): put file and line on shadow-load assist warnings

### DIFF
--- a/.changeset/shadow-load-assist-context.md
+++ b/.changeset/shadow-load-assist-context.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Shorten shadow-load assist warnings and attach file, line, excerpt, and reorder predecessor on diagnostic context so callers can name the statement that failed then recovered.

--- a/.changeset/shadow-load-assist-context.md
+++ b/.changeset/shadow-load-assist-context.md
@@ -2,4 +2,4 @@
 "@supabase/pg-delta": patch
 ---
 
-Shorten shadow-load assist warnings and attach file, line, excerpt, and reorder predecessor on diagnostic context so callers can name the statement that failed then recovered.
+Shadow-load assist warnings name the stuck file:line, the statement to move (or a suggested loadOrder), and session-setting statements that poisoned the connection. The same text is emitted through `onWarning` and `loadDiagnostics`.

--- a/packages/pg-delta/src/frontends/index.ts
+++ b/packages/pg-delta/src/frontends/index.ts
@@ -10,6 +10,8 @@ export {
   type LoadSqlFilesOptions,
 } from "./load-sql-files.ts";
 
+export type { LoadAssistFailure, LoadAssistLocation } from "./load-assist.ts";
+
 export {
   exportSqlFiles,
   type ExportOptions,

--- a/packages/pg-delta/src/frontends/load-assist.test.ts
+++ b/packages/pg-delta/src/frontends/load-assist.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import {
+  compactSqlExcerpt,
+  formatAssistLocation,
+  formatReorderOnFailureMessage,
+  formatSessionPollutionMessage,
+  readLoadAssistFailures,
+  toLoadAssistContext,
+} from "./load-assist.ts";
+
+describe("load-assist formatters", () => {
+  test("statement-kind names the move and says loadOrder cannot fix it", () => {
+    const message = formatReorderOnFailureMessage("statement-kind", [
+      {
+        file: "01_mixed.sql",
+        line: 1,
+        excerpt: "ALTER PUBLICATION p ADD TABLE public.t;",
+        error: 'relation "t" does not exist',
+        after: {
+          file: "01_mixed.sql",
+          line: 2,
+          excerpt: "CREATE TABLE public.t (id integer);",
+        },
+      },
+    ]);
+    expect(message).toMatchInlineSnapshot(`
+      "Default load order stuck; reordered (statement-kind).
+        move 01_mixed.sql:1 ALTER PUBLICATION p ADD TABLE public.t;
+        after 01_mixed.sql:2 CREATE TABLE public.t (id integer);
+      loadOrder cannot fix same-file order — edit or split the file."
+    `);
+  });
+
+  test("cross-file after recommends loadOrder, not a same-file edit", () => {
+    const message = formatReorderOnFailureMessage("statement-kind", [
+      {
+        file: "_cluster/publications.sql",
+        line: 1,
+        excerpt: "ALTER PUBLICATION p ADD TABLE public.t;",
+        after: {
+          file: "public/tables/t.sql",
+          line: 1,
+          excerpt: "CREATE TABLE public.t (id integer);",
+        },
+      },
+    ]);
+    expect(message).toMatchInlineSnapshot(`
+      "Default load order stuck; reordered (statement-kind).
+        stuck _cluster/publications.sql:1 ALTER PUBLICATION p ADD TABLE public.t;
+        after public/tables/t.sql:1 CREATE TABLE public.t (id integer);
+      Set loadOrder on .pgdelta-export.json to put public/tables/t.sql before _cluster/publications.sql."
+    `);
+  });
+
+  test("file-kind lists stuck location and a concrete loadOrder", () => {
+    const message = formatReorderOnFailureMessage(
+      "file-kind",
+      [
+        {
+          file: "_cluster/publications.sql",
+          line: 1,
+          excerpt: "ALTER PUBLICATION p ADD TABLE public.t;",
+          after: {
+            file: "public/tables/t.sql",
+            line: 1,
+            excerpt: "CREATE TABLE public.t (id integer);",
+          },
+        },
+      ],
+      ["public/tables/t.sql", "_cluster/publications.sql"],
+    );
+    expect(message).toMatchInlineSnapshot(`
+      "Default load order stuck; reordered (file-kind).
+        stuck _cluster/publications.sql:1 ALTER PUBLICATION p ADD TABLE public.t;
+        after public/tables/t.sql:1 CREATE TABLE public.t (id integer);
+      Set loadOrder on .pgdelta-export.json: public/tables/t.sql, _cluster/publications.sql."
+    `);
+  });
+
+  test("session poisoning names the stuck statement and the earlier SET", () => {
+    const message = formatSessionPollutionMessage(
+      [
+        {
+          file: "01_table.sql",
+          line: 1,
+          excerpt: "CREATE TABLE locked.t (id integer);",
+          error: "permission denied for schema locked",
+        },
+      ],
+      [{ file: "00_set.sql", line: 1, excerpt: "SET ROLE load_weak;" }],
+    );
+    expect(message).toMatchInlineSnapshot(`
+      "New connection unblocked a stuck load (session poisoning).
+        stuck 01_table.sql:1 CREATE TABLE locked.t (id integer); (permission denied for schema locked)
+        earlier 00_set.sql:1 SET ROLE load_weak;
+      Remove session-setting statements from declarative SQL, or do not share that session with later DDL."
+    `);
+  });
+
+  test("toLoadAssistContext keeps after and error for callers", () => {
+    const context = toLoadAssistContext(
+      [
+        {
+          file: "mixed.sql",
+          line: 1,
+          excerpt: "ALTER PUBLICATION p ADD TABLE public.t;",
+          error: 'relation "t" does not exist',
+          after: {
+            file: "mixed.sql",
+            line: 2,
+            excerpt: "CREATE TABLE public.t;",
+          },
+        },
+      ],
+      { kind: "statement-kind" },
+    );
+    expect(context).toMatchInlineSnapshot(`
+      {
+        "failures": [
+          {
+            "after": {
+              "excerpt": "CREATE TABLE public.t;",
+              "file": "mixed.sql",
+              "line": 2,
+            },
+            "error": "relation "t" does not exist",
+            "excerpt": "ALTER PUBLICATION p ADD TABLE public.t;",
+            "file": "mixed.sql",
+            "line": 1,
+          },
+        ],
+        "files": [
+          "mixed.sql",
+        ],
+        "kind": "statement-kind",
+      }
+    `);
+    const roundTrip = readLoadAssistFailures(context["failures"]);
+    expect(roundTrip[0]?.after?.line).toBe(2);
+    expect(roundTrip[0]?.error).toContain("does not exist");
+  });
+
+  test("formatAssistLocation omits an invented line", () => {
+    expect(
+      formatAssistLocation({ file: "a.sql", excerpt: "CREATE TABLE t;" }),
+    ).toBe("a.sql CREATE TABLE t;");
+    expect(compactSqlExcerpt("CREATE   TABLE  t;")).toBe("CREATE TABLE t;");
+  });
+});

--- a/packages/pg-delta/src/frontends/load-assist.ts
+++ b/packages/pg-delta/src/frontends/load-assist.ts
@@ -1,0 +1,179 @@
+/**
+ * Shadow-load assist warnings: structured locations plus the user-facing
+ * copy that tells an author how to fix file order vs statement order vs
+ * session poisoning.
+ */
+
+export type LoadAssistLocation = {
+  file: string;
+  line?: number;
+  excerpt?: string;
+};
+
+export type LoadAssistFailure = LoadAssistLocation & {
+  error?: string;
+  after?: LoadAssistLocation;
+};
+
+export function compactSqlExcerpt(sql: string): string {
+  const text = sql.replace(/\s+/g, " ").trim();
+  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+}
+
+export function errorWithoutLocation(message: string): string {
+  const idx = message.lastIndexOf(" — at line ");
+  return idx === -1 ? message : message.slice(0, idx);
+}
+
+export function formatAssistLocation(loc: LoadAssistLocation): string {
+  const at = loc.line !== undefined ? `${loc.file}:${loc.line}` : loc.file;
+  return loc.excerpt !== undefined ? `${at} ${loc.excerpt}` : at;
+}
+
+function failureLine(failure: LoadAssistFailure, label: string): string {
+  const loc = formatAssistLocation(failure);
+  const err =
+    failure.error !== undefined && failure.error.length > 0
+      ? ` (${compactSqlExcerpt(failure.error)})`
+      : "";
+  return `  ${label} ${loc}${err}`;
+}
+
+function isSameFileMove(failure: LoadAssistFailure): boolean {
+  return failure.after !== undefined && failure.after.file === failure.file;
+}
+
+export function formatReorderOnFailureMessage(
+  kind: "file-kind" | "statement-kind",
+  failures: readonly LoadAssistFailure[],
+  suggestedLoadOrder?: readonly string[],
+): string {
+  const lines = [`Default load order stuck; reordered (${kind}).`];
+  let anySameFile = false;
+  let anyCrossFile = false;
+  for (const failure of failures) {
+    if (isSameFileMove(failure)) {
+      anySameFile = true;
+      lines.push(`  move ${formatAssistLocation(failure)}`);
+      lines.push(`  after ${formatAssistLocation(failure.after!)}`);
+    } else {
+      lines.push(failureLine(failure, "stuck"));
+      if (failure.after !== undefined) {
+        anyCrossFile = true;
+        lines.push(`  after ${formatAssistLocation(failure.after)}`);
+      }
+    }
+  }
+  if (anySameFile) {
+    lines.push(
+      "loadOrder cannot fix same-file order — edit or split the file.",
+    );
+  }
+  if (anyCrossFile || !anySameFile) {
+    if (suggestedLoadOrder !== undefined && suggestedLoadOrder.length > 0) {
+      lines.push(
+        `Set loadOrder on .pgdelta-export.json: ${suggestedLoadOrder.join(", ")}.`,
+      );
+    } else {
+      const first = failures.find(
+        (failure) =>
+          failure.after !== undefined && failure.after.file !== failure.file,
+      );
+      if (first?.after?.file !== undefined) {
+        lines.push(
+          `Set loadOrder on .pgdelta-export.json to put ${first.after.file} before ${first.file}.`,
+        );
+      } else if (!anySameFile) {
+        lines.push("Set loadOrder on .pgdelta-export.json.");
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+export function formatSessionPollutionMessage(
+  failures: readonly LoadAssistFailure[],
+  earlier: readonly LoadAssistLocation[] = [],
+): string {
+  const lines = ["New connection unblocked a stuck load (session poisoning)."];
+  for (const failure of failures) {
+    lines.push(failureLine(failure, "stuck"));
+  }
+  for (const loc of earlier) {
+    lines.push(`  earlier ${formatAssistLocation(loc)}`);
+  }
+  lines.push(
+    "Remove session-setting statements from declarative SQL, or do not share that session with later DDL.",
+  );
+  return lines.join("\n");
+}
+
+export function toLoadAssistContext(
+  failures: readonly LoadAssistFailure[],
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    files: [...new Set(failures.map((failure) => failure.file))],
+    failures: failures.map((failure) => ({
+      file: failure.file,
+      ...(failure.line !== undefined ? { line: failure.line } : {}),
+      ...(failure.excerpt !== undefined ? { excerpt: failure.excerpt } : {}),
+      ...(failure.error !== undefined ? { error: failure.error } : {}),
+      ...(failure.after !== undefined ? { after: failure.after } : {}),
+    })),
+    ...extra,
+  };
+}
+
+export function readLoadAssistFailures(value: unknown): LoadAssistFailure[] {
+  if (!Array.isArray(value)) return [];
+  const failures: LoadAssistFailure[] = [];
+  for (const item of value) {
+    if (typeof item !== "object" || item === null || !("file" in item)) {
+      continue;
+    }
+    if (typeof item.file !== "string") continue;
+    const afterRaw =
+      "after" in item && typeof item.after === "object" && item.after !== null
+        ? item.after
+        : undefined;
+    const after =
+      afterRaw !== undefined &&
+      "file" in afterRaw &&
+      typeof afterRaw.file === "string"
+        ? {
+            file: afterRaw.file,
+            ...("line" in afterRaw && typeof afterRaw.line === "number"
+              ? { line: afterRaw.line }
+              : {}),
+            ...("excerpt" in afterRaw && typeof afterRaw.excerpt === "string"
+              ? { excerpt: afterRaw.excerpt }
+              : {}),
+          }
+        : undefined;
+    failures.push({
+      file: item.file,
+      ...("line" in item && typeof item.line === "number"
+        ? { line: item.line }
+        : {}),
+      ...("excerpt" in item && typeof item.excerpt === "string"
+        ? { excerpt: item.excerpt }
+        : {}),
+      ...("error" in item && typeof item.error === "string"
+        ? { error: item.error }
+        : {}),
+      ...(after !== undefined ? { after } : {}),
+    });
+  }
+  return failures;
+}
+
+export function readStringList(value: unknown): string[] | undefined {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string")
+  ) {
+    return undefined;
+  }
+  return value;
+}

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -63,6 +63,15 @@ import {
 } from "../extract/extract.ts";
 import { notExtensionMember, USER_SCHEMA_FILTER } from "../extract/scope.ts";
 import { encodeId, type StableId } from "../core/stable-id.ts";
+import {
+  compactSqlExcerpt,
+  errorWithoutLocation,
+  formatReorderOnFailureMessage,
+  formatSessionPollutionMessage,
+  toLoadAssistContext,
+  type LoadAssistFailure,
+  type LoadAssistLocation,
+} from "./load-assist.ts";
 import { splitSqlStatements } from "./sql-format/format-utils.ts";
 
 /** SQLSTATE 25001 ("active_sql_transaction") — raised when a statement that
@@ -176,8 +185,14 @@ async function applyStatementFallback(
   sql: string,
 ): Promise<
   | { status: "done" }
-  | { status: "prefix"; remainder: string; error: unknown }
-  | { status: "none" }
+  | {
+      status: "prefix";
+      remainder: string;
+      error: unknown;
+      failedSql: string;
+      failedIndex: number;
+    }
+  | { status: "none"; failedSql?: string; failedIndex?: number }
 > {
   const stmts = splitSqlStatements(sql);
   if (stmts.length <= 1) return { status: "none" };
@@ -189,11 +204,19 @@ async function applyStatementFallback(
     return { status: "done" };
   } catch (error) {
     if (error instanceof ShadowLoadError) throw error;
-    if (i === 0) return { status: "none" };
+    if (i === 0) {
+      return {
+        status: "none",
+        failedSql: joinStatements([stmts[0]!]),
+        failedIndex: 0,
+      };
+    }
     return {
       status: "prefix",
       remainder: joinStatements(stmts.slice(i)),
       error,
+      failedSql: joinStatements([stmts[i]!]),
+      failedIndex: i,
     };
   }
 }
@@ -208,49 +231,88 @@ type LoadFailure = {
   file: SqlFile;
 } & DescribedFailure;
 
-function compactSqlExcerpt(sql: string): string {
-  const text = sql.replace(/\s+/g, " ").trim();
-  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+function lineAt(sql: string, offset: number): number {
+  return sql.slice(0, offset).split("\n").length;
 }
 
-function firstSqlExcerpt(sql: string): string | undefined {
-  const line = sql
-    .split("\n")
-    .map((part) => part.trim())
-    .find((part) => part.length > 0 && !part.startsWith("--"));
-  return line === undefined ? undefined : compactSqlExcerpt(line);
-}
-
-function statementContainingOffset(
+function locateAt(
   sql: string,
   offset: number,
-): string | undefined {
-  const stmts = splitSqlStatements(sql);
+  excerptSql?: string,
+): { line: number; excerpt: string } {
+  const line = lineAt(sql, offset);
+  if (excerptSql !== undefined) {
+    return { line, excerpt: compactSqlExcerpt(excerptSql) };
+  }
+  const lineStart = sql.slice(0, offset).lastIndexOf("\n") + 1;
+  const nl = sql.indexOf("\n", offset);
+  const lineText = sql.slice(lineStart, nl === -1 ? undefined : nl).trim();
+  return { line, excerpt: compactSqlExcerpt(lineText) };
+}
+
+function statementAtOffset(
+  sql: string,
+  stmts: readonly string[],
+  offset: number,
+): { start: number; text: string } | undefined {
   let searchFrom = 0;
   for (const stmt of stmts) {
     const start = sql.indexOf(stmt, searchFrom);
     if (start === -1) continue;
     const end = start + stmt.length;
-    if (offset >= start && offset < end) return compactSqlExcerpt(stmt);
+    if (offset >= start && offset < end) return { start, text: stmt };
     searchFrom = end;
   }
   return undefined;
 }
 
-function errorWithoutLocation(message: string): string {
-  const idx = message.lastIndexOf(" — at line ");
-  return idx === -1 ? message : message.slice(0, idx);
+function normalizeStmt(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim().replace(/;$/, "");
+}
+
+function occurrenceBefore(stmts: readonly string[], index: number): number {
+  const target = normalizeStmt(stmts[index] ?? "");
+  if (target.length === 0) return 0;
+  let seen = 0;
+  for (let i = 0; i < index; i++) {
+    if (normalizeStmt(stmts[i]!) === target) seen++;
+  }
+  return seen;
+}
+
+function indexOfStatement(
+  sql: string,
+  stmts: readonly string[],
+  statement: string,
+  occurrence = 0,
+): number {
+  const needle = normalizeStmt(statement);
+  if (needle.length === 0) return -1;
+  let seen = 0;
+  let searchFrom = 0;
+  for (const stmt of stmts) {
+    const start = sql.indexOf(stmt, searchFrom);
+    if (start === -1) continue;
+    if (normalizeStmt(stmt) === needle) {
+      if (seen === occurrence) return start;
+      seen++;
+    }
+    searchFrom = start + stmt.length;
+  }
+  return -1;
 }
 
 /**
- * Enrich a failed file's error with the offending statement's location. A file
- * is applied as ONE multi-statement query, so node-postgres sets `position` (a
- * 1-based character offset into the file's SQL) on the DatabaseError. Turn that
- * into an "at line N: <excerpt>" suffix so a stuck / non-converged load reports
- * WHICH statement failed inside a multi-statement file, not just the file name +
- * bare message. The position comes straight from PostgreSQL — no SQL parsing.
+ * Map a Postgres `position` (1-based, relative to the query that was sent)
+ * back to the authored file. Statement fallback sends one statement at a
+ * time, so `sentSql` may be a remainder or a single replayed statement.
  */
-function describeFileFailure(sql: string, error: unknown): DescribedFailure {
+function describeFileFailure(
+  sentSql: string,
+  error: unknown,
+  authoredSql?: string,
+  source?: { sql: string; failedIndex: number },
+): DescribedFailure {
   const base = error instanceof Error ? error.message : String(error);
   const raw = (error as { position?: unknown } | null)?.position;
   const pos =
@@ -259,24 +321,77 @@ function describeFileFailure(sql: string, error: unknown): DescribedFailure {
       : typeof raw === "number"
         ? raw
         : Number.NaN;
-  const fallback = firstSqlExcerpt(sql);
-  if (!Number.isFinite(pos) || pos < 1 || pos > sql.length) {
-    return fallback === undefined
-      ? { message: base }
-      : { message: base, line: 1, excerpt: fallback };
+  const authored = authoredSql ?? sentSql;
+  const authoredStmts = splitSqlStatements(authored);
+  const sentStmts =
+    sentSql === authored ? authoredStmts : splitSqlStatements(sentSql);
+  if (source !== undefined) {
+    const sourceStmts =
+      source.sql === authored ? authoredStmts : splitSqlStatements(source.sql);
+    const failed = sourceStmts[source.failedIndex];
+    if (failed !== undefined) {
+      const authoredStart = indexOfStatement(
+        authored,
+        authoredStmts,
+        failed,
+        occurrenceBefore(sourceStmts, source.failedIndex),
+      );
+      if (authoredStart >= 0) {
+        const loc = locateAt(authored, authoredStart, failed);
+        return {
+          message: `${base} — at line ${loc.line}: ${loc.excerpt}`,
+          line: loc.line,
+          excerpt: loc.excerpt,
+        };
+      }
+    }
   }
-  const before = sql.slice(0, pos - 1);
-  const line = before.split("\n").length;
-  const lineStart = before.lastIndexOf("\n") + 1;
-  const nl = sql.indexOf("\n", pos - 1);
-  const lineText = sql.slice(lineStart, nl === -1 ? undefined : nl).trim();
-  const excerpt =
-    statementContainingOffset(sql, pos - 1) ?? compactSqlExcerpt(lineText);
-  return {
-    message: `${base} — at line ${line}: ${excerpt}`,
-    line,
-    excerpt,
-  };
+  if (Number.isFinite(pos) && pos >= 1 && pos <= sentSql.length) {
+    const sentHit = statementAtOffset(sentSql, sentStmts, pos - 1);
+    if (authored !== sentSql && sentHit !== undefined) {
+      const authoredStart = indexOfStatement(
+        authored,
+        authoredStmts,
+        sentHit.text,
+      );
+      if (authoredStart >= 0) {
+        const inner = Math.max(0, pos - 1 - sentHit.start);
+        const loc = locateAt(authored, authoredStart + inner, sentHit.text);
+        return {
+          message: `${base} — at line ${loc.line}: ${loc.excerpt}`,
+          line: loc.line,
+          excerpt: loc.excerpt,
+        };
+      }
+    }
+    const loc = locateAt(sentSql, pos - 1, sentHit?.text);
+    return {
+      message: `${base} — at line ${loc.line}: ${loc.excerpt}`,
+      line: loc.line,
+      excerpt: loc.excerpt,
+    };
+  }
+  if (sentStmts.length === 1) {
+    const authoredStart = indexOfStatement(
+      authored,
+      authoredStmts,
+      sentStmts[0]!,
+    );
+    if (authoredStart >= 0) {
+      const loc = locateAt(authored, authoredStart, sentStmts[0]);
+      return {
+        message: `${base} — at line ${loc.line}: ${loc.excerpt}`,
+        line: loc.line,
+        excerpt: loc.excerpt,
+      };
+    }
+    return { message: base, excerpt: compactSqlExcerpt(sentStmts[0]!) };
+  }
+  if (authoredStmts.length === 1) {
+    const excerpt = compactSqlExcerpt(authoredStmts[0]!);
+    return { message: base, line: 1, excerpt };
+  }
+  return { message: base };
 }
 
 /**
@@ -810,6 +925,10 @@ export interface LoadSqlFilesOptions {
   reorderFilesByKind?: (files: SqlFile[]) => SqlFile[] | Promise<SqlFile[]>;
   /** Assist: split one file into kind-ordered statement units (stage 4). */
   splitFileByKind?: (file: SqlFile) => SqlFile[] | Promise<SqlFile[]>;
+  /** Attach `after` predecessors before assist warnings are emitted. */
+  enrichLoadAssistFailures?: (
+    failures: LoadAssistFailure[],
+  ) => LoadAssistFailure[];
 }
 
 /** `reorderOnFailure` wins when both aliases are set. Default true. */
@@ -822,25 +941,41 @@ export function resolveReorderOnFailure(options: {
   return true;
 }
 
-function sessionPollutionMessage(): string {
-  return "New connection unblocked a stuck load (session poisoning).";
+function toAssistFailures(
+  stuck: LoadFailure[],
+  enrich?: (failures: LoadAssistFailure[]) => LoadAssistFailure[],
+): LoadAssistFailure[] {
+  const failures: LoadAssistFailure[] = stuck.map((item) => ({
+    file: item.file.name,
+    ...(item.line !== undefined ? { line: item.line } : {}),
+    ...(item.excerpt !== undefined ? { excerpt: item.excerpt } : {}),
+    error: errorWithoutLocation(item.message),
+  }));
+  return enrich !== undefined ? enrich(failures) : failures;
 }
 
-function reorderOnFailureMessage(kind: "file-kind" | "statement-kind"): string {
-  return `Default load order stuck; reordered (${kind}). Set loadOrder on .pgdelta-export.json.`;
-}
-
-/** File/line/excerpt live on `context` so `onWarning` stays free of statement text. */
-function loadAssistContext(stuck: LoadFailure[]): Record<string, unknown> {
-  return {
-    files: [...new Set(stuck.map((f) => f.file.name))],
-    failures: stuck.map((f) => ({
-      file: f.file.name,
-      ...(f.line !== undefined ? { line: f.line } : {}),
-      ...(f.excerpt !== undefined ? { excerpt: f.excerpt } : {}),
-      error: errorWithoutLocation(f.message),
-    })),
-  };
+function persistentSessionSettingLocations(
+  file: SqlFile,
+): LoadAssistLocation[] {
+  if (findSessionSettingStatements(file.sql).length === 0) return [];
+  const locs: LoadAssistLocation[] = [];
+  let searchFrom = 0;
+  for (const stmt of splitSqlStatements(file.sql)) {
+    const start = file.sql.indexOf(stmt, searchFrom);
+    if (start === -1) continue;
+    searchFrom = start + stmt.length;
+    const leading = stmt.replace(/^\s+/, "");
+    if (/^set\s+local\b/i.test(leading) || /^reset\b/i.test(leading)) {
+      continue;
+    }
+    if (findSessionSettingStatements(stmt).length === 0) continue;
+    locs.push({
+      file: file.name,
+      line: lineAt(file.sql, start),
+      excerpt: compactSqlExcerpt(stmt),
+    });
+  }
+  return locs;
 }
 
 export async function loadSqlFiles(
@@ -974,6 +1109,14 @@ export async function loadSqlFiles(
 
   // Caller array order is the default (export loadOrder or lex collect).
   let pending = [...files];
+  const authoredSqlByName = new Map(files.map((file) => [file.name, file.sql]));
+  const appliedFiles: SqlFile[] = [];
+  const appliedNames = new Set<string>();
+  const recordApplied = (file: SqlFile): void => {
+    if (appliedNames.has(file.name)) return;
+    appliedNames.add(file.name);
+    appliedFiles.push(file);
+  };
   let rounds = 0;
   // body-validation warnings for SEEDED-schema routines (populated below,
   // outside the try/finally so the final result can merge them in).
@@ -999,6 +1142,7 @@ export async function loadSqlFiles(
   let fileKindTried = false;
   let statementKindTried = false;
   let failuresBeforeReconnect: LoadFailure[] = [];
+  let earlierSessionSettings: LoadAssistLocation[] = [];
   let failuresBeforeReorder: LoadFailure[] = [];
   let client: PoolClient = await shadow.connect();
   let clientOpen = true;
@@ -1073,11 +1217,27 @@ export async function loadSqlFiles(
       const failures: LoadFailure[] = [];
       const next: SqlFile[] = [];
       let progressed = false;
+      const recordFailure = (
+        target: SqlFile,
+        described: DescribedFailure,
+      ): void => {
+        const prev = failStreak.get(target.name);
+        failStreak.set(target.name, {
+          message: described.message,
+          count:
+            prev !== undefined && prev.message === described.message
+              ? prev.count + 1
+              : 1,
+        });
+        failures.push({ file: target, ...described });
+        next.push(target);
+      };
       for (const file of pending) {
         try {
           await applyFile(client, file.sql);
           progressed = true;
           failStreak.delete(file.name);
+          recordApplied(file);
         } catch (error) {
           // A ShadowLoadError from applyFile is a deterministic policy refusal
           // (mixed non-transactional file, or a non-allowlisted non-transactional
@@ -1090,6 +1250,7 @@ export async function loadSqlFiles(
           // would commit them alone and change where later DDL lands.
           // ALTER DEFAULT PRIVILEGES is the same: committing it early would
           // grant later objects created by sibling files.
+          let sentSql = file.sql;
           if (
             statementFallback &&
             findSessionSettingStatements(file.sql).length === 0 &&
@@ -1100,6 +1261,7 @@ export async function loadSqlFiles(
               progressed = true;
               splitFiles.add(file.name);
               failStreak.delete(file.name);
+              recordApplied(file);
               continue;
             }
             if (split.status === "prefix") {
@@ -1109,37 +1271,50 @@ export async function loadSqlFiles(
                 name: file.name,
                 sql: split.remainder,
               };
-              const described = describeFileFailure(remainder.sql, split.error);
-              const prev = failStreak.get(file.name);
-              failStreak.set(file.name, {
-                message: described.message,
-                count:
-                  prev !== undefined && prev.message === described.message
-                    ? prev.count + 1
-                    : 1,
-              });
-              failures.push({ file: remainder, ...described });
-              next.push(remainder);
+              recordFailure(
+                remainder,
+                describeFileFailure(
+                  split.failedSql,
+                  split.error,
+                  authoredSqlByName.get(file.name),
+                  { sql: file.sql, failedIndex: split.failedIndex },
+                ),
+              );
+              continue;
+            }
+            if (split.failedSql !== undefined) {
+              sentSql = split.failedSql;
+            }
+            if (split.failedIndex !== undefined) {
+              recordFailure(
+                file,
+                describeFileFailure(
+                  sentSql,
+                  error,
+                  authoredSqlByName.get(file.name),
+                  { sql: file.sql, failedIndex: split.failedIndex },
+                ),
+              );
               continue;
             }
           }
-          const described = describeFileFailure(file.sql, error);
-          const prev = failStreak.get(file.name);
-          failStreak.set(file.name, {
-            message: described.message,
-            count:
-              prev !== undefined && prev.message === described.message
-                ? prev.count + 1
-                : 1,
-          });
-          failures.push({ file, ...described });
-          next.push(file);
+          recordFailure(
+            file,
+            describeFileFailure(
+              sentSql,
+              error,
+              authoredSqlByName.get(file.name),
+            ),
+          );
         }
       }
       if (!progressed) {
         lastFailures = failures;
         if (connectionReuse === "reconnect-on-stuck" && !reconnected) {
           failuresBeforeReconnect = failures;
+          earlierSessionSettings = appliedFiles.flatMap(
+            persistentSessionSettingLocations,
+          );
           await releaseClient(true);
           client = await shadow.connect();
           clientOpen = true;
@@ -1209,12 +1384,16 @@ export async function loadSqlFiles(
         });
         if (fileKindTried || statementKindTried) {
           const kind = statementKindTried ? "statement-kind" : "file-kind";
-          const message = reorderOnFailureMessage(kind);
+          const assist = toAssistFailures(
+            failuresBeforeReorder,
+            options.enrichLoadAssistFailures,
+          );
+          const message = formatReorderOnFailureMessage(kind, assist);
           details.push({
             code: "reorder_on_failure",
             severity: "warning",
             message,
-            context: loadAssistContext(failuresBeforeReorder),
+            context: toLoadAssistContext(assist, { kind }),
           });
           options.onWarning?.(message);
         }
@@ -1231,23 +1410,47 @@ export async function loadSqlFiles(
     }
 
     if (reconnectUnblocked) {
-      const message = sessionPollutionMessage();
+      const assist = toAssistFailures(
+        failuresBeforeReconnect,
+        options.enrichLoadAssistFailures,
+      );
+      const message = formatSessionPollutionMessage(
+        assist,
+        earlierSessionSettings,
+      );
       stageDiagnostics.push({
         code: "session_pollution",
         severity: "warning",
         message,
-        context: loadAssistContext(failuresBeforeReconnect),
+        context: toLoadAssistContext(assist, {
+          earlier: earlierSessionSettings,
+        }),
       });
       options.onWarning?.(message);
     }
     if (fileKindTried || statementKindTried) {
       const kind = statementKindTried ? "statement-kind" : "file-kind";
-      const message = reorderOnFailureMessage(kind);
+      const assist = toAssistFailures(
+        failuresBeforeReorder,
+        options.enrichLoadAssistFailures,
+      );
+      const suggestedLoadOrder =
+        kind === "file-kind" && splitFiles.size === 0
+          ? appliedFiles.map((file) => file.name.split(/[\\/]/).join("/"))
+          : undefined;
+      const message = formatReorderOnFailureMessage(
+        kind,
+        assist,
+        suggestedLoadOrder,
+      );
       stageDiagnostics.push({
         code: "reorder_on_failure",
         severity: "warning",
         message,
-        context: loadAssistContext(failuresBeforeReorder),
+        context: toLoadAssistContext(assist, {
+          kind,
+          ...(suggestedLoadOrder !== undefined ? { suggestedLoadOrder } : {}),
+        }),
       });
       options.onWarning?.(message);
     }

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -198,6 +198,50 @@ async function applyStatementFallback(
   }
 }
 
+type DescribedFailure = {
+  message: string;
+  line?: number;
+  excerpt?: string;
+};
+
+type LoadFailure = {
+  file: SqlFile;
+} & DescribedFailure;
+
+function compactSqlExcerpt(sql: string): string {
+  const text = sql.replace(/\s+/g, " ").trim();
+  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+}
+
+function firstSqlExcerpt(sql: string): string | undefined {
+  const line = sql
+    .split("\n")
+    .map((part) => part.trim())
+    .find((part) => part.length > 0 && !part.startsWith("--"));
+  return line === undefined ? undefined : compactSqlExcerpt(line);
+}
+
+function statementContainingOffset(
+  sql: string,
+  offset: number,
+): string | undefined {
+  const stmts = splitSqlStatements(sql);
+  let searchFrom = 0;
+  for (const stmt of stmts) {
+    const start = sql.indexOf(stmt, searchFrom);
+    if (start === -1) continue;
+    const end = start + stmt.length;
+    if (offset >= start && offset < end) return compactSqlExcerpt(stmt);
+    searchFrom = end;
+  }
+  return undefined;
+}
+
+function errorWithoutLocation(message: string): string {
+  const idx = message.lastIndexOf(" — at line ");
+  return idx === -1 ? message : message.slice(0, idx);
+}
+
 /**
  * Enrich a failed file's error with the offending statement's location. A file
  * is applied as ONE multi-statement query, so node-postgres sets `position` (a
@@ -206,7 +250,7 @@ async function applyStatementFallback(
  * WHICH statement failed inside a multi-statement file, not just the file name +
  * bare message. The position comes straight from PostgreSQL — no SQL parsing.
  */
-function describeFileFailure(sql: string, error: unknown): string {
+function describeFileFailure(sql: string, error: unknown): DescribedFailure {
   const base = error instanceof Error ? error.message : String(error);
   const raw = (error as { position?: unknown } | null)?.position;
   const pos =
@@ -215,14 +259,24 @@ function describeFileFailure(sql: string, error: unknown): string {
       : typeof raw === "number"
         ? raw
         : Number.NaN;
-  if (!Number.isFinite(pos) || pos < 1 || pos > sql.length) return base;
+  const fallback = firstSqlExcerpt(sql);
+  if (!Number.isFinite(pos) || pos < 1 || pos > sql.length) {
+    return fallback === undefined
+      ? { message: base }
+      : { message: base, line: 1, excerpt: fallback };
+  }
   const before = sql.slice(0, pos - 1);
   const line = before.split("\n").length;
   const lineStart = before.lastIndexOf("\n") + 1;
   const nl = sql.indexOf("\n", pos - 1);
   const lineText = sql.slice(lineStart, nl === -1 ? undefined : nl).trim();
-  const excerpt = lineText.length > 80 ? `${lineText.slice(0, 80)}…` : lineText;
-  return `${base} — at line ${line}: ${excerpt}`;
+  const excerpt =
+    statementContainingOffset(sql, pos - 1) ?? compactSqlExcerpt(lineText);
+  return {
+    message: `${base} — at line ${line}: ${excerpt}`,
+    line,
+    excerpt,
+  };
 }
 
 /**
@@ -768,32 +822,25 @@ export function resolveReorderOnFailure(options: {
   return true;
 }
 
-function formatLoadFileNames(
-  failures: Array<{ file: SqlFile; message: string }>,
-): string {
-  return [...new Set(failures.map((f) => f.file.name))].join(", ");
+function sessionPollutionMessage(): string {
+  return "New connection unblocked a stuck load (session poisoning).";
 }
 
-function sessionPollutionMessage(
-  stuck: Array<{ file: SqlFile; message: string }>,
-): string {
-  return (
-    `A new connection unblocked a stuck same-connection shadow load (session pollution). ` +
-    `Stuck pending files: ${formatLoadFileNames(stuck)}. ` +
-    `Please open an issue at https://github.com/supabase/postgres/issues with the failed ALTER PUBLICATION and the follow-on CREATE POLICY / owner error.`
-  );
+function reorderOnFailureMessage(kind: "file-kind" | "statement-kind"): string {
+  return `Default load order stuck; reordered (${kind}). Set loadOrder on .pgdelta-export.json.`;
 }
 
-function reorderOnFailureMessage(
-  kind: "file-kind" | "statement-kind",
-  stuck: Array<{ file: SqlFile; message: string }>,
-): string {
-  return (
-    `The default file order stuck, so the loader reordered on failure (${kind}). ` +
-    `Stuck files: ${formatLoadFileNames(stuck)}. ` +
-    `You can permanently fix this by putting tables and extensions before policy-only and ALTER PUBLICATION files ` +
-    `(or by setting loadOrder on .pgdelta-export.json to that emission order) so the default order succeeds next time.`
-  );
+/** File/line/excerpt live on `context` so `onWarning` stays free of statement text. */
+function loadAssistContext(stuck: LoadFailure[]): Record<string, unknown> {
+  return {
+    files: [...new Set(stuck.map((f) => f.file.name))],
+    failures: stuck.map((f) => ({
+      file: f.file.name,
+      ...(f.line !== undefined ? { line: f.line } : {}),
+      ...(f.excerpt !== undefined ? { excerpt: f.excerpt } : {}),
+      error: errorWithoutLocation(f.message),
+    })),
+  };
 }
 
 export async function loadSqlFiles(
@@ -936,7 +983,7 @@ export async function loadSqlFiles(
   let stageDiagnostics: Diagnostic[] = [];
   // the most recent round's per-file failures, retained so a budget-exhaustion
   // error can report WHY each still-pending file failed (review P1 #2).
-  let lastFailures: Array<{ file: SqlFile; message: string }> = [];
+  let lastFailures: LoadFailure[] = [];
   // per-file count of CONSECUTIVE rounds a file failed with the SAME message, so
   // a stuck / non-converged error can say "failed identically in N round(s)" —
   // a file whose error never changes is a genuine missing dependency (or cycle),
@@ -951,8 +998,8 @@ export async function loadSqlFiles(
   let reconnectUnblocked = false;
   let fileKindTried = false;
   let statementKindTried = false;
-  let failuresBeforeReconnect: Array<{ file: SqlFile; message: string }> = [];
-  let failuresBeforeReorder: Array<{ file: SqlFile; message: string }> = [];
+  let failuresBeforeReconnect: LoadFailure[] = [];
+  let failuresBeforeReorder: LoadFailure[] = [];
   let client: PoolClient = await shadow.connect();
   let clientOpen = true;
   const releaseClient = async (discard = false): Promise<void> => {
@@ -1023,7 +1070,7 @@ export async function loadSqlFiles(
         );
       }
       rounds++;
-      const failures: Array<{ file: SqlFile; message: string }> = [];
+      const failures: LoadFailure[] = [];
       const next: SqlFile[] = [];
       let progressed = false;
       for (const file of pending) {
@@ -1062,30 +1109,30 @@ export async function loadSqlFiles(
                 name: file.name,
                 sql: split.remainder,
               };
-              const message = describeFileFailure(remainder.sql, split.error);
+              const described = describeFileFailure(remainder.sql, split.error);
               const prev = failStreak.get(file.name);
               failStreak.set(file.name, {
-                message,
+                message: described.message,
                 count:
-                  prev !== undefined && prev.message === message
+                  prev !== undefined && prev.message === described.message
                     ? prev.count + 1
                     : 1,
               });
-              failures.push({ file: remainder, message });
+              failures.push({ file: remainder, ...described });
               next.push(remainder);
               continue;
             }
           }
-          const message = describeFileFailure(file.sql, error);
+          const described = describeFileFailure(file.sql, error);
           const prev = failStreak.get(file.name);
           failStreak.set(file.name, {
-            message,
+            message: described.message,
             count:
-              prev !== undefined && prev.message === message
+              prev !== undefined && prev.message === described.message
                 ? prev.count + 1
                 : 1,
           });
-          failures.push({ file, message });
+          failures.push({ file, ...described });
           next.push(file);
         }
       }
@@ -1162,11 +1209,12 @@ export async function loadSqlFiles(
         });
         if (fileKindTried || statementKindTried) {
           const kind = statementKindTried ? "statement-kind" : "file-kind";
-          const message = reorderOnFailureMessage(kind, failuresBeforeReorder);
+          const message = reorderOnFailureMessage(kind);
           details.push({
             code: "reorder_on_failure",
             severity: "warning",
             message,
+            context: loadAssistContext(failuresBeforeReorder),
           });
           options.onWarning?.(message);
         }
@@ -1183,21 +1231,23 @@ export async function loadSqlFiles(
     }
 
     if (reconnectUnblocked) {
-      const message = sessionPollutionMessage(failuresBeforeReconnect);
+      const message = sessionPollutionMessage();
       stageDiagnostics.push({
         code: "session_pollution",
         severity: "warning",
         message,
+        context: loadAssistContext(failuresBeforeReconnect),
       });
       options.onWarning?.(message);
     }
     if (fileKindTried || statementKindTried) {
       const kind = statementKindTried ? "statement-kind" : "file-kind";
-      const message = reorderOnFailureMessage(kind, failuresBeforeReorder);
+      const message = reorderOnFailureMessage(kind);
       stageDiagnostics.push({
         code: "reorder_on_failure",
         severity: "warning",
         message,
+        context: loadAssistContext(failuresBeforeReorder),
       });
       options.onWarning?.(message);
     }

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -44,10 +44,12 @@ import { applyManifestLoadOrder } from "./export-manifest.ts";
 import { deriveAssumedSchemaSeed } from "./seed-assumed-schemas.ts";
 import {
   analyzeForShadow,
+  attachReorderPredecessors,
   classesByFileFromAnalyzed,
   preorderFilesByKind,
   ReorderUnavailableError,
   splitAndReorderFile,
+  type LoadAssistFailure,
   type OrderedSqlFile,
   type ShadowLoadCycle,
 } from "./sql-order.ts";
@@ -335,6 +337,54 @@ export interface PlanSchemaFilesOptions {
  *  each server again. */
 function majorOf(pgVersion: string): number {
   return Number.parseInt(pgVersion, 10);
+}
+
+function readLoadAssistFailures(value: unknown): LoadAssistFailure[] {
+  if (!Array.isArray(value)) return [];
+  const failures: LoadAssistFailure[] = [];
+  for (const item of value) {
+    if (typeof item !== "object" || item === null || !("file" in item)) {
+      continue;
+    }
+    if (typeof item.file !== "string") continue;
+    failures.push({
+      file: item.file,
+      ...("line" in item && typeof item.line === "number"
+        ? { line: item.line }
+        : {}),
+      ...("excerpt" in item && typeof item.excerpt === "string"
+        ? { excerpt: item.excerpt }
+        : {}),
+      ...("error" in item && typeof item.error === "string"
+        ? { error: item.error }
+        : {}),
+    });
+  }
+  return failures;
+}
+
+function enrichLoadAssistDiagnostics(
+  diagnostics: Diagnostic[],
+  analyzed: Awaited<ReturnType<typeof analyzeForShadow>> | null,
+  originalSqlByName: ReadonlyMap<string, string>,
+): Diagnostic[] {
+  if (analyzed === null) return diagnostics;
+  return diagnostics.map((diagnostic) => {
+    if (diagnostic.code !== "reorder_on_failure") return diagnostic;
+    const failures = readLoadAssistFailures(diagnostic.context?.["failures"]);
+    if (failures.length === 0) return diagnostic;
+    return {
+      ...diagnostic,
+      context: {
+        ...diagnostic.context,
+        failures: attachReorderPredecessors(
+          failures,
+          analyzed,
+          originalSqlByName,
+        ),
+      },
+    };
+  });
 }
 
 export interface PlanSchemaFilesResult {
@@ -735,7 +785,11 @@ export async function planSchemaFiles(
 
   return {
     plan: thePlan,
-    loadDiagnostics: loadResult.diagnostics,
+    loadDiagnostics: enrichLoadAssistDiagnostics(
+      loadResult.diagnostics,
+      analyzed,
+      originalSqlByName,
+    ),
     targetDiagnostics: targetResult.diagnostics,
     driftDiagnostics,
     skipped: prepared.skipped,

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -49,7 +49,6 @@ import {
   preorderFilesByKind,
   ReorderUnavailableError,
   splitAndReorderFile,
-  type LoadAssistFailure,
   type OrderedSqlFile,
   type ShadowLoadCycle,
 } from "./sql-order.ts";
@@ -337,54 +336,6 @@ export interface PlanSchemaFilesOptions {
  *  each server again. */
 function majorOf(pgVersion: string): number {
   return Number.parseInt(pgVersion, 10);
-}
-
-function readLoadAssistFailures(value: unknown): LoadAssistFailure[] {
-  if (!Array.isArray(value)) return [];
-  const failures: LoadAssistFailure[] = [];
-  for (const item of value) {
-    if (typeof item !== "object" || item === null || !("file" in item)) {
-      continue;
-    }
-    if (typeof item.file !== "string") continue;
-    failures.push({
-      file: item.file,
-      ...("line" in item && typeof item.line === "number"
-        ? { line: item.line }
-        : {}),
-      ...("excerpt" in item && typeof item.excerpt === "string"
-        ? { excerpt: item.excerpt }
-        : {}),
-      ...("error" in item && typeof item.error === "string"
-        ? { error: item.error }
-        : {}),
-    });
-  }
-  return failures;
-}
-
-function enrichLoadAssistDiagnostics(
-  diagnostics: Diagnostic[],
-  analyzed: Awaited<ReturnType<typeof analyzeForShadow>> | null,
-  originalSqlByName: ReadonlyMap<string, string>,
-): Diagnostic[] {
-  if (analyzed === null) return diagnostics;
-  return diagnostics.map((diagnostic) => {
-    if (diagnostic.code !== "reorder_on_failure") return diagnostic;
-    const failures = readLoadAssistFailures(diagnostic.context?.["failures"]);
-    if (failures.length === 0) return diagnostic;
-    return {
-      ...diagnostic,
-      context: {
-        ...diagnostic.context,
-        failures: attachReorderPredecessors(
-          failures,
-          analyzed,
-          originalSqlByName,
-        ),
-      },
-    };
-  });
 }
 
 export interface PlanSchemaFilesResult {
@@ -712,6 +663,8 @@ export async function planSchemaFiles(
         : {}),
       ...(analyzed !== null
         ? {
+            enrichLoadAssistFailures: (failures) =>
+              attachReorderPredecessors(failures, analyzed, originalSqlByName),
             reorderFilesByKind: (pending: SqlFile[]) =>
               preorderFilesByKind(
                 pending,
@@ -785,11 +738,7 @@ export async function planSchemaFiles(
 
   return {
     plan: thePlan,
-    loadDiagnostics: enrichLoadAssistDiagnostics(
-      loadResult.diagnostics,
-      analyzed,
-      originalSqlByName,
-    ),
+    loadDiagnostics: loadResult.diagnostics,
     targetDiagnostics: targetResult.diagnostics,
     driftDiagnostics,
     skipped: prepared.skipped,

--- a/packages/pg-delta/src/frontends/sql-order.test.ts
+++ b/packages/pg-delta/src/frontends/sql-order.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, test } from "bun:test";
 import {
   __setPgTopoImporterForTests,
   analyzeForShadow,
+  attachReorderPredecessors,
   canReorder,
   classesByFileFromAnalyzed,
   orderForShadow,
@@ -443,6 +444,33 @@ describe("kind pre-order (file-kind / statement-kind escalate)", () => {
     );
     const analyzed = await analyzeForShadow([mixed]);
     expect(splitAndReorderFile(mixed, analyzed)).toEqual([mixed]);
+  });
+
+  test("attachReorderPredecessors points ALTER PUBLICATION at the prior CREATE TABLE", async () => {
+    const earlier = file("other.sql", "CREATE TABLE public.u (id int);");
+    const mixed = file(
+      "mixed.sql",
+      "ALTER PUBLICATION p ADD TABLE public.t;\nCREATE TABLE public.t (id int);",
+    );
+    const analyzed = await analyzeForShadow([earlier, mixed]);
+    const [enriched] = attachReorderPredecessors(
+      [
+        {
+          file: "mixed.sql",
+          line: 1,
+          excerpt: "ALTER PUBLICATION p ADD TABLE public.t;",
+        },
+      ],
+      analyzed,
+      new Map([
+        [earlier.name, earlier.sql],
+        [mixed.name, mixed.sql],
+      ]),
+    );
+    expect(enriched?.after?.file).toBe("mixed.sql");
+    expect(enriched?.after?.line).toBe(2);
+    expect(enriched?.after?.excerpt?.toLowerCase()).toContain("create table");
+    expect(enriched?.after?.file).not.toBe("other.sql");
   });
 
   test("splitAndReorderFile matches remainder statements exactly", async () => {

--- a/packages/pg-delta/src/frontends/sql-order.test.ts
+++ b/packages/pg-delta/src/frontends/sql-order.test.ts
@@ -473,6 +473,48 @@ describe("kind pre-order (file-kind / statement-kind escalate)", () => {
     expect(enriched?.after?.file).not.toBe("other.sql");
   });
 
+  test("attachReorderPredecessors omits after when the statement cannot be matched", async () => {
+    const mixed = file(
+      "mixed.sql",
+      "CREATE TABLE public.t (id int);\nALTER PUBLICATION p ADD TABLE public.t;",
+    );
+    const analyzed = await analyzeForShadow([mixed]);
+    const [enriched] = attachReorderPredecessors(
+      [{ file: "mixed.sql", line: 99, excerpt: "CREATE WIDGET no.such;" }],
+      analyzed,
+      new Map([[mixed.name, mixed.sql]]),
+    );
+    expect(enriched?.after).toBeUndefined();
+  });
+
+  test("attachReorderPredecessors names the other file for a late ALTER PUBLICATION", async () => {
+    const table = file(
+      "public/tables/t.sql",
+      "CREATE TABLE public.t (id int);",
+    );
+    const pub = file(
+      "_cluster/publications.sql",
+      "ALTER PUBLICATION p ADD TABLE public.t;",
+    );
+    const analyzed = await analyzeForShadow([pub, table]);
+    const [enriched] = attachReorderPredecessors(
+      [
+        {
+          file: "_cluster/publications.sql",
+          line: 1,
+          excerpt: "ALTER PUBLICATION p ADD TABLE public.t;",
+        },
+      ],
+      analyzed,
+      new Map([
+        [table.name, table.sql],
+        [pub.name, pub.sql],
+      ]),
+    );
+    expect(enriched?.after?.file).toBe("public/tables/t.sql");
+    expect(enriched?.after?.excerpt?.toLowerCase()).toContain("create table");
+  });
+
   test("splitAndReorderFile matches remainder statements exactly", async () => {
     const full = file(
       "schemas.sql",

--- a/packages/pg-delta/src/frontends/sql-order.ts
+++ b/packages/pg-delta/src/frontends/sql-order.ts
@@ -400,6 +400,101 @@ function normalizeSql(sql: string): string {
   return sql.replace(/\s+/g, " ").trim().replace(/;$/, "");
 }
 
+export type LoadAssistLocation = {
+  file: string;
+  line?: number;
+  excerpt?: string;
+};
+
+export type LoadAssistFailure = LoadAssistLocation & {
+  error?: string;
+  after?: LoadAssistLocation;
+};
+
+function compactAssistExcerpt(sql: string): string {
+  const text = sql.replace(/\s+/g, " ").trim();
+  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+}
+
+function lineOfUnit(
+  originalSql: string | undefined,
+  unit: OrderedSqlFile,
+): number | undefined {
+  if (originalSql === undefined) return undefined;
+  if (unit.provenance.sourceOffset !== undefined) {
+    return originalSql.slice(0, unit.provenance.sourceOffset).split("\n")
+      .length;
+  }
+  const idx = originalSql.indexOf(unit.sql.trim());
+  if (idx < 0) return undefined;
+  return originalSql.slice(0, idx).split("\n").length;
+}
+
+function locationOfUnit(
+  unit: OrderedSqlFile,
+  originalSqlByName: ReadonlyMap<string, string>,
+): LoadAssistLocation {
+  const file = unit.provenance.filePath;
+  const line = lineOfUnit(originalSqlByName.get(file), unit);
+  const excerpt = compactAssistExcerpt(unit.sql);
+  return line === undefined ? { file, excerpt } : { file, line, excerpt };
+}
+
+function matchFailedUnit(
+  analyzed: ShadowOrderResult,
+  failure: LoadAssistFailure,
+  originalSql: string | undefined,
+): OrderedSqlFile | undefined {
+  const units = analyzed.files.filter(
+    (file) => file.provenance.filePath === failure.file,
+  );
+  if (units.length === 0) return undefined;
+  if (failure.excerpt !== undefined) {
+    const needle = normalizeSql(failure.excerpt.replace(/…$/, ""));
+    const hit = units.find((unit) => {
+      const hay = normalizeSql(unit.sql);
+      return hay.includes(needle) || needle.includes(hay);
+    });
+    if (hit !== undefined) return hit;
+  }
+  if (failure.line !== undefined) {
+    const hit = units.find(
+      (unit) => lineOfUnit(originalSql, unit) === failure.line,
+    );
+    if (hit !== undefined) return hit;
+  }
+  return [...units].sort(
+    (a, b) => a.provenance.statementIndex - b.provenance.statementIndex,
+  )[0];
+}
+
+/** Point a stuck statement at the topo statement that should run before it. */
+export function attachReorderPredecessors(
+  failures: readonly LoadAssistFailure[],
+  analyzed: ShadowOrderResult,
+  originalSqlByName: ReadonlyMap<string, string>,
+): LoadAssistFailure[] {
+  return failures.map((failure) => {
+    const unit = matchFailedUnit(
+      analyzed,
+      failure,
+      originalSqlByName.get(failure.file),
+    );
+    if (unit === undefined) return failure;
+    const index = analyzed.files.indexOf(unit);
+    if (index <= 0) return failure;
+    const sameFileBefore = analyzed.files
+      .slice(0, index)
+      .filter((file) => file.provenance.filePath === unit.provenance.filePath);
+    const predecessor = sameFileBefore.at(-1) ?? analyzed.files[index - 1];
+    if (predecessor === undefined) return failure;
+    return {
+      ...failure,
+      after: locationOfUnit(predecessor, originalSqlByName),
+    };
+  });
+}
+
 /** Split one file (or a fallback remainder) into statement units, late-kind last. */
 export function splitAndReorderFile(
   file: SqlFile,

--- a/packages/pg-delta/src/frontends/sql-order.ts
+++ b/packages/pg-delta/src/frontends/sql-order.ts
@@ -29,6 +29,11 @@
  */
 import type { AnalyzeOptions, ObjectRef, StatementId } from "@supabase/pg-topo";
 import type { SqlFile } from "./load-sql-files.ts";
+import {
+  compactSqlExcerpt,
+  type LoadAssistFailure,
+  type LoadAssistLocation,
+} from "./load-assist.ts";
 import { splitSqlStatements } from "./sql-format/format-utils.ts";
 
 /** Provenance back to the authored source, so a caller can render
@@ -400,22 +405,6 @@ function normalizeSql(sql: string): string {
   return sql.replace(/\s+/g, " ").trim().replace(/;$/, "");
 }
 
-export type LoadAssistLocation = {
-  file: string;
-  line?: number;
-  excerpt?: string;
-};
-
-export type LoadAssistFailure = LoadAssistLocation & {
-  error?: string;
-  after?: LoadAssistLocation;
-};
-
-function compactAssistExcerpt(sql: string): string {
-  const text = sql.replace(/\s+/g, " ").trim();
-  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
-}
-
 function lineOfUnit(
   originalSql: string | undefined,
   unit: OrderedSqlFile,
@@ -436,7 +425,7 @@ function locationOfUnit(
 ): LoadAssistLocation {
   const file = unit.provenance.filePath;
   const line = lineOfUnit(originalSqlByName.get(file), unit);
-  const excerpt = compactAssistExcerpt(unit.sql);
+  const excerpt = compactSqlExcerpt(unit.sql);
   return line === undefined ? { file, excerpt } : { file, line, excerpt };
 }
 
@@ -463,9 +452,7 @@ function matchFailedUnit(
     );
     if (hit !== undefined) return hit;
   }
-  return [...units].sort(
-    (a, b) => a.provenance.statementIndex - b.provenance.statementIndex,
-  )[0];
+  return undefined;
 }
 
 /** Point a stuck statement at the topo statement that should run before it. */

--- a/packages/pg-delta/src/index.ts
+++ b/packages/pg-delta/src/index.ts
@@ -97,6 +97,10 @@ export {
   type LoadResult,
   type LoadSqlFilesOptions,
 } from "./frontends/load-sql-files.ts";
+export type {
+  LoadAssistFailure,
+  LoadAssistLocation,
+} from "./frontends/load-assist.ts";
 export {
   exportSqlFiles,
   type ExportOptions,

--- a/packages/pg-delta/src/public-api.test.ts
+++ b/packages/pg-delta/src/public-api.test.ts
@@ -54,6 +54,8 @@ describe("public API surface", () => {
       "utf-8",
     );
     expect(frontendSrc).toContain("type LoadSqlFilesOptions");
+    expect(src).toContain("LoadAssistFailure");
+    expect(frontendSrc).toContain("LoadAssistFailure");
 
     // Named type for the loadSqlFiles third argument. Pinning
     // `strictDataStatements: true` is valid and documents the schema-first /

--- a/packages/pg-delta/tests/load-sql-files-reorder-on-failure.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-reorder-on-failure.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/frontends/load-sql-files.ts";
 import {
   analyzeForShadow,
+  attachReorderPredecessors,
   classesByFileFromAnalyzed,
   preorderFilesByKind,
   splitAndReorderFile,
@@ -34,12 +35,17 @@ describe("loadSqlFiles — reorderOnFailure", () => {
     const shadow = await createTestDb("rof_stmt");
     try {
       const analyzed = await analyzeForShadow(MIXED_ADD_THEN_TABLE);
+      const originalSqlByName = new Map(
+        MIXED_ADD_THEN_TABLE.map((file) => [file.name, file.sql]),
+      );
       const warnings: string[] = [];
       let fileKindCalls = 0;
       const result = await loadSqlFiles(MIXED_ADD_THEN_TABLE, shadow.pool, {
         connectionReuse: "keep",
         reorderOnFailure: true,
         onWarning: (m) => warnings.push(m),
+        enrichLoadAssistFailures: (failures) =>
+          attachReorderPredecessors(failures, analyzed, originalSqlByName),
         reorderFilesByKind: (pending) => {
           fileKindCalls++;
           return preorderFilesByKind(
@@ -59,12 +65,34 @@ describe("loadSqlFiles — reorderOnFailure", () => {
       const reorder = result.diagnostics.find(
         (d) => d.code === "reorder_on_failure",
       );
-      expect(reorder?.message).toMatch(/statement-kind/);
-      expect(reorder?.message).toMatch(/loadOrder/);
-      expect(warnings.join("\n")).toMatch(/statement-kind/);
-      expect(warnings.join("\n")).not.toContain("ALTER PUBLICATION");
-      const failures = reorder?.context?.["failures"];
-      expect(Array.isArray(failures) && failures.length > 0).toBe(true);
+      expect(reorder?.message).toMatchInlineSnapshot(`
+        "Default load order stuck; reordered (statement-kind).
+          move 01_mixed.sql:1 ALTER PUBLICATION p ADD TABLE public.t
+          after 01_mixed.sql:2 CREATE TABLE public.t (id integer);
+        loadOrder cannot fix same-file order — edit or split the file."
+      `);
+      expect(warnings.join("\n")).toEqual(reorder?.message ?? "");
+      expect(reorder?.context).toMatchInlineSnapshot(`
+        {
+          "failures": [
+            {
+              "after": {
+                "excerpt": "CREATE TABLE public.t (id integer);",
+                "file": "01_mixed.sql",
+                "line": 2,
+              },
+              "error": "relation "public.t" does not exist",
+              "excerpt": "ALTER PUBLICATION p ADD TABLE public.t",
+              "file": "01_mixed.sql",
+              "line": 1,
+            },
+          ],
+          "files": [
+            "01_mixed.sql",
+          ],
+          "kind": "statement-kind",
+        }
+      `);
     } finally {
       await shadow.drop();
     }

--- a/packages/pg-delta/tests/load-sql-files-reorder-on-failure.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-reorder-on-failure.test.ts
@@ -56,8 +56,15 @@ describe("loadSqlFiles — reorderOnFailure", () => {
       expect(
         result.diagnostics.some((d) => d.code === "reorder_on_failure"),
       ).toBe(true);
-      expect(warnings.join("\n")).toMatch(/statement-kind|statement kind/i);
-      expect(warnings.join("\n")).toMatch(/tables/i);
+      const reorder = result.diagnostics.find(
+        (d) => d.code === "reorder_on_failure",
+      );
+      expect(reorder?.message).toMatch(/statement-kind/);
+      expect(reorder?.message).toMatch(/loadOrder/);
+      expect(warnings.join("\n")).toMatch(/statement-kind/);
+      expect(warnings.join("\n")).not.toContain("ALTER PUBLICATION");
+      const failures = reorder?.context?.["failures"];
+      expect(Array.isArray(failures) && failures.length > 0).toBe(true);
     } finally {
       await shadow.drop();
     }

--- a/packages/pg-delta/tests/load-sql-files-session-pollution.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-session-pollution.test.ts
@@ -56,12 +56,35 @@ describe("loadSqlFiles — connectionReuse", () => {
       const pollution = result.diagnostics.find(
         (d) => d.code === "session_pollution",
       );
-      expect(pollution?.message).toMatch(/session poisoning/i);
-      expect(pollution?.message).not.toContain("github.com");
-      const failures = pollution?.context?.["failures"];
-      expect(Array.isArray(failures) && failures.length > 0).toBe(true);
-      expect(warnings.join("\n")).toMatch(/session poisoning/i);
-      expect(warnings.join("\n")).not.toContain("CREATE TABLE");
+      expect(pollution?.message).toMatchInlineSnapshot(`
+        "New connection unblocked a stuck load (session poisoning).
+          stuck 01_table.sql:1 CREATE TABLE locked.t (id integer) (permission denied for schema locked)
+          earlier 00_set.sql:1 SET ROLE load_weak
+        Remove session-setting statements from declarative SQL, or do not share that session with later DDL."
+      `);
+      expect(warnings.join("\n")).toEqual(pollution?.message ?? "");
+      expect(pollution?.context).toMatchInlineSnapshot(`
+        {
+          "earlier": [
+            {
+              "excerpt": "SET ROLE load_weak",
+              "file": "00_set.sql",
+              "line": 1,
+            },
+          ],
+          "failures": [
+            {
+              "error": "permission denied for schema locked",
+              "excerpt": "CREATE TABLE locked.t (id integer)",
+              "file": "01_table.sql",
+              "line": 1,
+            },
+          ],
+          "files": [
+            "01_table.sql",
+          ],
+        }
+      `);
     } finally {
       await shadow.pool.query(`DROP ROLE IF EXISTS load_weak`).catch(() => {});
       await shadow.drop();

--- a/packages/pg-delta/tests/load-sql-files-session-pollution.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-session-pollution.test.ts
@@ -53,10 +53,15 @@ describe("loadSqlFiles — connectionReuse", () => {
       expect(
         result.diagnostics.some((d) => d.code === "session_pollution"),
       ).toBe(true);
-      expect(warnings.join("\n")).toMatch(/session pollution/i);
-      expect(warnings.join("\n")).toContain(
-        "https://github.com/supabase/postgres/issues",
+      const pollution = result.diagnostics.find(
+        (d) => d.code === "session_pollution",
       );
+      expect(pollution?.message).toMatch(/session poisoning/i);
+      expect(pollution?.message).not.toContain("github.com");
+      const failures = pollution?.context?.["failures"];
+      expect(Array.isArray(failures) && failures.length > 0).toBe(true);
+      expect(warnings.join("\n")).toMatch(/session poisoning/i);
+      expect(warnings.join("\n")).not.toContain("CREATE TABLE");
     } finally {
       await shadow.pool.query(`DROP ROLE IF EXISTS load_weak`).catch(() => {});
       await shadow.drop();
@@ -124,7 +129,7 @@ describe("loadSqlFiles — connectionReuse", () => {
       expect(
         result.factBase.has({ kind: "view", schema: "public", name: "v" }),
       ).toBe(true);
-      expect(warnings.some((w) => /session pollution/i.test(w))).toBe(false);
+      expect(warnings.some((w) => /session poisoning/i.test(w))).toBe(false);
       expect(
         result.diagnostics.some((d) => d.code === "session_pollution"),
       ).toBe(false);

--- a/packages/pg-delta/tests/load-sql-files-statement-fallback.test.ts
+++ b/packages/pg-delta/tests/load-sql-files-statement-fallback.test.ts
@@ -132,11 +132,13 @@ describe("loadSqlFiles — statementFallback", () => {
         error = e;
       }
       expect(error).toBeInstanceOf(ShadowLoadError);
-      expect(
-        (error as ShadowLoadError).details.some(
-          (d) => d.code === "stuck_statement",
-        ),
-      ).toBe(true);
+      const stuck = (error as ShadowLoadError).details.find(
+        (d) => d.code === "stuck_statement",
+      );
+      expect(stuck).toBeDefined();
+      expect(stuck?.message).toMatchInlineSnapshot(
+        `"_cluster/publications.sql: relation "public.missing" does not exist — at line 4: ALTER PUBLICATION p ADD TABLE public.missing (failed identically in 3 round(s) — likely a genuine missing dependency, not ordering)"`,
+      );
       const { rows } = await shadow.pool.query<{ n: number }>(`
         SELECT count(*)::int AS n
         FROM pg_publication_rel pr


### PR DESCRIPTION
## Summary

- Shadow-load assist warnings are short (`session poisoning`, set `loadOrder`).
- File, line, excerpt, and Postgres error live on diagnostic `context` so `onWarning` stays free of statement text.
- `reorder_on_failure` also names the same-file statement the stuck one should run after.

## Linked issue

N/A (follow-up to #445).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass