### PR TITLE
docs(pg-delta): convert diagrams to Mermaid and fix stale/incorrect claims

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -56,11 +56,14 @@ Five steps, each its own document when you want the depth:
 ### 1. Extract — a database becomes facts
 
 `extract()` reads a database in **one consistent snapshot** (a single
-`REPEATABLE READ` transaction, so the catalog can't shift under it) and produces
-a **fact base**. A *fact* is one addressable thing — a table, a column, a
-constraint, an index, a policy, an ACL grant, an ownership edge — captured as a
-content-addressed `{ id, payload }`. Identity is structured (schema + name +
-kind), never a fragile attnum or OID. DDL text is whatever
+`REPEATABLE READ` transaction by default; opt-in concurrency fans extraction
+families over connections that all import the same exported snapshot) and
+produces a **fact base**. A *fact* is one addressable thing — a table, a
+column, a constraint, an index, a policy, an ACL grant — captured as a
+content-addressed `{ id, payload }`. Alongside the facts sit **dependency
+edges** (`depends`, `owner`, `memberOfExtension`, `managedBy`): ownership and
+extension membership are edges, not payload fields. Identity is structured
+(schema + name + kind), never a fragile attnum or OID. DDL text is whatever
 PostgreSQL's own `pg_get_*def()` reports, so it's already canonical.
 
 The fact base is a Merkle tree: every fact has a hash, and parents roll up their
@@ -88,11 +91,12 @@ exist here.
 ### 4. Prove — a plan earns trust on a clone
 
 This is the safety net the old engine never had. `provePlan()` applies the plan
-to a **throwaway clone**, re-extracts it, and checks two things:
+to a **throwaway clone**, re-extracts it, and checks three things:
 
 - **State proof** — the result's fact hashes equal the desired state (zero drift).
-- **Data preservation** — rows in kept ordinary heap tables survive (and a table
-  rewritten without declaring it fails the proof).
+- **Data preservation** — rows in kept ordinary heap tables survive.
+- **Rewrite observation** — a table whose `relfilenode` changed under an action
+  that did not declare `rewriteRisk` fails the proof.
 
 Because re-extraction yields the same kind of facts, "did the migration work?"
 becomes a hash comparison, run automatically in CI — not a production incident.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -37,20 +37,18 @@ lives in exactly *two* forms — is in
 
 ## The pipeline
 
-```
-            ┌─ live DB ────────────┐
-            │                      ▼
-.sql files ─┴─► shadow DB ──►  extract  ──►  fact base
-                                                │
-                                              diff (vs the other side)
-                                                │
-                                                ▼
-                                            deltas ──► plan ──► actions
-                                                                  │
-                                                       ┌──────────┴───────────┐
-                                                       ▼                      ▼
-                                                     apply                  prove
-                                                  (the target)          (a clone)
+```mermaid
+flowchart LR
+    LIVE[("live DB")] --> EXTRACT
+    SQL[".sql files"] --> SHADOW[("shadow DB")]
+    SHADOW --> EXTRACT
+    EXTRACT["extract"] --> FB["fact base"]
+    FB --> DIFF["diff<br/><i>(vs the other side)</i>"]
+    DIFF --> DELTAS["deltas"]
+    DELTAS --> PLAN["plan"]
+    PLAN --> ACTIONS["actions"]
+    ACTIONS --> PROVE["prove<br/><i>(a clone)</i>"]
+    ACTIONS --> APPLY["apply<br/><i>(the target)</i>"]
 ```
 
 Five steps, each its own document when you want the depth:

--- a/docs/architecture/custom-folder.md
+++ b/docs/architecture/custom-folder.md
@@ -51,7 +51,7 @@ survives regeneration.
 | `schema export` — unmanaged scan | `.sql` files under `_custom/` are neither owned nor unmanaged: they never trigger the refusal and are never listed in the manifest. |
 | `schema export` — prune | The `_custom/` subtree is never walked; `--prune-unmanaged` never deletes anything inside it. |
 | `schema export` — scaffold | On export, if `_custom/README.md` does not exist, it is created with the contract documentation (template in §6). `README.md` is not `.sql`, so the loader and pruner ignore it. |
-| `schema apply` | No change: the recursive glob already loads `_custom/**/*.sql` into the shadow, and the bounded retry-round loader (plus the on-failure reorder escalation) absorbs ordering. |
+| `schema apply` | No change: the recursive glob already loads `_custom/**/*.sql` into the shadow, and the bounded retry-round loader absorbs cross-file ordering (the on-failure escalation additionally rescues late-kind statements — policies, publication/subscription DDL; statements within a `_custom` file otherwise apply in authored order). |
 | `schema lint` | New warnings — see §4. |
 | `unmodeled_kind` diagnostic | Message gains a hint pointing at `_custom/` (§5). |
 

--- a/docs/architecture/custom-folder.md
+++ b/docs/architecture/custom-folder.md
@@ -51,7 +51,7 @@ survives regeneration.
 | `schema export` — unmanaged scan | `.sql` files under `_custom/` are neither owned nor unmanaged: they never trigger the refusal and are never listed in the manifest. |
 | `schema export` — prune | The `_custom/` subtree is never walked; `--prune-unmanaged` never deletes anything inside it. |
 | `schema export` — scaffold | On export, if `_custom/README.md` does not exist, it is created with the contract documentation (template in §6). `README.md` is not `.sql`, so the loader and pruner ignore it. |
-| `schema apply` | No change: the recursive glob already loads `_custom/**/*.sql` into the shadow, and the bounded retry-round loader (plus the default pg-topo reorder) absorbs ordering. |
+| `schema apply` | No change: the recursive glob already loads `_custom/**/*.sql` into the shadow, and the bounded retry-round loader (plus the on-failure reorder escalation) absorbs ordering. |
 | `schema lint` | New warnings — see §4. |
 | `unmodeled_kind` diagnostic | Message gains a hint pointing at `_custom/` (§5). |
 

--- a/docs/architecture/extension-intent.md
+++ b/docs/architecture/extension-intent.md
@@ -313,9 +313,9 @@ Deviations from the sketch, each deliberate:
 flowchart TB
     LIVE["live DB"] --> EX
     FILES["SQL files → shadow"] --> EX
-    SNAP["snapshot"] --> EX
     EX["<b>core extract</b>: pg_catalog → schema facts<br/><b>handler capture</b>: ext catalogs → intent facts + managedBy edges<br/><i>(one exported snapshot; integration-aware extract)</i>"]
     EX --> FB["<b>ONE FACT BASE</b> — schema facts + intent facts + edges<br/><i>(managedBy edges mark operationally-created objects)</i>"]
+    SNAP["snapshot<br/><i>(already a serialized fact base)</i>"] --> FB
     FB -->|"resolveView: managedBy provenance → project out&nbsp;&nbsp;(Deliverable A)"| DIFF["<b>generic hash diff</b> → deltas<br/><i>(schema + intent, one Delta type, O(changed))</i>"]
     DIFF --> RULES["<b>ONE rule table</b> (schema rules + registered handler intent rules) → actions"]
     RULES --> GRAPH["<b>ONE graph</b> → one deterministic sort<br/><i>(replay actions are ordinary nodes, wired by consumes / produces)</i>"]

--- a/docs/architecture/extension-intent.md
+++ b/docs/architecture/extension-intent.md
@@ -309,27 +309,18 @@ Deviations from the sketch, each deliberate:
 
 ## 4. Architecture
 
-```text
- live DB ──────────────┐   core extract:    pg_catalog        → schema facts
- SQL files ─ shadow ───┤   handler capture:  ext catalogs      → intent facts + managedBy edges
- snapshot ─────────────┘   (one exported snapshot; integration-aware extract)
-                │
-                ▼
-        ONE FACT BASE   schema facts + intent facts + edges
-                │        ( managedBy edges mark operationally-created objects )
-                │  resolveView:  managedBy provenance → project out   (Deliverable A)
-                ▼
-        generic hash diff  → deltas  (schema + intent, one Delta type, O(changed))
-                ▼
-        ONE rule table  (schema rules + registered handler intent rules) → actions
-                ▼
-        ONE graph → one deterministic sort
-        (replay actions are ordinary nodes, wired by consumes / produces)
-                ▼
-        PROOF: apply to clone → re-extract (core + handlers) → hash-compare both;
-        data-preservation seeds messages / partition rows
-                ▼
-        apply (segmented, transactionality-aware)
+```mermaid
+flowchart TB
+    LIVE["live DB"] --> EX
+    FILES["SQL files → shadow"] --> EX
+    SNAP["snapshot"] --> EX
+    EX["<b>core extract</b>: pg_catalog → schema facts<br/><b>handler capture</b>: ext catalogs → intent facts + managedBy edges<br/><i>(one exported snapshot; integration-aware extract)</i>"]
+    EX --> FB["<b>ONE FACT BASE</b> — schema facts + intent facts + edges<br/><i>(managedBy edges mark operationally-created objects)</i>"]
+    FB -->|"resolveView: managedBy provenance → project out&nbsp;&nbsp;(Deliverable A)"| DIFF["<b>generic hash diff</b> → deltas<br/><i>(schema + intent, one Delta type, O(changed))</i>"]
+    DIFF --> RULES["<b>ONE rule table</b> (schema rules + registered handler intent rules) → actions"]
+    RULES --> GRAPH["<b>ONE graph</b> → one deterministic sort<br/><i>(replay actions are ordinary nodes, wired by consumes / produces)</i>"]
+    GRAPH --> PROOF["<b>PROOF</b>: apply to clone → re-extract (core + handlers) → hash-compare both;<br/>data-preservation seeds messages / partition rows"]
+    PROOF --> APPLY["<b>apply</b> <i>(segmented, transactionality-aware)</i>"]
 ```
 
 ### 4.1 The handler — a generic engine extension point

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -23,16 +23,17 @@ projection (`excludeManaged`/`excludeExtensionMembers`), delta-level filtering
 `skipSchema`) — collapses into one: **define the view, diff the view, prove the
 view.**
 
-```
-            raw source ─┐                          ┌─ raw desired
-                        ▼                          ▼
-                  view(facts, policy, capability)        ◀── ONE definition
-                        │                          │
-              effectiveSource ──── diff ──── effectiveDesired
-                        │
-                     deltas ── rules ── actions ── graph ── sort ── apply
-                        │
-                     provePlan  (re-extract is run through the SAME view)
+```mermaid
+flowchart TB
+    RAWS["raw source"] --> VIEW
+    RAWD["raw desired"] --> VIEW
+    VIEW{{"<b>view(facts, policy, capability)</b><br/>ONE definition, applied to both sides"}}
+    VIEW --> EFFS["effectiveSource"]
+    VIEW --> EFFD["effectiveDesired"]
+    EFFS --> DIFF["diff"]
+    EFFD --> DIFF
+    DIFF --> CHAIN["deltas → rules → actions → graph → sort → apply"]
+    CHAIN --> PROVE["provePlan<br/><i>(re-extract is run through the SAME view)</i>"]
 ```
 
 ## Why this is forced by the constraints (not a preference)

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -32,8 +32,9 @@ flowchart TB
     VIEW --> EFFD["effectiveDesired"]
     EFFS --> DIFF["diff"]
     EFFD --> DIFF
-    DIFF --> CHAIN["deltas → rules → actions → graph → sort → apply"]
-    CHAIN --> PROVE["provePlan<br/><i>(re-extract is run through the SAME view)</i>"]
+    DIFF --> CHAIN["deltas → rules → actions → graph → sort"]
+    CHAIN --> PROVE["provePlan on a clone<br/><i>(re-extract is run through the SAME view)</i>"]
+    CHAIN --> APPLY["apply<br/><i>(the target)</i>"]
 ```
 
 ## Why this is forced by the constraints (not a preference)

--- a/docs/architecture/onboarding.md
+++ b/docs/architecture/onboarding.md
@@ -13,7 +13,7 @@ flowchart TD
   SqlFiles["SQL-file frontend\nsrc/frontends/load-sql-files.ts"] --> FB
   FB --> View["resolveView\nsrc/policy/policy.ts\n(policy · capability · baseline)"]
   View --> Diff["diff\nsrc/core/diff.ts\n(generic, zero per-kind code)"]
-  Diff --> Plan["plan\nsrc/plan/plan.ts + rules.ts\n(rule table → one action graph)"]
+  Diff --> Plan["plan\nsrc/plan/plan.ts → phases/ + rules.ts\n(rule table → one action graph,\nsorted by src/plan/graph.ts)"]
   Plan --> Apply["apply\nsrc/apply/apply.ts"]
   Plan --> Prove["provePlan\nsrc/proof/prove.ts\n(apply to a clone, re-extract, compare)"]
   Corpus["corpus/ scenarios\n(a.sql / b.sql)"] --> Prove
@@ -25,7 +25,7 @@ Answers to the five questions a newcomer asks:
 |---|---|
 | Where do facts come from? | `src/extract/extract.ts` orchestrates per-family extractors (`src/extract/*.ts` — e.g. `relations.ts`, `foreign.ts`, `types.ts`; shared `pg_depend` resolver in `dependencies.ts`) over a live DB; `src/frontends/load-sql-files.ts` does `.sql` → shadow DB → extract. Both produce a `FactBase`. |
 | What is a fact? | `src/core/fact.ts` — a content-addressed `{ id: StableId, parent?, payload }`. Identity lives in `src/core/stable-id.ts`; hashing in `src/core/hash.ts`. |
-| How is ordering decided? | `src/plan/plan.ts` builds atomic actions from the rule registry (`src/plan/rules.ts`, with per-family rules in `src/plan/rules/*.ts`) and orders them with one topological sort over the dependency graph (`src/plan/internal.ts`). At fact grain there are no cycles to break. |
+| How is ordering decided? | `src/plan/plan.ts` orchestrates four phases under `src/plan/phases/` (`change-set` → `replacement-expansion` → `action-emitter` → `action-graph`). Actions come from the rule registry (`src/plan/rules.ts`, with per-family rules in `src/plan/rules/*.ts`); the one deterministic topological sort is `topoSort` in `src/plan/graph.ts` (graph-construction building blocks and compaction live in `src/plan/internal.ts`). At fact grain there are no cycles to break. |
 | What proves a change safe? | `src/proof/prove.ts` — applies the plan to a throwaway clone, re-extracts, and checks the fact hashes match (state) and seeded rows survive (data). |
 | Where does product-specific scope live? | `src/policy/` — `resolveView(facts, policy, capability, baseline)` projects the managed view; `src/policy/supabase.ts` is the Supabase package. Never in core diff/plan. |
 

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -115,33 +115,20 @@ storage detail; it is what makes P2 hold.
 
 ## 3. The architecture
 
-```text
-frontends:   live DB ──(single-snapshot extract)──┐
-             SQL files ──(shadow-DB elaboration)──┼──▶  FACT BASE
-             snapshot JSON ───────────────────────┘     normalized fact rows + parent &
-                                                        dependency edges; content hash per
-                                                        fact, Merkle rollups along parents
-                                  │
-                  generic diff: rollup-guided descent → fact-level DELTAS
-                  (hash compare — zero per-type code, O(changed))
-                                  │
-                     RULE TABLE  ◀── the only per-type logic in the system
-                                  │
-                          ATOMIC ACTIONS  (≈ 1:1 with deltas)
-              each declares produces / consumes / destroys, lock class,
-              rewrite risk, data-loss class, transactionality
-                                  │
-              ONE dependency graph → one deterministic topological sort
-              (a cycle is a rule bug caught by CI, not a runtime repair job)
-                                  │
-              optional COMPACTION: merge adjacent actions into idiomatic DDL
-              by joining facts along parent relations, only where no edge
-              crosses the merge (cosmetics; off for machines)
-                                  │
-                   PLAN = ordered deltas + fingerprints + safety report
-                                  │
-            ┌── PROOF: apply to scratch clone, re-extract, hash-compare ──┐
-            └──────────── apply (lock-aware segmented txns) ──────────────┘
+```mermaid
+flowchart TB
+    LIVE["live DB<br/><i>(single-snapshot extract)</i>"] --> FB
+    FILES["SQL files<br/><i>(shadow-DB elaboration)</i>"] --> FB
+    SNAP["snapshot JSON"] --> FB
+    FB["<b>FACT BASE</b><br/>normalized fact rows + parent & dependency edges;<br/>content hash per fact, Merkle rollups along parents"]
+    FB --> DIFF["<b>generic diff</b>: rollup-guided descent → fact-level <b>DELTAS</b><br/><i>(hash compare — zero per-type code, O(changed))</i>"]
+    RULES["<b>RULE TABLE</b><br/>the only per-type logic in the system"] --> ACTIONS
+    DIFF --> ACTIONS["<b>ATOMIC ACTIONS</b> <i>(≈ 1:1 with deltas)</i><br/>each declares produces / consumes / destroys, lock class,<br/>rewrite risk, data-loss class, transactionality"]
+    ACTIONS --> SORT["<b>ONE dependency graph</b> → one deterministic topological sort<br/><i>(a cycle is a rule bug caught by CI, not a runtime repair job)</i>"]
+    SORT --> COMPACT["optional <b>COMPACTION</b>: merge adjacent actions into idiomatic DDL<br/>by joining facts along parent relations, only where no edge<br/>crosses the merge <i>(cosmetics; off for machines)</i>"]
+    COMPACT --> PLAN["<b>PLAN</b> = ordered deltas + fingerprints + safety report"]
+    PLAN --> PROOF["<b>PROOF</b>: apply to scratch clone,<br/>re-extract, hash-compare"]
+    PLAN --> APPLY["<b>apply</b><br/><i>(lock-aware segmented txns)</i>"]
 ```
 
 ### 3.1 The fact base: a normalized, content-addressed relation

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -242,7 +242,8 @@ re-implemented inside an imperative diff.
   workflow. Four specifics the shadow loader owns:
   - **Ordering is best-effort and fail-safe.** Files may not arrive
     apply-ordered; the loader follows the export manifest's recorded
-    `loadOrder` when present (else authored order), retries deferred
+    `loadOrder` when present (else lexicographic path order on the CLI;
+    caller-array order in the library), retries deferred
     statements in bounded rounds *against the shadow*, and on a stuck load
     escalates — reconnect once, then kind-based reordering via the
     dev-layer static analyzer. This does not violate P1: ordering
@@ -667,8 +668,8 @@ trusted component. pg-topo is loaded through a guarded dynamic `import()` and
 declared an *optional peer dependency*; merely importing the core never pulls
 the libpg-query WASM parser — only calling the `@supabase/pg-delta/sql-order`
 subpath does. In pg-delta's own CLI the assist is **escalate-on-failure**:
-`schema apply` loads in the export manifest's `loadOrder` (else authored
-order) first, reconnects once on a poisoned session, and only then reorders —
+`schema apply` loads in the export manifest's `loadOrder` (else lexicographic
+path order) first, reconnects once on a poisoned session, and only then reorders —
 file-kind, then statement-kind — with a warning naming what to move
 (`--no-reorder` disables only the reordering stages; the one-time reconnect
 still applies); other

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -241,15 +241,18 @@ re-implemented inside an imperative diff.
   reference matching in the trusted path. This *is* the declarative
   workflow. Four specifics the shadow loader owns:
   - **Ordering is best-effort and fail-safe.** Files may not arrive
-    apply-ordered; the loader may pre-sort with the dev-layer static
-    analyzer and/or retry deferred statements in bounded rounds *against
-    the shadow*. This does not violate P1: ordering assistance can only
-    fail to build the shadow — a visible error before anything is
-    extracted — never corrupt the desired state, because Postgres remains
-    the elaborator. (The objection to round-retry was as a *production
-    apply engine* against live targets; on a throwaway shadow it is
-    harmless.) The pre-sort is the **statement reordering assist** — an
-    opt-in, degradable layer above the parser-free loader; see §4.4.1.
+    apply-ordered; the loader follows the export manifest's recorded
+    `loadOrder` when present (else authored order), retries deferred
+    statements in bounded rounds *against the shadow*, and on a stuck load
+    escalates — reconnect once, then kind-based reordering via the
+    dev-layer static analyzer. This does not violate P1: ordering
+    assistance can only fail to build the shadow — a visible error before
+    anything is extracted — never corrupt the desired state, because
+    Postgres remains the elaborator. (The objection to round-retry was as
+    a *production apply engine* against live targets; on a throwaway
+    shadow it is harmless.) The kind-based escalation is the **statement
+    reordering assist** — a degradable layer above the parser-free loader;
+    see §4.4.1.
   - **Body validation is restored before extraction.** Loading runs with
     `check_function_bodies = off`; accepting the catalog without
     re-checking would admit a typo'd routine body into the desired state —
@@ -650,9 +653,9 @@ workflow exists to provide, and a regression in the rewrite.
 - The assist returns **one statement per `SqlFile`** with a zero-padded ordinal
   name prefix (`0007__schema/users.sql`). Fed that, the existing loader becomes
   statement-granular with **zero core change** — its rounds, transaction-control
-  rejection, non-transactional handling, and mutual-FK hint all carry over, and
-  its per-round lexicographic name sort reproduces the assist's order. The
-  loader cannot tell it was fed sorted statements.
+  rejection, non-transactional handling, and mutual-FK hint all carry over (a
+  caller that lex-sorts by name keeps the assist's order). The loader cannot
+  tell it was fed sorted statements.
 - Every input statement is preserved **exactly once** — including statements the
   analyzer cannot classify and statements trapped in a cycle (the analyzer's
   ordered output is a *total* order; cycle members land at a best-effort
@@ -663,9 +666,13 @@ workflow exists to provide, and a regression in the rewrite.
 trusted component. pg-topo is loaded through a guarded dynamic `import()` and
 declared an *optional peer dependency*; merely importing the core never pulls
 the libpg-query WASM parser — only calling the `@supabase/pg-delta/sql-order`
-subpath does. Reorder is always-on in pg-delta's own CLI (`schema apply`,
-with `--no-reorder` to reproduce raw file granularity); other consumers
-(supabase/cli) opt in by adding pg-topo themselves and calling the subpath.
+subpath does. In pg-delta's own CLI the assist is **escalate-on-failure**:
+`schema apply` loads in the export manifest's `loadOrder` (else authored
+order) first, reconnects once on a poisoned session, and only then reorders —
+file-kind, then statement-kind — with a warning naming what to move
+(`--no-reorder` skips the escalation, so a stuck load stays stuck); other
+consumers (supabase/cli) opt in by adding pg-topo themselves and calling the
+subpath.
 When the peer is absent the subpath throws a typed `ReorderUnavailableError`
 with an install hint (and `canReorder()` lets a caller probe instead of catch).
 

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -670,7 +670,8 @@ subpath does. In pg-delta's own CLI the assist is **escalate-on-failure**:
 `schema apply` loads in the export manifest's `loadOrder` (else authored
 order) first, reconnects once on a poisoned session, and only then reorders —
 file-kind, then statement-kind — with a warning naming what to move
-(`--no-reorder` skips the escalation, so a stuck load stays stuck); other
+(`--no-reorder` disables only the reordering stages; the one-time reconnect
+still applies); other
 consumers (supabase/cli) opt in by adding pg-topo themselves and calling the
 subpath.
 When the peer is absent the subpath throws a typed `ReorderUnavailableError`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,8 +129,9 @@ Author your schema as ordinary `.sql` files in a directory; order doesn't matter
 (the loader resolves dependencies across files in bounded rounds; if a load
 still sticks it reconnects once and then escalates to kind-based reordering,
 warning you exactly which statement to move — `--no-reorder` opts out of the
-escalation). `schema apply` loads them into a **shadow** database, extracts
-that as the desired state, and migrates the target to match:
+reordering, though the one-time reconnect still applies). `schema apply` loads
+them into a **shadow** database, extracts that as the desired state, and
+migrates the target to match:
 
 ```bash
 pgdelta schema apply \
@@ -211,6 +212,8 @@ pgdelta schema export --source "$SOURCE_URL" --out-dir ./schema
 # The export also drops a .pgdelta-export.json manifest (profile, scope,
 # redaction mode, owned files, load order); schema apply reads it back so the
 # directory round-trips under the same settings and loads in the recorded order.
+# A custom profile is recorded by id only — pass the same --profile <path>
+# again at apply time (built-in raw/supabase profiles need no flag).
 ```
 
 > The shadow database must be fresh and empty. When `--shadow` is omitted in

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -383,8 +383,9 @@ const thePlan = plan(sourceFb, factBase, ctx.planOptions);
 await apply(thePlan, targetPool, ctx.applyOptions);
 ```
 
-- **`raw`** (default) — no policy: diff everything. (It ships one presence-only
-  handler, for `vault`, so vault-encrypted state is detected rather than read.)
+- **`raw`** (default) — no policy: diff everything. (It ships one handler, for
+  `vault`: extension presence plus best-effort plan warnings on structural use —
+  secret state is never read or captured.)
 - **`supabase`** — excludes Supabase-managed roles, schemas, and extensions, and
   captures stateful-extension objects (e.g. pg_partman children) so they aren't
   dropped.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,19 +23,14 @@ You can drive it two ways:
 
 Everything flows through one pipeline:
 
-```
-extract   read a database into a "fact base" (one fact per object: table,
-          column, constraint, policy, grant, … — all content-addressed)
-   ↓
-diff      compare two fact bases → a list of deltas (add / remove / set / link)
-   ↓
-plan      turn deltas into ordered, atomic DDL actions (one dependency graph,
-          one deterministic sort — no cycle-breakers)
-   ↓
-prove     apply the plan to a throwaway clone, re-extract, and check the result
-          equals the desired state AND seeded rows survived  ← the safety net
-   ↓
-apply     run the plan against the real target (fingerprint-gated)
+```mermaid
+flowchart TB
+    EXTRACT["<b>extract</b> — read a database into a <i>fact base</i><br/>one fact per object: table, column, constraint,<br/>policy, grant, … — all content-addressed"]
+    DIFF["<b>diff</b> — compare two fact bases → a list of deltas<br/><i>(add / remove / set / link / unlink)</i>"]
+    PLAN["<b>plan</b> — turn deltas into ordered, atomic DDL actions<br/><i>one dependency graph, one deterministic sort — no cycle-breakers</i>"]
+    PROVE["<b>prove</b> — apply the plan to a throwaway clone, re-extract, and check the<br/>result equals the desired state AND seeded rows survived — <b>the safety net</b>"]
+    APPLY["<b>apply</b> — run the plan against the real target <i>(fingerprint-gated)</i>"]
+    EXTRACT --> DIFF --> PLAN --> PROVE --> APPLY
 ```
 
 The desired state can come from **another live database** or from your
@@ -59,7 +54,9 @@ pgdelta <command> [flags]
 ```
 
 `pgdelta help` prints the command list. Exit codes: **0** success,
-**1** runtime failure (or drift detected), **2** bad arguments.
+**1** runtime failure (or drift detected), **2** bad arguments, **3** blocking
+diagnostics (e.g. the `--strict-coverage` refusal, or `render` on a plan with
+no actions).
 
 ### Flow 1 — migrate one database to match another
 
@@ -107,7 +104,7 @@ fingerprint check; it never authorizes data loss.
 
 `prove` always prints the plan's projection-audit result. Current plans show a
 summary of raw source/desired differences hidden by policy, baseline,
-capability, management-scope, or reference-only projection, with a stable reason
+capability, management-scope, `managedBy`, or reference-only projection, with a stable reason
 code and classification for each suppression; legacy plans report the audit as
 unavailable and ask you to re-plan. Human detail is bounded to 50 entries and 10
 suppressions per selected entry by default. When more entries exist, selection
@@ -129,9 +126,10 @@ legacy plan that predates projection audits; re-plan before relying on that gate
 ### Flow 2 — declarative: keep your schema as `.sql` files
 
 Author your schema as ordinary `.sql` files in a directory; order doesn't matter
-(the loader resolves dependencies across files in bounded rounds). `schema apply`
-loads them into a **shadow** database, extracts that as the desired state, and
-migrates the target to match:
+(the loader resolves dependencies across files in bounded rounds, and a
+statement-level reordering assist is on by default — `--no-reorder` opts out).
+`schema apply` loads them into a **shadow** database, extracts that as the
+desired state, and migrates the target to match:
 
 ```bash
 pgdelta schema apply \
@@ -181,9 +179,12 @@ Export the inverse — a live database back out to `.sql` files:
 pgdelta schema export --source "$SOURCE_URL" --out-dir ./schema
 # Writes one directory per schema at the root plus a reserved _cluster/ for
 # objects that belong to no schema:
-#   ./schema/_cluster/roles.sql
 #   ./schema/app/schema.sql
 #   ./schema/app/tables/users.sql
+#   ./schema/_cluster/publications.sql
+# The default --scope database omits cluster-global roles/memberships; add
+# --scope cluster to export them too (./schema/_cluster/roles.sql).
+#
 # --path-style nested reproduces the historical schemas/app/tables/users.sql +
 # cluster/roles.sql tree (composes with every --layout).
 #
@@ -198,10 +199,12 @@ pgdelta schema export --source "$SOURCE_URL" --out-dir ./schema
 #   --flat-schemas partman,audit                (one file per category)
 #   --no-group-partitions                       (keep partition children separate)
 #
-# --format-options pretty-prints the exported SQL (any layout; off by default):
+# The exported SQL is pretty-printed by default (lowercase keywords, width 180).
+# --format-options overrides the knobs; --no-format turns formatting off
+# (the two are mutually exclusive):
 #   --format-options '{"keywordCase":"upper","maxWidth":180}'
-# It is cosmetic — the load(export(db)) ≡ db guarantee still holds. The same
-# formatter is available as a library helper at @supabase/pg-delta/sql-format
+# Formatting is cosmetic — the load(export(db)) ≡ db guarantee still holds. The
+# same formatter is available as a library helper at @supabase/pg-delta/sql-format
 # (formatSqlStatements).
 ```
 
@@ -225,18 +228,22 @@ has drifted (and prints the deltas) — handy in CI.
 |---|---|---|
 | `diff` | Print the deltas between two live DBs | `--source` `--desired` `[--strict-coverage]` |
 | `plan` | Produce a plan artifact (JSON) | `--source` `--desired` `[--out]` `[--profile]` `[--renames]` `[--no-compact]` `[--accept-rename]` `[--restrict-to-applier]` `[--strict-coverage]` |
+| `render` | Write a plan out as reviewable `.sql` | `--plan` `--out` `[--allow-drops]` |
 | `apply` | Apply a plan to a target | `--plan` `--target` `[--profile]` `[--force]` `[--allow-data-loss]` |
 | `prove` | Apply a plan to a clone and verify convergence + data preservation | `--plan` `--clone` `--desired-snapshot` `[--profile]` `[--strict-audit]` `[--audit-all]` `[--trusted-local-host]` `[--allow-remote-clone]` `[--allow-unverified-source-identity]` |
 | `snapshot` | Save a database's fact base to a file | `--source` `--out` `[--strict-coverage]` |
 | `drift` | Compare a live DB against a saved snapshot | `--env` `--snapshot` `[--strict-coverage]` |
-| `schema export` | Export a live DB to `.sql` files | `--source` `--out-dir` `[--layout]` `[--path-style]` `[--profile]` `[--strict-coverage]` |
-| `schema apply` | Load `.sql` files via a shadow DB and migrate a target | `--dir` `[--shadow]` `--target` `[--scope]` `[--isolated-shadow]` `[--renames]` `[--accept-rename]` `[--force]` `[--allow-data-loss]` `[--trusted-local-host]` `[--allow-remote-shadow]` `[--profile]` `[--restrict-to-applier]` `[--strict-coverage]` `[--dry-run]` `[--verbose]` `[--out-plan]` |
+| `schema export` | Export a live DB to `.sql` files | `--source` `--out-dir` `[--scope]` `[--layout]` `[--path-style]` `[--format-options]` `[--no-format]` `[--profile]` `[--strict-coverage]` |
+| `schema apply` | Load `.sql` files via a shadow DB and migrate a target | `--dir` `[--shadow]` `--target` `[--scope]` `[--isolated-shadow]` `[--renames]` `[--accept-rename]` `[--force]` `[--allow-data-loss]` `[--no-reorder]` `[--trusted-local-host]` `[--allow-remote-shadow]` `[--profile]` `[--restrict-to-applier]` `[--strict-coverage]` `[--dry-run]` `[--verbose]` `[--out-plan]` |
+| `schema lint` | Statically check `.sql` files for load-order problems (no database) | `--dir` `[--custom-migration-refs]` |
 
 Common flags, explained:
 
-- **`--profile raw\|supabase`** — selects an *integration profile* (default `raw`).
-  `supabase` knows about Supabase-managed roles/schemas/extensions and excludes
-  them from the diff. See [Profiles](#profiles) below.
+- **`--profile raw\|supabase\|<path>`** — selects an *integration profile*
+  (default `raw`). `supabase` knows about Supabase-managed
+  roles/schemas/extensions and excludes them from the diff; a path (containing
+  `/` or ending in `.json`) loads a custom profile. See [Profiles](#profiles)
+  below.
 - **`--strict-coverage`** — refuse to act while user objects exist in a kind the
   engine doesn't model yet (instead of silently ignoring them).
 - **`--strict-audit`** — on `prove`, fail when the plan's projection audit has
@@ -255,10 +262,10 @@ Common flags, explained:
 
 ## Programmatic API
 
-The package ships TypeScript source via subpath exports. The everything-entry is
-`@supabase/pg-delta`; each stage is also importable on its own
-(`/extract`, `/plan`, `/apply`, `/proof`, `/frontends`, `/core`, `/policy`,
-`/integrations`).
+The everything-entry is `@supabase/pg-delta`; each stage is also importable on
+its own (`/extract`, `/plan`, `/apply`, `/proof`, `/frontends`, `/core`,
+`/policy`, `/integrations`, `/sql-order`, `/sql-format`). Bun consumers get the
+TypeScript source directly; Node and Deno get the compiled `dist/` JS.
 
 It takes [`pg`](https://node-postgres.com/) `Pool`s as input.
 
@@ -371,7 +378,8 @@ const thePlan = plan(sourceFb, factBase, ctx.planOptions);
 await apply(thePlan, targetPool, ctx.applyOptions);
 ```
 
-- **`raw`** (default) — no handlers, no policy: diff everything.
+- **`raw`** (default) — no policy: diff everything. (It ships one presence-only
+  handler, for `vault`, so vault-encrypted state is detected rather than read.)
 - **`supabase`** — excludes Supabase-managed roles, schemas, and extensions, and
   captures stateful-extension objects (e.g. pg_partman children) so they aren't
   dropped.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,10 +126,11 @@ legacy plan that predates projection audits; re-plan before relying on that gate
 ### Flow 2 — declarative: keep your schema as `.sql` files
 
 Author your schema as ordinary `.sql` files in a directory; order doesn't matter
-(the loader resolves dependencies across files in bounded rounds, and a
-statement-level reordering assist is on by default — `--no-reorder` opts out).
-`schema apply` loads them into a **shadow** database, extracts that as the
-desired state, and migrates the target to match:
+(the loader resolves dependencies across files in bounded rounds; if a load
+still sticks it reconnects once and then escalates to kind-based reordering,
+warning you exactly which statement to move — `--no-reorder` opts out of the
+escalation). `schema apply` loads them into a **shadow** database, extracts
+that as the desired state, and migrates the target to match:
 
 ```bash
 pgdelta schema apply \
@@ -206,6 +207,10 @@ pgdelta schema export --source "$SOURCE_URL" --out-dir ./schema
 # Formatting is cosmetic — the load(export(db)) ≡ db guarantee still holds. The
 # same formatter is available as a library helper at @supabase/pg-delta/sql-format
 # (formatSqlStatements).
+#
+# The export also drops a .pgdelta-export.json manifest (profile, scope,
+# redaction mode, owned files, load order); schema apply reads it back so the
+# directory round-trips under the same settings and loads in the recorded order.
 ```
 
 > The shadow database must be fresh and empty. When `--shadow` is omitted in

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -243,7 +243,7 @@ has drifted (and prints the deltas) — handy in CI.
 | `drift` | Compare a live DB against a saved snapshot | `--env` `--snapshot` `[--strict-coverage]` |
 | `schema export` | Export a live DB to `.sql` files | `--source` `--out-dir` `[--scope]` `[--layout]` `[--path-style]` `[--format-options]` `[--no-format]` `[--profile]` `[--strict-coverage]` |
 | `schema apply` | Load `.sql` files via a shadow DB and migrate a target | `--dir` `[--shadow]` `--target` `[--scope]` `[--isolated-shadow]` `[--renames]` `[--accept-rename]` `[--force]` `[--allow-data-loss]` `[--no-reorder]` `[--trusted-local-host]` `[--allow-remote-shadow]` `[--profile]` `[--restrict-to-applier]` `[--strict-coverage]` `[--dry-run]` `[--verbose]` `[--out-plan]` |
-| `schema lint` | Statically check `.sql` files for load-order problems (no database) | `--dir` `[--custom-migration-refs]` |
+| `schema lint` | Statically check `.sql` files for load-order problems (no database) | `--dir` `[--custom-migration-refs warn\|off]` |
 
 Common flags, explained:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,14 +9,14 @@
 > single safety net: **every migration is applied to a throwaway clone and
 > proven to converge, with your data intact, before you trust it.** At rewrite
 > cutover the engine was **~11,500 lines (79% smaller)** — a **rewrite-era
-> snapshot**. As of **2026-08-03** the published package is **~30.8k non-test
-> LOC / 115 files** (engine slice ~18.3k; product surface ~12.2k including
-> ~3.8k `sql-format`; see §4), with one rule table instead of ~100 hand-written
+> snapshot**. As of **2026-08-21** the published package is **~37.6k non-test
+> LOC / 129 files** (engine slice ~23.0k; product surface ~14.3k including
+> ~3.9k `sql-format`; see §4), with one rule table instead of ~100 hand-written
 > change classes, a correctness guarantee the old engine never had, and — as of
 > the first performance pass — **4.2× faster extraction**.
 
 - **Audience**: engineers, reviewers, and decision-makers evaluating the rewrite.
-- **Status**: engine code-complete and proven on a **321-scenario corpus (642
+- **Status**: engine code-complete and proven on a **331-scenario corpus (662
   cases, both directions)** across PostgreSQL 14–18 — all green (one
   `EXPECTED_RED` pin on PG16+ for a known teardown). Shipped as
   `@supabase/pg-delta` in a breaking-change alpha; what's next is in
@@ -99,7 +99,7 @@ pie title Old pg-delta source: 53,933 LOC across 341 files
 source, 75% of the files** — and roughly two-thirds of it is structurally
 identical create/alter/drop/privilege/comment/security-label handling, repeated
 once per object type. That single directory is **~2.7× the rewrite-era new
-engine (~11.5k)** and still **~1.7× today's engine slice (~18.3k)**.
+engine (~11.5k)** and still **~1.4× today's engine slice (~23.0k)**.
 
 ---
 
@@ -186,17 +186,17 @@ size.
 | libpg-query / WASM in trusted path | yes (hard dependency) | no (dev-time only) | **removed** |
 | Extract latency (~12k-object catalog) | ~1.88 s | ~0.45 s | **−76% (4.2×)** |
 
-### Size today (measured 2026-08-03)
+### Size today (measured 2026-08-21)
 
 Non-test `packages/pg-delta/src` (`find … ! -name '*.test.ts' | xargs wc -l`):
 
 | Budget | Scope | LOC |
 |---|---|---:|
-| **Engine slice** | `core` + `extract` + `plan` + `proof` + `apply` + `policy` + `integrations` | **18,293** |
-| **Product surface** | `frontends` + `cli` | **12,215** |
-| **Published package total** | all non-test `src/` (incl. root `index.ts`) | **30,773** / **115** files |
+| **Engine slice** | `core` + `extract` + `plan` + `proof` + `apply` + `policy` + `integrations` | **22,973** |
+| **Product surface** | `frontends` + `cli` | **14,335** |
+| **Published package total** | all non-test `src/` (incl. root `index.ts`) | **37,630** / **129** files |
 
-**Engine LOC** excludes `frontends/sql-format` (**3,842** LOC), which sits in
+**Engine LOC** excludes `frontends/sql-format` (**3,888** LOC), which sits in
 the product-surface budget. Boundary: `./sql-format` is a package subpath export
 (`package.json`); the root index re-exports no sql-format **symbols**, but root
 consumers **do** load the formatter transitively via `exportSqlFiles` →
@@ -204,7 +204,7 @@ consumers **do** load the formatter transitively via `exportSqlFiles` →
 reliably avoid loading it — do not claim that root imports “never load the
 formatter.”
 
-**Corpus today:** **321** scenarios × 2 directions (**642** cases) under
+**Corpus today:** **331** scenarios × 2 directions (**662** cases) under
 `packages/pg-delta/corpus`.
 
 ```mermaid
@@ -226,11 +226,11 @@ flowchart LR
 
 The old engine carried **~34,000 lines of tests** — largely per-type unit tests
 asserting exact SQL strings. The new engine proves correctness *behaviourally*
-instead: a **321-scenario corpus, run in both directions (build and teardown)
-under the full proof loop, on PostgreSQL 14–18** (642 cases per version —
+instead: a **331-scenario corpus, run in both directions (build and teardown)
+under the full proof loop, on PostgreSQL 14–18** (662 cases per version —
 all green aside from one pinned `EXPECTED_RED` teardown on PG16+; measured
-2026-08-03), plus a **generative soak** (below). Correctness is demonstrated by "apply it and re-extract — does it
-match?", not by pinning byte strings.
+2026-08-21), plus a **generative soak** (below). Correctness is demonstrated by
+"apply it and re-extract — does it match?", not by pinning byte strings.
 
 - **Compact and uncompacted proof** — each scenario builds, applies, and proves
   two independent plan artifacts, so compaction is enforced as cosmetic rather

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,8 +9,8 @@
 > single safety net: **every migration is applied to a throwaway clone and
 > proven to converge, with your data intact, before you trust it.** At rewrite
 > cutover the engine was **~11,500 lines (79% smaller)** — a **rewrite-era
-> snapshot**. As of **2026-08-21** the published package is **~37.6k non-test
-> LOC / 129 files** (engine slice ~23.0k; product surface ~14.3k including
+> snapshot**. As of **2026-08-25** the published package is **~38.5k non-test
+> LOC / 130 files** (engine slice ~23.0k; product surface ~15.2k including
 > ~3.9k `sql-format`; see §4), with one rule table instead of ~100 hand-written
 > change classes, a correctness guarantee the old engine never had, and — as of
 > the first performance pass — **4.2× faster extraction**.
@@ -187,15 +187,15 @@ size.
 | libpg-query / WASM in trusted path | yes (hard dependency) | no (dev-time only) | **removed** |
 | Extract latency (~12k-object catalog) | ~1.88 s | ~0.45 s | **−76% (4.2×)** |
 
-### Size today (measured 2026-08-21)
+### Size today (measured 2026-08-25)
 
 Non-test `packages/pg-delta/src` (`find … ! -name '*.test.ts' | xargs wc -l`):
 
 | Budget | Scope | LOC |
 |---|---|---:|
 | **Engine slice** | `core` + `extract` + `plan` + `proof` + `apply` + `policy` + `integrations` | **22,973** |
-| **Product surface** | `frontends` + `cli` | **14,335** |
-| **Published package total** | all non-test `src/` (incl. root `index.ts`) | **37,630** / **129** files |
+| **Product surface** | `frontends` + `cli` | **15,168** |
+| **Published package total** | all non-test `src/` (incl. root `index.ts`) | **38,468** / **130** files |
 
 **Engine LOC** excludes `frontends/sql-format` (**3,888** LOC), which sits in
 the product-surface budget. Boundary: `./sql-format` is a package subpath export
@@ -230,7 +230,7 @@ asserting exact SQL strings. The new engine proves correctness *behaviourally*
 instead: a **331-scenario corpus, run in both directions (build and teardown)
 under the full proof loop, on PostgreSQL 14–18** (662 cases per version —
 all green aside from one pinned `EXPECTED_RED` teardown on PG16+; measured
-2026-08-21), plus a **generative soak** (below). Correctness is demonstrated by
+2026-08-25), plus a **generative soak** (below). Correctness is demonstrated by
 "apply it and re-extract — does it match?", not by pinning byte strings.
 
 - **Compact and uncompacted proof** — each scenario builds, applies, and proves

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -135,16 +135,17 @@ flowchart LR
     VIEW --> DIFF["generic diff<br/>(zero per-kind code)"]
     DIFF --> RULES["rule table →<br/>atomic actions"]
     RULES --> GRAPH["one dependency graph →<br/>one deterministic sort"]
-    GRAPH --> APPLY["apply<br/>(single txn,<br/>per-statement attribution)"]
+    GRAPH --> APPLY["apply<br/>(lock-aware segmented txns,<br/>per-statement attribution)"]
     GRAPH --> PROVE{{"PROVE on a clone:<br/>state == target?<br/>data preserved?"}}
     PROVE -->|yes| TRUST["trusted migration"]
     PROVE -->|drift| REJECT["rejected in CI"]
 ```
 
 Everything flows at **one granularity — the fact.** A table, column, constraint,
-index, policy, ACL entry, ownership edge, extension membership: each is its own
-content-addressed fact. State, diff, dependencies, and actions all live at that
-same grain, so:
+index, policy, ACL entry: each is its own content-addressed fact — and ownership
+and extension membership ride beside them as dependency edges (`owner`,
+`memberOfExtension`), data rather than payload fields. State, diff,
+dependencies, and actions all live at that same grain, so:
 
 - **diff is generic** — a rollup-guided descent emitting `add`/`remove`/`set`/
   `link`/`unlink` deltas, with *zero per-type code*;
@@ -256,9 +257,10 @@ inconsistent code paths (`excludeManaged`, `excludeExtensionMembers`, post-diff
 be a `skipAuthorization` boolean threaded through every serializer; now **ownership
 is an edge**, and projecting a role out of the view simply prunes that edge — the
 parameter ceases to exist *structurally*, not as a workaround. The same move
-turned `skipSchema` into the catalog fact `extrelocatable`. All of it collapses
-into one `resolveView(facts, policy, capability)` applied identically before
-`plan()` and `prove()`. See
+turned `skipSchema` into catalog-sourced state (`pg_extension.extrelocatable`,
+carried as the extension fact's `_relocatable` metadata). All of it collapses
+into one `resolveView(facts, policy, capability, baseline)` applied identically
+before `plan()` and `prove()`. See
 [architecture/managed-view-architecture.md](architecture/managed-view-architecture.md).
 
 **Stateful extensions keep their data.** pgmq, pg_cron and pg_partman create
@@ -279,7 +281,7 @@ construction: it manages X, or it tells you it doesn't.
 **Ordering is correct by construction.** No cycle-breaker registry that grows by
 one entry per field-discovered cycle — at fact grain there are no cycles to break.
 
-**The core library is lean.** `createPlan` consumers no longer pull a WASM SQL
+**The core library is lean.** `plan()` consumers no longer pull a WASM SQL
 parser into the trusted path. PostgreSQL does the elaboration.
 
 **It resolves most known issues by design.** Of **134 tracked issues** in the
@@ -310,9 +312,12 @@ output (gated by an edge-set oracle + the full corpus on PG 14–18):
 | `extract` (cold, ~12k objects) | 1,881 ms | 453 ms | **4.2×** |
 | `extract` (re-extract, warm) | 1,523 ms | 323 ms | 4.7× |
 
-Parallel snapshot extraction was then *re-profiled and deferred*: after the
-rewrite the resolver is one unsplittable query that caps the parallel ceiling
-below 2×, not worth a consistency-critical refactor.
+Parallel snapshot extraction was then *re-profiled and de-prioritized* — after
+the rewrite the resolver is one unsplittable query that caps the parallel
+ceiling below 2×. It has since shipped as an **opt-in** knob:
+`ExtractOptions.concurrency` fans extraction families over connections that all
+import one exported snapshot (byte-identical output, capped at 8); the default
+remains serial.
 
 **Memory.** The content-addressed fact base is lean — measured at **~660 bytes
 per fact**; two full catalogs plus the diff and plan for a ~12k-object database
@@ -331,9 +336,11 @@ pathological schema into an actionable diagnostic instead of a hang.
 
 Honest boundaries matter as much as the wins:
 
-- **Same 7-stage pipeline shape and the `creates/drops/requires` change
-  contract** — this was the old engine's genuinely good idea; the rebuild keeps
-  it and makes the layers generic.
+- **Same 7-stage pipeline shape and the same change-contract idea** — the old
+  engine's `creates/drops/requires` survives as each action's
+  `produces` / `consumes` / `destroys` (+ `releases`) edges; this was the old
+  engine's genuinely good idea, and the rebuild keeps it while making the
+  layers generic.
 - **Data diffing (DML) is permanently out of scope** — this is a schema tool.
 
 What v1 does **not** yet do (each documented, regression-free, with a trigger to
@@ -343,11 +350,12 @@ revisit):
 |---|---|---|
 | *Model* rare kinds (casts, operators, text-search, statistics, languages, transforms) | They are **detected and reported**, never silently dropped; modeling is demand-driven | [COVERAGE.md](../packages/pg-delta/COVERAGE.md), [roadmap/backlog.md](roadmap/backlog.md) |
 | Extension-intent **Phase B** (replay extension objects on rebuild) | Phase A (don't-drop) ships; replay is blocked on a declarative-format decision | [roadmap/extension-intent-phase-b.md](roadmap/extension-intent-phase-b.md) |
-| Parallel snapshot extraction | Re-profiled: < 2× win for high refactor risk | [roadmap/backlog.md](roadmap/backlog.md) |
 | Committed Supabase baseline snapshot | The supabase profile's filter rules hide every known platform object class; the baseline is a long-tail increment over them | [roadmap/backlog.md](roadmap/backlog.md) |
 
-Consumers migrate once, at the cutover parity bar: the public surface stays the
-`createPlan` / `applyPlan` facade, on a new major, with a migration guide.
+Consumers migrate once, at the cutover parity bar: the old `createPlan` /
+`applyPlan` facade maps onto the new `plan` / `apply` / `provePlan` surface, on
+a new major, with a migration guide
+([MIGRATION.md](../packages/pg-delta/MIGRATION.md)).
 
 ---
 

--- a/packages/pg-delta/COVERAGE.md
+++ b/packages/pg-delta/COVERAGE.md
@@ -28,8 +28,8 @@ Most families are fully modeled end-to-end. The cases worth calling out — so
 | Constraints | table + domain + foreign-table CHECK | yes | foreign tables carry only CHECK (no PK/FK/UNIQUE/EXCLUSION); serialized via `ALTER FOREIGN TABLE` |
 | Foreign tables | yes (columns, options, local CHECK) | yes | inherit/partition-of foreign tables out of scope |
 | Security labels | yes (`SECURITY LABEL`) | yes | needs a provider; CI uses the `dummy_seclabel` image. See the dedicated scope note below for which targets are supported / diagnosed / out of scope |
-| Extension members | observed via `memberOfExtension` edges | projected out by default | sub-entity member families use the extract-time anti-join (tier-4-deferrals.md) |
-| Not modeled | — | — | casts, operators (class/family), text-search, statistics, transforms, user languages, parameter ACLs: **detected + reported** as `unmodeled_kind`, never silently dropped |
+| Extension members | observed via `memberOfExtension` edges | kept reference-only (never diff) | sub-entity member families use the extract-time anti-join (see the extension-members section below) |
+| Not modeled | — | — | casts, operators (incl. classes/families), text-search, statistics, transforms, user languages, parameter ACLs: **detected + reported** as `unmodeled_kind`, never silently dropped |
 
 Ownership is modeled as an `owner` EDGE (object --owner--> role), not a payload
 field: it diffs as an edge link/unlink that the planner renders as `ALTER …
@@ -125,8 +125,9 @@ per file with a `-- pgdelta-migration:` comment that `schema lint` checks. See
   the codec but not extracted; user-defined languages are rare and the
   built-ins (`sql`, `plpgsql`, `c`, `internal`) are not user state. Add a
   `language` extractor + rule when a real need appears.
-- **FTS configs/dictionaries/parsers/templates, operator classes/families as
-  first-class facts, casts, transforms, statistics objects** — out of v1 scope;
+- **FTS configs/dictionaries/parsers/templates, operators and operator
+  classes/families as first-class facts, casts, transforms, statistics
+  objects** — out of v1 scope;
   none are modeled, all are detected. Extension-provided variants are filtered
   at extract time (see below).
 - **Parameter ACLs** (`pg_parameter_acl`, PG 15+ — backs `GRANT SET ON
@@ -141,15 +142,17 @@ per file with a `-- pgdelta-migration:` comment that `schema lint` checks. See
   platform pins versions out of band; including it produces phantom diffs).
 - **Collation `collversion`** — excluded (host-glibc/ICU dependent).
 
-## Extension members: observed, projected by default (4b)
+## Extension members: observed, reference-only by default (4b)
 
 Extension-owned objects are **observed** at extraction as ordinary facts
 carrying a `memberOfExtension` edge to their extension — "provenance is data, an
-edge fact, not an extraction-time filter" (§3.1) — and then **projected out of
-the managed universe by default** in `plan()`/`prove()`
-(`excludeExtensionMembers`, the counterpart of `excludeManaged`). So policy-free
-behaviour is unchanged (members never diff), while raw `extract()` can see them
-with full ownership provenance.
+edge fact, not an extraction-time filter" (§3.1) — and then kept
+**reference-only** in the managed view that `plan()`/`prove()` diff
+(`extensionMemberClosure` / `extensionMemberReferenceOnly` inside
+`resolveView`): the member facts survive as addressable reference targets but
+never enter the diff, while their satellite customizations still can. So
+policy-free behaviour is unchanged (members never diff), while raw `extract()`
+can see them with full ownership provenance.
 
 Flipped (member-ROOT families, each observed + tagged, verified by the
 `extension-member-parity` pg_depend oracle): schemas, tables, sequences,
@@ -158,10 +161,11 @@ domains, enum/composite/range types, collations.
 
 A reference INTO a member (a user table column of an extension type, a default
 calling an extension function) resolves to the **extension**, not the member
-fact (the resolver's collapse branches): the member is projected out, so a
-member-targeted edge would be pruned with it and the dependent would lose its
-ordering on the extension. The collapsed edge points at the extension (which
-survives), so ordering holds — pinned by `extension-member-ordering`.
+fact — the `pg_depend` resolver collapses it in a single join keyed on the
+member's catalog identity. The member is reference-only in the managed view,
+so a member-targeted edge could never order the dependent's DDL; the collapsed
+edge points at the extension (a first-class fact that does plan), so ordering
+holds — pinned by `extension-member-ordering`.
 
 **Still filtered (documented, regression-free):** sub-entity families (columns,
 constraints, indexes, triggers, policies, rewrite rules) and rare member-root

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -74,18 +74,14 @@ Run `pgdelta <command> --help` for flags.
 
 ## How it works
 
-```text
-extract   read a database into a fact base
-          (one content-addressed fact per table, column, constraint, policy, grant, …)
-   ↓
-diff      compare two fact bases → deltas (generic; zero per-object-type code)
-   ↓
-plan      deltas → ordered atomic DDL actions
-          (one rule table, one dependency graph, one deterministic sort)
-   ↓
-prove     apply to a throwaway clone, re-extract, compare
-   ↓
-apply     execute against the real target
+```mermaid
+flowchart TB
+    EXTRACT["<b>extract</b> — read a database into a fact base<br/><i>one content-addressed fact per table, column, constraint, policy, grant, …</i>"]
+    DIFF["<b>diff</b> — compare two fact bases → deltas<br/><i>generic; zero per-object-type code</i>"]
+    PLAN["<b>plan</b> — deltas → ordered atomic DDL actions<br/><i>one rule table, one dependency graph, one deterministic sort</i>"]
+    PROVE["<b>prove</b> — apply to a throwaway clone, re-extract, compare"]
+    APPLY["<b>apply</b> — execute against the real target"]
+    EXTRACT --> DIFF --> PLAN --> PROVE --> APPLY
 ```
 
 Because everything lives at one grain — the fact — the diff needs no per-kind
@@ -194,7 +190,8 @@ migration channel first. It is catalog-sourced (no SQL parsing), non-blocking by
 default, and blocking under `--strict-coverage`.
 
 Frontends that own the migration channel can automate delivery instead of asking
-the user to. `listCustomFiles(root)` returns every `_custom/**/*.sql` with its
+the user to. `listCustomFiles(root)` (from `@supabase/pg-delta/frontends`)
+returns every `_custom/**/*.sql` with its
 body and parsed directives, plus a `delivered` flag (a recorded migration, or an
 explicit `none`); a frontend appends the undelivered ones to the catch-up
 migration it already generates and stamps the directive back, taking run-once
@@ -268,7 +265,7 @@ PGDELTA_NEXT_SOAK=200 bun test tests/generative.test.ts  # bigger generative soa
 bun scripts/benchmark.ts                                 # timing numbers
 ```
 
-The **corpus** (`corpus/`, 321 scenarios) is the primary correctness gate: every
+The **corpus** (`corpus/`, 331 scenarios) is the primary correctness gate: every
 scenario is proven in both directions, with compact and uncompacted plan
 artifacts built and applied independently — so compaction is enforced as
 cosmetic rather than load-bearing. CI runs it across PostgreSQL 14–18.

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -235,8 +235,10 @@ publication/subscription DDL), then splits the stuck file into kind-ordered
 statement units. Every escalation emits a warning naming the stuck `file:line`,
 the statement to move (or a suggested `loadOrder`), and any session-poisoning
 statements — so you can fix the authored tree instead of depending on the
-rescue. `--no-reorder` (API: `reorderOnFailure: false`) skips the escalation,
-so a stuck load stays stuck.
+rescue. `--no-reorder` (API: `reorderOnFailure: false`) disables only the two
+reordering stages — the one-time reconnect still applies — so a load the
+default order cannot satisfy fails with Postgres's own errors instead of
+being rescued.
 
 The kind classification rides on
 [`@supabase/pg-topo`](https://www.npmjs.com/package/@supabase/pg-topo):

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -215,21 +215,31 @@ objects stay invisible with no per-command flag. The baseline's digest is
 stamped on plan and export artifacts and reconciled at apply/prove, so
 `plan == prove == apply` holds and a swapped or edited baseline fails loudly.
 
-## Statement reordering assist (opt-in)
+## Load order and the reordering assist
 
 `loadSqlFiles` is parser-free: it sequences whole *files* into the shadow, so it
-tolerates cross-file disorder. It never permutes statements inside a file.
-When a file cannot commit atomically, `statementFallback` (default on) keeps
-the prefix Postgres already accepted and retries the **remaining** statements
-in authored order after other files have progressed — it does not sort the
-file. Pass `false` for whole-file rollback. Files that contain session-setting
-statements (`SET search_path`, `SET ROLE`, any `SET LOCAL`, …) or
-`ALTER DEFAULT PRIVILEGES` stay file-atomic so those settings cannot expire
-or apply to sibling files' objects.
+tolerates cross-file disorder. A directory produced by `schema export` loads in
+the manifest's recorded `loadOrder` (`.pgdelta-export.json`); anything else
+loads in caller/lexicographic order. When a file cannot commit atomically,
+`statementFallback` (default on) keeps the prefix Postgres already accepted and
+retries the **remaining** statements in authored order after other files have
+progressed — it does not sort the file. Pass `false` for whole-file rollback.
+Files that contain session-setting statements (`SET search_path`, `SET ROLE`,
+any `SET LOCAL`, …) or `ALTER DEFAULT PRIVILEGES` stay file-atomic so those
+settings cannot expire or apply to sibling files' objects.
 
-The opt-in reordering assist is what actually reorders within a file: it
-splits files into one-statement units and topologically pre-sorts them via
-[`@supabase/pg-topo`](https://www.npmjs.com/package/@supabase/pg-topo).
+When the default order sticks, the loader **escalates instead of failing
+blind**: it reconnects once (a session-setting statement can poison the
+connection), then retries with late-kind files last (policies,
+publication/subscription DDL), then splits the stuck file into kind-ordered
+statement units. Every escalation emits a warning naming the stuck `file:line`,
+the statement to move (or a suggested `loadOrder`), and any session-poisoning
+statements — so you can fix the authored tree instead of depending on the
+rescue. `--no-reorder` (API: `reorderOnFailure: false`) skips the escalation,
+so a stuck load stays stuck.
+
+The kind classification rides on
+[`@supabase/pg-topo`](https://www.npmjs.com/package/@supabase/pg-topo):
 
 - **Subpath:** `@supabase/pg-delta/sql-order` exposes `orderForShadow(files)` /
   `analyzeForShadow(files)`, `canReorder()`, and the typed
@@ -237,9 +247,10 @@ splits files into one-statement units and topologically pre-sorts them via
 - **Dependency posture:** `@supabase/pg-topo` is an **optional peer**, loaded
   only through a guarded dynamic `import()`. Importing the core never pulls the
   libpg-query WASM parser. If the peer is absent the subpath throws with an
-  install hint; `canReorder()` probes instead.
-- **CLI:** `schema apply` runs the assist by default (`--no-reorder` opts out).
-  `schema lint --dir <dir>` runs the analyzer statically, with no database.
+  install hint; `canReorder()` probes instead, and `schema apply` warns and
+  loads raw at file granularity.
+- **CLI:** `schema lint --dir <dir>` runs the analyzer statically, with no
+  database.
 
 ## Documentation
 

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -230,9 +230,11 @@ settings cannot expire or apply to sibling files' objects.
 
 When the default order sticks, the loader **escalates instead of failing
 blind**: it reconnects once (a session-setting statement can poison the
-connection), then retries with late-kind files last (policies,
-publication/subscription DDL), then splits the stuck file into kind-ordered
-statement units. Every escalation emits a warning naming the stuck `file:line`,
+connection); `schema apply` / `planSchemaFiles` then retry with late-kind
+files last (policies, publication/subscription DDL) and finally split the
+stuck file into kind-ordered statement units. (Direct `loadSqlFiles` callers
+get only the reconnect unless they supply the `reorderFilesByKind` /
+`splitFileByKind` callbacks.) Every escalation emits a warning naming the stuck `file:line`,
 the statement to move (or a suggested `loadOrder`), and any session-poisoning
 statements — so you can fix the authored tree instead of depending on the
 rescue. `--no-reorder` (API: `reorderOnFailure: false`) disables only the two

--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -120,9 +120,9 @@ that belong to no schema:
 ```text
 schema/
   _cluster/
-    roles.sql
-    publications.sql
-    extensions/pgcrypto.sql
+    roles.sql                 ← cluster-global roles/memberships appear under
+    publications.sql             --scope cluster (the default --scope database
+    extensions/pgcrypto.sql      omits them)
   app/
     schema.sql
     tables/users.sql          ← columns, defaults, constraints, indexes,


### PR DESCRIPTION
## Summary

This PR converts ASCII art pipeline diagrams throughout the documentation to Mermaid flowcharts for better readability and maintainability. Every factual claim in the touched docs was verified against the source; the incorrect or stale ones are fixed here. All 11 Mermaid blocks were parse-validated with the mermaid library headlessly before pushing.

- **Diagram modernization**: Replaced text-based ASCII diagrams in architecture docs, getting-started guide, and README files with Mermaid `flowchart` syntax
- **Load order and reordering assist**: Updated documentation to reflect the new escalate-on-failure behavior (#445/#447) where the loader first tries the export manifest's `loadOrder` (else lexicographic path order on the CLI), reconnects once on a stuck session, then escalates to kind-based reordering with warnings naming the statement to move (`--no-reorder` disables only the reordering stages)
- **Schema export**: Documented the `--scope` flag (default `database` omits cluster-global roles; `cluster` includes them), corrected `--format-options` (formatting is ON by default; `--no-format` disables), and documented the `.pgdelta-export.json` manifest (custom profiles still need `--profile <path>` at apply time)
- **CLI reference**: Added `render` and `schema lint` to the command table, completed `schema export` / `schema apply` flag rows, documented exit code **3** (blocking diagnostics, e.g. the `--strict-coverage` refusal), and the custom-profile path form of `--profile`
- **Metrics refresh**: LOC counts re-measured with the docs' own methodology (38,468 total / 130 files, 22,973 engine slice) and corpus size (331 scenarios / 662 cases) as of 2026-08-25
- **Architecture corrections**:
  - Ownership and extension membership are dependency edges (`owner`, `memberOfExtension`, `managedBy`), not facts
  - Extension members are kept reference-only in `resolveView` (the documented `excludeExtensionMembers` no longer exists); dropped a dangling `tier-4-deferrals.md` pointer
  - The proof checks three things (added the rewrite-observation check); apply is lock-aware segmented txns, not a single txn
  - Parallel extraction shipped as opt-in `ExtractOptions.concurrency`; `resolveView` takes a `baseline` parameter
  - The removed `createPlan`/`applyPlan` names and the old `creates/drops/requires` contract no longer presented as current API
  - The `raw` profile ships the vault handler (presence + best-effort warnings; secret state never read); the topological sort lives in `src/plan/graph.ts` (onboarding map)
  - onboarding.md now names the four `src/plan/phases/`

All 8 findings from the Codex review rounds were verified against the code and fixed (threads resolved).

Note: the package README's pipeline diagram is now Mermaid, which GitHub renders but npmjs.com shows as a raw code block (kept simple enough to read as text).

## Linked issue

This is a documentation-only change with no associated issue.

- [x] This is a documentation update (no issue required)

## Checklist

- [x] No code changes requiring tests
- [x] No changeset needed (documentation only)
- [x] Diagrams converted to Mermaid, parse-validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QChKmcrCBQFYmwCmzXvvTD