### PR TITLE
fix(pg-delta): order an in-place alter after the in-place alter of its dependency

### DIFF
--- a/.changeset/alter-after-dep-cycles-and-transitive.md
+++ b/.changeset/alter-after-dep-cycles-and-transitive.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): walk through unchanged dependencies when ordering in-place ALTERs, and skip an alter-after-dep edge that would close an action-graph cycle. A column default over an unchanged domain now waits for the underlying enum ADD VALUE; a 3-domain default ring and a domain-default + new-column + OWNED BY sandwich stay sortable.

--- a/.changeset/enum-add-value-existing-default.md
+++ b/.changeset/enum-add-value-existing-default.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): order an in-place ALTER of a dependent after the in-place ALTER of what it depends on. Adding an enum value and pointing an existing column's default at it in the same plan previously emitted `ALTER TABLE … SET DEFAULT 'c'::st` before `ALTER TYPE st ADD VALUE 'c'`, so apply failed with 22P02 (invalid input value for enum).

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1557,36 +1557,16 @@ PR #455 orders an in-place ALTER after the in-place ALTER of a direct
 dependency (SET DEFAULT vs ADD VALUE). Pairwise reciprocal depends (two
 domains whose defaults reference each other) were fixed in-PR so the new
 edge does not turn a valid fact cycle into an unsortable action graph.
-Two round-2 Codex P2s and one round-3 P2 are **deferred**:
+The stacked follow-up (transitive walk + skip an alter-after-dep edge
+that would close an action-graph cycle) **fixed** the three later
+Codex P2s:
 
-- **Deferred — n-cycles of in-place-altered facts (3+ domain defaults,
-  or a BEGIN ATOMIC function ring, all changing in one plan).** The
-  pairwise back-edge skip does not see `d1 → d2 → d3 → d1`, so the new
-  edges close an action-graph cycle and `topoSort` throws. Loud, not a
-  silent wrong order. The 2-node case is the one that showed up in
-  review; chasing n-node SCCs here is the same contract one hop at a
-  time. A later change can skip edges whose endpoints sit in the same
-  desired-depends SCC of currently-altered facts.
-
-- **Deferred — transitive `depends` (column default → unchanged domain
-  → enum being ADD VALUEd).** The new walk matches the produces walk:
-  one hop on `outgoingEdges(subject)`. A default `'c'::dst` over an
-  unchanged domain whose base type is the enum records `default →
-  domain`, so ADD VALUE still falls through to the weight tie-break and
-  can 22P02. Same hole already exists for CREATE of a new column/default
-  through that domain. Fixing it properly is a transitive walk (or
-  reachability-to-alterer) on **both** sides, with the SCC skip above,
-  not an alter-only special case.
-
-- **Deferred — action-graph cycle via a newly produced consumer
-  (domain default ← sequence, new column of that domain, sequence
-  OWNED BY the new column).** Desired `depends` is acyclic (`c → d →
-  q`); extract deliberately omits the OWNED BY auto-edge because it
-  would cycle with the column default. The new alter-after-dep edge
-  (`q ALTER → d ALTER`) plus the existing produces walk (`d ALTER →
-  ADD c`) plus OWNED BY consuming the new column (`ADD c → q ALTER`)
-  closes a 3-action cycle. Parent planner emitted ALTER DOMAIN, ADD
-  COLUMN, ALTER SEQUENCE. Same loud `topoSort` failure class as the
-  n-ring; the "don't add an edge that closes a cycle" check they want
-  is general action-graph reachability, not another one-off guard.
-  Round 3 of the same contract.
+- **Fixed — n-cycles of in-place-altered facts.** Closing edge of a
+  3-domain default ring is dropped when the other two already give a
+  path; `topoSort` no longer throws.
+- **Fixed — transitive `depends` (column default → unchanged domain →
+  enum ADD VALUE).** The alter-after-dep walk continues through
+  unchanged facts until it hits an in-place alterer.
+- **Fixed — OWNED BY sandwich cycle.** `q ALTER → d ALTER` is skipped
+  because `d ALTER → ADD c → q ALTER` already exists; apply order stays
+  ALTER DOMAIN, ADD COLUMN, ALTER SEQUENCE.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1550,3 +1550,30 @@ not the contract this PR promised.
   `grant_option` flag is dropped, so those statements look like a plain
   grant/revoke. The consumer asked for GRANT vs REVOKE of the privilege
   itself, not grant-option bookkeeping.
+
+## PR #455 review triage (Codex) — alter-after-dependency order
+
+PR #455 orders an in-place ALTER after the in-place ALTER of a direct
+dependency (SET DEFAULT vs ADD VALUE). Pairwise reciprocal depends (two
+domains whose defaults reference each other) were fixed in-PR so the new
+edge does not turn a valid fact cycle into an unsortable action graph.
+Two round-2 Codex P2s are **deferred**:
+
+- **Deferred — n-cycles of in-place-altered facts (3+ domain defaults,
+  or a BEGIN ATOMIC function ring, all changing in one plan).** The
+  pairwise back-edge skip does not see `d1 → d2 → d3 → d1`, so the new
+  edges close an action-graph cycle and `topoSort` throws. Loud, not a
+  silent wrong order. The 2-node case is the one that showed up in
+  review; chasing n-node SCCs here is the same contract one hop at a
+  time. A later change can skip edges whose endpoints sit in the same
+  desired-depends SCC of currently-altered facts.
+
+- **Deferred — transitive `depends` (column default → unchanged domain
+  → enum being ADD VALUEd).** The new walk matches the produces walk:
+  one hop on `outgoingEdges(subject)`. A default `'c'::dst` over an
+  unchanged domain whose base type is the enum records `default →
+  domain`, so ADD VALUE still falls through to the weight tie-break and
+  can 22P02. Same hole already exists for CREATE of a new column/default
+  through that domain. Fixing it properly is a transitive walk (or
+  reachability-to-alterer) on **both** sides, with the SCC skip above,
+  not an alter-only special case.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1557,7 +1557,7 @@ PR #455 orders an in-place ALTER after the in-place ALTER of a direct
 dependency (SET DEFAULT vs ADD VALUE). Pairwise reciprocal depends (two
 domains whose defaults reference each other) were fixed in-PR so the new
 edge does not turn a valid fact cycle into an unsortable action graph.
-Two round-2 Codex P2s are **deferred**:
+Two round-2 Codex P2s and one round-3 P2 are **deferred**:
 
 - **Deferred — n-cycles of in-place-altered facts (3+ domain defaults,
   or a BEGIN ATOMIC function ring, all changing in one plan).** The
@@ -1577,3 +1577,16 @@ Two round-2 Codex P2s are **deferred**:
   through that domain. Fixing it properly is a transitive walk (or
   reachability-to-alterer) on **both** sides, with the SCC skip above,
   not an alter-only special case.
+
+- **Deferred — action-graph cycle via a newly produced consumer
+  (domain default ← sequence, new column of that domain, sequence
+  OWNED BY the new column).** Desired `depends` is acyclic (`c → d →
+  q`); extract deliberately omits the OWNED BY auto-edge because it
+  would cycle with the column default. The new alter-after-dep edge
+  (`q ALTER → d ALTER`) plus the existing produces walk (`d ALTER →
+  ADD c`) plus OWNED BY consuming the new column (`ADD c → q ALTER`)
+  closes a 3-action cycle. Parent planner emitted ALTER DOMAIN, ADD
+  COLUMN, ALTER SEQUENCE. Same loud `topoSort` failure class as the
+  n-ring; the "don't add an edge that closes a cycle" check they want
+  is general action-graph reachability, not another one-off guard.
+  Round 3 of the same contract.

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/a.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/a.sql
@@ -1,0 +1,8 @@
+CREATE TYPE public.st AS ENUM ('a', 'b');
+
+CREATE DOMAIN public.dst AS public.st;
+
+CREATE TABLE public.t (
+  id integer PRIMARY KEY,
+  s public.dst DEFAULT 'a'
+);

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/b.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/b.sql
@@ -1,0 +1,11 @@
+-- 'c' is a NEW enum value used as the NEW DEFAULT of an EXISTING column
+-- whose type is an UNCHANGED domain over the enum. The default depends on
+-- the domain, not the enum; ADD VALUE must still run (and commit) first.
+CREATE TYPE public.st AS ENUM ('a', 'b', 'c');
+
+CREATE DOMAIN public.dst AS public.st;
+
+CREATE TABLE public.t (
+  id integer PRIMARY KEY,
+  s public.dst DEFAULT 'c'
+);

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/seed-b.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.t (id, s) VALUES (1, 'a'), (2, 'b');

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/seed.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.t (id, s) VALUES (1, 'a'), (2, 'b');

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-existing-default/a.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-existing-default/a.sql
@@ -1,0 +1,6 @@
+CREATE TYPE public.st AS ENUM ('a', 'b');
+
+CREATE TABLE public.t (
+  id integer PRIMARY KEY,
+  s public.st DEFAULT 'a'
+);

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-existing-default/b.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-existing-default/b.sql
@@ -1,0 +1,13 @@
+-- 'c' is a NEW enum value, used as the NEW DEFAULT of an EXISTING column in
+-- the SAME plan: the ADD VALUE must be ordered before AND committed before the
+-- ALTER COLUMN … SET DEFAULT, or apply fails with 22P02 (invalid input value
+-- for enum). Distinct from enum-add-value-used-in-new-column: there the
+-- default is CREATED (a produces walk orders it after the type's alter); here
+-- the default is ALTERED in place, so the ordering must come from the
+-- alter-vs-alter path.
+CREATE TYPE public.st AS ENUM ('a', 'b', 'c');
+
+CREATE TABLE public.t (
+  id integer PRIMARY KEY,
+  s public.st DEFAULT 'c'
+);

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-existing-default/seed-b.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-existing-default/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.t (id, s) VALUES (1, 'a'), (2, 'b');

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-existing-default/seed.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-existing-default/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.t (id, s) VALUES (1, 'a'), (2, 'b');

--- a/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
+++ b/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
@@ -69,7 +69,12 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
     const setDefault = sql.findIndex((s) => s.includes("SET DEFAULT 'c'"));
     expect(addValue).toBeGreaterThanOrEqual(0);
     expect(setDefault).toBeGreaterThanOrEqual(0);
-    expect(sql).toMatchInlineSnapshot();
+    expect(sql).toMatchInlineSnapshot(`
+      [
+        "ALTER TYPE "public"."st" ADD VALUE 'c' AFTER 'b'",
+        "ALTER TABLE "public"."t" ALTER COLUMN "s" SET DEFAULT 'c'::public.st",
+      ]
+    `);
     expect(addValue).toBeLessThan(setDefault);
   });
 });

--- a/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
+++ b/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
@@ -1,0 +1,75 @@
+/**
+ * An in-place ALTER of a dependent must run AFTER the in-place ALTER of what
+ * it depends on (Slack report, 2026-09-02): adding an enum value and pointing
+ * an EXISTING column's default at that value in the same plan emitted
+ *
+ *   ALTER TABLE … ALTER COLUMN … SET DEFAULT 'c'::st;   -- 22P02: invalid input
+ *   ALTER TYPE … ADD VALUE 'c';
+ *
+ * The produces walk already orders a CREATE after in-place alterers of its
+ * dependencies (a NEW column with the new value as default works), but an
+ * alter action produces nothing, so the alter-vs-alter pair fell through to
+ * the weight tie-break (default 6 < type 7). No Docker — synthetic fact bases.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import type { StableId } from "../core/stable-id.ts";
+import { plan } from "./plan.ts";
+
+const schemaId: StableId = { kind: "schema", name: "public" };
+const typeId: StableId = { kind: "type", schema: "public", name: "st" };
+const tableId: StableId = { kind: "table", schema: "public", name: "t" };
+const columnId: StableId = {
+  kind: "column",
+  schema: "public",
+  table: "t",
+  name: "s",
+};
+const defaultId: StableId = {
+  kind: "default",
+  schema: "public",
+  table: "t",
+  name: "s",
+};
+
+const state = (values: string[], defaultValue: string) =>
+  buildFactBase(
+    [
+      { id: schemaId, payload: {} },
+      {
+        id: typeId,
+        parent: schemaId,
+        payload: { variant: "enum", values },
+      },
+      { id: tableId, parent: schemaId, payload: { persistence: "p" } },
+      {
+        id: columnId,
+        parent: tableId,
+        payload: { type: "public.st", notNull: false },
+      },
+      {
+        id: defaultId,
+        parent: columnId,
+        payload: { expr: `'${defaultValue}'::public.st` },
+      },
+    ] satisfies Fact[],
+    [
+      { from: columnId, to: typeId, kind: "depends" },
+      // pg_depend: the attrdef's Const of type st references pg_type st
+      { from: defaultId, to: typeId, kind: "depends" },
+    ],
+  );
+
+describe("plan() — in-place alter of a dependent follows its dependency's alter", () => {
+  test("SET DEFAULT to a new enum value is ordered after ADD VALUE", () => {
+    const source = state(["a", "b"], "a");
+    const desired = state(["a", "b", "c"], "c");
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    const addValue = sql.findIndex((s) => s.includes("ADD VALUE 'c'"));
+    const setDefault = sql.findIndex((s) => s.includes("SET DEFAULT 'c'"));
+    expect(addValue).toBeGreaterThanOrEqual(0);
+    expect(setDefault).toBeGreaterThanOrEqual(0);
+    expect(sql).toMatchInlineSnapshot();
+    expect(addValue).toBeLessThan(setDefault);
+  });
+});

--- a/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
+++ b/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
@@ -83,8 +83,7 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
     // ALTER DOMAIN … SET DEFAULT once both exist), both defaults changing in
     // one plan. Neither order is derivable from the fact graph and either
     // works at apply (both types exist throughout), so the edge must not be
-    // added in both directions — that would be an unsortable action graph
-    // where the previous behavior emitted both alters (Codex P2, PR #455).
+    // added in both directions — that would be an unsortable action graph.
     const d1: StableId = { kind: "domain", schema: "public", name: "d1" };
     const d2: StableId = { kind: "domain", schema: "public", name: "d2" };
     const domains = (def1: string, def2: string) =>
@@ -116,5 +115,180 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
         "ALTER DOMAIN "public"."d2" SET DEFAULT (2)::public.d1",
       ]
     `);
+  });
+
+  test("a three-domain default ring does not form a cycle", () => {
+    const d1: StableId = { kind: "domain", schema: "public", name: "d1" };
+    const d2: StableId = { kind: "domain", schema: "public", name: "d2" };
+    const d3: StableId = { kind: "domain", schema: "public", name: "d3" };
+    const domains = (a: string, b: string, c: string) =>
+      buildFactBase(
+        [
+          { id: schemaId, payload: {} },
+          {
+            id: d1,
+            parent: schemaId,
+            payload: { baseType: "integer", notNull: false, default: a },
+          },
+          {
+            id: d2,
+            parent: schemaId,
+            payload: { baseType: "integer", notNull: false, default: b },
+          },
+          {
+            id: d3,
+            parent: schemaId,
+            payload: { baseType: "integer", notNull: false, default: c },
+          },
+        ] satisfies Fact[],
+        [
+          { from: d1, to: d2, kind: "depends" },
+          { from: d2, to: d3, kind: "depends" },
+          { from: d3, to: d1, kind: "depends" },
+        ],
+      );
+    const source = domains(
+      "(1)::public.d2",
+      "(1)::public.d3",
+      "(1)::public.d1",
+    );
+    const desired = domains(
+      "(2)::public.d2",
+      "(2)::public.d3",
+      "(2)::public.d1",
+    );
+    expect(() => plan(source, desired)).not.toThrow();
+    expect(
+      plan(source, desired)
+        .actions.map((a) => a.sql)
+        .toSorted(),
+    ).toEqual([
+      `ALTER DOMAIN "public"."d1" SET DEFAULT (2)::public.d2`,
+      `ALTER DOMAIN "public"."d2" SET DEFAULT (2)::public.d3`,
+      `ALTER DOMAIN "public"."d3" SET DEFAULT (2)::public.d1`,
+    ]);
+  });
+
+  test("SET DEFAULT through an unchanged domain is ordered after ADD VALUE", () => {
+    const domainId: StableId = {
+      kind: "domain",
+      schema: "public",
+      name: "dst",
+    };
+    const throughDomain = (values: string[], defaultValue: string) =>
+      buildFactBase(
+        [
+          { id: schemaId, payload: {} },
+          {
+            id: typeId,
+            parent: schemaId,
+            payload: { variant: "enum", values },
+          },
+          {
+            id: domainId,
+            parent: schemaId,
+            payload: { baseType: "public.st", notNull: false, default: null },
+          },
+          { id: tableId, parent: schemaId, payload: { persistence: "p" } },
+          {
+            id: columnId,
+            parent: tableId,
+            payload: { type: "public.dst", notNull: false },
+          },
+          {
+            id: defaultId,
+            parent: columnId,
+            payload: { expr: `'${defaultValue}'::public.dst` },
+          },
+        ] satisfies Fact[],
+        [
+          { from: columnId, to: domainId, kind: "depends" },
+          { from: defaultId, to: domainId, kind: "depends" },
+          { from: domainId, to: typeId, kind: "depends" },
+        ],
+      );
+    const source = throughDomain(["a", "b"], "a");
+    const desired = throughDomain(["a", "b", "c"], "c");
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    const addValue = sql.findIndex((s) => s.includes("ADD VALUE 'c'"));
+    const setDefault = sql.findIndex((s) => s.includes("SET DEFAULT 'c'"));
+    expect(addValue).toBeGreaterThanOrEqual(0);
+    expect(setDefault).toBeGreaterThanOrEqual(0);
+    expect(addValue).toBeLessThan(setDefault);
+  });
+
+  test("OWNED BY a new column of a domain whose default uses the sequence stays sortable", () => {
+    const domainId: StableId = { kind: "domain", schema: "public", name: "d" };
+    const seqId: StableId = { kind: "sequence", schema: "public", name: "q" };
+    const newCol: StableId = {
+      kind: "column",
+      schema: "public",
+      table: "t",
+      name: "c",
+    };
+    const seqPayload = (
+      ownedBy: { schema: string; table: string; column: string } | null,
+    ) => ({
+      dataType: "bigint",
+      increment: "1",
+      minValue: "1",
+      maxValue: "9223372036854775807",
+      start: "1",
+      cache: "1",
+      cycle: false,
+      ownedBy,
+    });
+    const source = buildFactBase(
+      [
+        { id: schemaId, payload: {} },
+        { id: tableId, parent: schemaId, payload: { persistence: "p" } },
+        {
+          id: domainId,
+          parent: schemaId,
+          payload: { baseType: "bigint", notNull: false, default: "1" },
+        },
+        { id: seqId, parent: schemaId, payload: seqPayload(null) },
+      ] satisfies Fact[],
+      [],
+    );
+    const desired = buildFactBase(
+      [
+        { id: schemaId, payload: {} },
+        { id: tableId, parent: schemaId, payload: { persistence: "p" } },
+        {
+          id: domainId,
+          parent: schemaId,
+          payload: {
+            baseType: "bigint",
+            notNull: false,
+            default: `nextval('public.q'::regclass)`,
+          },
+        },
+        {
+          id: seqId,
+          parent: schemaId,
+          payload: seqPayload({
+            schema: "public",
+            table: "t",
+            column: "c",
+          }),
+        },
+        {
+          id: newCol,
+          parent: tableId,
+          payload: { type: "public.d", notNull: false },
+        },
+      ] satisfies Fact[],
+      [
+        { from: domainId, to: seqId, kind: "depends" },
+        { from: newCol, to: domainId, kind: "depends" },
+      ],
+    );
+    expect(() => plan(source, desired)).not.toThrow();
+    expect(plan(source, desired).actions.map((a) => a.sql)).toEqual([
+      `ALTER DOMAIN "public"."d" SET DEFAULT nextval('public.q'::regclass)`,
+      `ALTER TABLE "public"."t" ADD COLUMN "c" public.d`,
+      `ALTER SEQUENCE "public"."q" OWNED BY "public"."t"."c"`,
+    ]);
   });
 });

--- a/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
+++ b/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
@@ -77,4 +77,39 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
     `);
     expect(addValue).toBeLessThan(setDefault);
   });
+
+  test("reciprocal dependencies between two altered facts do not form a cycle", () => {
+    // Two domains whose DEFAULT expressions reference each other (possible via
+    // ALTER DOMAIN … SET DEFAULT once both exist), both defaults changing in
+    // one plan. Neither order is derivable from the fact graph and either
+    // works at apply (both types exist throughout), so the edge must not be
+    // added in both directions — that would be an unsortable action graph
+    // where the previous behavior emitted both alters (Codex P2, PR #455).
+    const d1: StableId = { kind: "domain", schema: "public", name: "d1" };
+    const d2: StableId = { kind: "domain", schema: "public", name: "d2" };
+    const domains = (def1: string, def2: string) =>
+      buildFactBase(
+        [
+          { id: schemaId, payload: {} },
+          {
+            id: d1,
+            parent: schemaId,
+            payload: { baseType: "integer", notNull: false, default: def1 },
+          },
+          {
+            id: d2,
+            parent: schemaId,
+            payload: { baseType: "integer", notNull: false, default: def2 },
+          },
+        ] satisfies Fact[],
+        [
+          { from: d1, to: d2, kind: "depends" },
+          { from: d2, to: d1, kind: "depends" },
+        ],
+      );
+    const source = domains("(1)::public.d2", "(1)::public.d1");
+    const desired = domains("(2)::public.d2", "(2)::public.d1");
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    expect(sql).toMatchInlineSnapshot();
+  });
 });

--- a/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
+++ b/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
@@ -110,6 +110,11 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
     const source = domains("(1)::public.d2", "(1)::public.d1");
     const desired = domains("(2)::public.d2", "(2)::public.d1");
     const sql = plan(source, desired).actions.map((a) => a.sql);
-    expect(sql).toMatchInlineSnapshot();
+    expect(sql).toMatchInlineSnapshot(`
+      [
+        "ALTER DOMAIN "public"."d1" SET DEFAULT (2)::public.d2",
+        "ALTER DOMAIN "public"."d2" SET DEFAULT (2)::public.d1",
+      ]
+    `);
   });
 });

--- a/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
+++ b/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
@@ -1,6 +1,6 @@
 /**
  * An in-place ALTER of a dependent must run AFTER the in-place ALTER of what
- * it depends on (Slack report, 2026-09-02): adding an enum value and pointing
+ * it depends on: adding an enum value and pointing
  * an EXISTING column's default at that value in the same plan emitted
  *
  *   ALTER TABLE … ALTER COLUMN … SET DEFAULT 'c'::st;   -- 22P02: invalid input

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -269,6 +269,7 @@ export function buildActionGraph(
     alterersOf.set(key, list);
   });
 
+  const alterAfterDep: Array<[before: number, after: number]> = [];
   actions.forEach((action, index) => {
     for (const id of action.releases) {
       const destroyer = destroyerOf.get(remember(id));
@@ -349,39 +350,49 @@ export function buildActionGraph(
         );
       }
     }
-    // An in-place ALTER of a dependent runs AFTER the in-place alterers of what
-    // its subject depends on — the alter-side mirror of the produces-walk rule
-    // below ("create the dependent against its FINAL state"). An alter produces
-    // nothing, so without this edge the pair fell through to the weight
-    // tie-break: `ALTER TABLE … SET DEFAULT 'c'::st` (default, weight 6) sorted
-    // before `ALTER TYPE st ADD VALUE 'c'` (type, weight 7) and apply failed
-    // with 22P02 (the NEW column case never hit it — its default is CREATED).
-    // Same guard as the produces side: a dependency alterer that itself
-    // consumes our subject needs us first, so it is skipped. A dependency this
-    // plan (re)produces orders through the producer edge above, not here.
-    // RECIPROCAL dependencies (two domains whose defaults reference each
-    // other — possible via ALTER DOMAIN … SET DEFAULT once both exist) derive
-    // no order from the fact graph, and either order applies since both
-    // objects exist throughout: adding the edge from both sides would make a
-    // valid fact cycle an unsortable action graph, so such pairs fall through
-    // to the tie-break as before (Codex P2, PR #455).
+    // An in-place ALTER of a dependent runs AFTER in-place alterers of what
+    // its subject depends on — including through unchanged facts (a column
+    // default over a domain whose base enum is ADD VALUEd). Candidates are
+    // applied after this loop so produces/consumes edges already exist; an
+    // edge that would close an action-graph cycle is dropped (the remaining
+    // path is the runnable order). A mutual pair of altered facts is skipped
+    // here so both directions do not force an order; either apply works.
     if (action.verb === "alter") {
       const subject = action.consumes[0];
       if (subject !== undefined && desired.has(subject)) {
         const subjectKey = encodeId(subject);
-        for (const edge of desired.outgoingEdges(subject)) {
-          const targetKey = remember(edge.to);
-          if (producerOf.has(targetKey)) continue;
-          const reciprocal = desired
-            .outgoingEdges(edge.to)
-            .some((back) => encodeId(back.to) === subjectKey);
-          if (reciprocal) continue;
-          for (const alterer of alterersOf.get(targetKey) ?? []) {
-            if (alterer === index) continue;
-            const altererConsumesSubject = (
-              actions[alterer] as Action
-            ).consumes.some((c) => encodeId(c) === subjectKey);
-            if (!altererConsumesSubject) edges.push([alterer, index]);
+        const seen = new Set<string>([subjectKey]);
+        const queue: StableId[] = [subject];
+        while (queue.length > 0) {
+          const current = queue.shift() as StableId;
+          const fromSubject = encodeId(current) === subjectKey;
+          for (const edge of desired.outgoingEdges(current)) {
+            const targetKey = remember(edge.to);
+            if (seen.has(targetKey)) continue;
+            seen.add(targetKey);
+            if (producerOf.has(targetKey)) continue;
+            const alterers = alterersOf.get(targetKey) ?? [];
+            if (alterers.length > 0) {
+              if (
+                fromSubject &&
+                desired
+                  .outgoingEdges(edge.to)
+                  .some((back) => encodeId(back.to) === subjectKey)
+              ) {
+                continue;
+              }
+              for (const alterer of alterers) {
+                if (alterer === index) continue;
+                const altererConsumesSubject = (
+                  actions[alterer] as Action
+                ).consumes.some((c) => encodeId(c) === subjectKey);
+                if (!altererConsumesSubject) {
+                  alterAfterDep.push([alterer, index]);
+                }
+              }
+              continue;
+            }
+            queue.push(edge.to);
           }
         }
       }
@@ -543,7 +554,37 @@ export function buildActionGraph(
     }
   });
 
+  for (const [before, after] of alterAfterDep) {
+    if (!actionReaches(edges, after, before)) edges.push([before, after]);
+  }
   return edges;
+}
+
+/** True when `from` can reach `to` following `[before, after]` action edges. */
+function actionReaches(
+  edges: readonly [before: number, after: number][],
+  from: number,
+  to: number,
+): boolean {
+  if (from === to) return true;
+  const adj = new Map<number, number[]>();
+  for (const [u, v] of edges) {
+    const list = adj.get(u) ?? [];
+    list.push(v);
+    adj.set(u, list);
+  }
+  const seen = new Set<number>([from]);
+  const queue = [from];
+  while (queue.length > 0) {
+    const cur = queue.shift() as number;
+    for (const next of adj.get(cur) ?? []) {
+      if (next === to) return true;
+      if (seen.has(next)) continue;
+      seen.add(next);
+      queue.push(next);
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -359,6 +359,12 @@ export function buildActionGraph(
     // Same guard as the produces side: a dependency alterer that itself
     // consumes our subject needs us first, so it is skipped. A dependency this
     // plan (re)produces orders through the producer edge above, not here.
+    // RECIPROCAL dependencies (two domains whose defaults reference each
+    // other — possible via ALTER DOMAIN … SET DEFAULT once both exist) derive
+    // no order from the fact graph, and either order applies since both
+    // objects exist throughout: adding the edge from both sides would make a
+    // valid fact cycle an unsortable action graph, so such pairs fall through
+    // to the tie-break as before (Codex P2, PR #455).
     if (action.verb === "alter") {
       const subject = action.consumes[0];
       if (subject !== undefined && desired.has(subject)) {
@@ -366,6 +372,10 @@ export function buildActionGraph(
         for (const edge of desired.outgoingEdges(subject)) {
           const targetKey = remember(edge.to);
           if (producerOf.has(targetKey)) continue;
+          const reciprocal = desired
+            .outgoingEdges(edge.to)
+            .some((back) => encodeId(back.to) === subjectKey);
+          if (reciprocal) continue;
           for (const alterer of alterersOf.get(targetKey) ?? []) {
             if (alterer === index) continue;
             const altererConsumesSubject = (

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -349,6 +349,33 @@ export function buildActionGraph(
         );
       }
     }
+    // An in-place ALTER of a dependent runs AFTER the in-place alterers of what
+    // its subject depends on — the alter-side mirror of the produces-walk rule
+    // below ("create the dependent against its FINAL state"). An alter produces
+    // nothing, so without this edge the pair fell through to the weight
+    // tie-break: `ALTER TABLE … SET DEFAULT 'c'::st` (default, weight 6) sorted
+    // before `ALTER TYPE st ADD VALUE 'c'` (type, weight 7) and apply failed
+    // with 22P02 (the NEW column case never hit it — its default is CREATED).
+    // Same guard as the produces side: a dependency alterer that itself
+    // consumes our subject needs us first, so it is skipped. A dependency this
+    // plan (re)produces orders through the producer edge above, not here.
+    if (action.verb === "alter") {
+      const subject = action.consumes[0];
+      if (subject !== undefined && desired.has(subject)) {
+        const subjectKey = encodeId(subject);
+        for (const edge of desired.outgoingEdges(subject)) {
+          const targetKey = remember(edge.to);
+          if (producerOf.has(targetKey)) continue;
+          for (const alterer of alterersOf.get(targetKey) ?? []) {
+            if (alterer === index) continue;
+            const altererConsumesSubject = (
+              actions[alterer] as Action
+            ).consumes.some((c) => encodeId(c) === subjectKey);
+            if (!altererConsumesSubject) edges.push([alterer, index]);
+          }
+        }
+      }
+    }
     // An alter materializes nothing, so its expression fact is CONSUMED, not
     // produced: `VALIDATE CONSTRAINT` (NOT VALID → VALID) rescans every row and
     // `SET DEFAULT` / a generated-expression change re-evaluate the expression.

--- a/packages/pg-delta/tests/expected-red.ts
+++ b/packages/pg-delta/tests/expected-red.ts
@@ -27,4 +27,9 @@ export const EXPECTED_RED: ReadonlyMap<string, RedPin> = new Map<
   // reverse (teardown) direction is expected-red ON PG16+ ONLY — pre-16 has no
   // dependent tracking, plain REVOKE succeeds, and the scenario passes.
   ["role-membership-dedup--multi-grantor:reverse", { minMajor: 16 }],
+  // Reverse is an enum value-set rebuild (drop 'c') while DOMAIN dst still
+  // depends on the enum — the planner refuses that, same as any domain-over-enum
+  // shrink. Forward (ADD VALUE + SET DEFAULT through the domain) is the hole
+  // this pin's sibling scenario covers.
+  ["type-ops--enum-add-value-used-in-domain-default:reverse", {}],
 ]);


### PR DESCRIPTION
## Summary

Adding an enum value and pointing an **existing** column's default at that value in the same plan emitted the statements in the wrong order, so apply failed with `22P02` (invalid input value for enum):

```sql
-- before this PR
ALTER TABLE "public"."t" ALTER COLUMN "s" SET DEFAULT 'c'::public.st;
ALTER TYPE "public"."st" ADD VALUE 'c' AFTER 'b';

-- after this PR
ALTER TYPE "public"."st" ADD VALUE 'c' AFTER 'b';
ALTER TABLE "public"."t" ALTER COLUMN "s" SET DEFAULT 'c'::public.st;
```

**Root cause.** `buildActionGraph` (`packages/pg-delta/src/plan/internal.ts`) orders a CREATE after the in-place alterers of the facts it depends on ("create the dependent against its FINAL state"), which is why a *new* column defaulting to a new enum value already worked. An ALTER produces nothing, so an alter-vs-alter pair got no edge and fell through to the kind-weight tie-break, where `default` (6) sorts before `type` (7).

**Fix.** Add the alter-side mirror of that rule: for an alter action, walk the desired outgoing edges of its subject and order it after every in-place alterer of a dependency this plan does not (re)produce, with the same "the alterer consumes our subject" guard the produces walk uses. The ADD VALUE already forces a commit boundary after itself, so fixing the order alone fixes apply.

**Cycle safety and transitive dependencies** (Codex review, three rounds; the last two landed via the stacked #456, squashed into this branch as 213b837): the walk continues through unchanged facts until it reaches an in-place alterer, and an edge is added only when the dependent cannot already reach the dependency's alterer, so it never turns a sortable action graph into a cycle. Covers reciprocal domain defaults, n-domain default rings, a column default through an unchanged domain over the extended enum, and a sequence `OWNED BY` a new column of a domain whose default the sequence feeds. The domain-over-enum corpus scenario's reverse direction is `EXPECTED_RED` (enum value removal blocked by a dependent domain, pre-existing unsupported rebuild). Triage notes in `docs/roadmap/pg-delta-next-follow-ups.md` under "PR #455 review triage (Codex)".

Commits follow the RED → GREEN split for each fix: failing test first, then the production change.

Validation: unit suite green; full corpus on `postgres:17-alpine` green on the pre-#456 head (664/664), CI matrix PG 14–18 on the final head; `format-and-lint`, `check-types`, `knip` clean.

## Linked issue

No GitHub issue; reported internally.

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNzZS5YcStDVZftvmFW5V7