### PR TITLE
fix(pg-delta): walk transitive alter-after-dep edges and skip cycle-closing ones

### DIFF
--- a/.changeset/alter-after-dep-cycles-and-transitive.md
+++ b/.changeset/alter-after-dep-cycles-and-transitive.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): walk through unchanged dependencies when ordering in-place ALTERs, and skip an alter-after-dep edge that would close an action-graph cycle. A column default over an unchanged domain now waits for the underlying enum ADD VALUE; a 3-domain default ring and a domain-default + new-column + OWNED BY sandwich stay sortable.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1557,36 +1557,16 @@ PR #455 orders an in-place ALTER after the in-place ALTER of a direct
 dependency (SET DEFAULT vs ADD VALUE). Pairwise reciprocal depends (two
 domains whose defaults reference each other) were fixed in-PR so the new
 edge does not turn a valid fact cycle into an unsortable action graph.
-Two round-2 Codex P2s and one round-3 P2 are **deferred**:
+The stacked follow-up (transitive walk + skip an alter-after-dep edge
+that would close an action-graph cycle) **fixed** the three later
+Codex P2s:
 
-- **Deferred — n-cycles of in-place-altered facts (3+ domain defaults,
-  or a BEGIN ATOMIC function ring, all changing in one plan).** The
-  pairwise back-edge skip does not see `d1 → d2 → d3 → d1`, so the new
-  edges close an action-graph cycle and `topoSort` throws. Loud, not a
-  silent wrong order. The 2-node case is the one that showed up in
-  review; chasing n-node SCCs here is the same contract one hop at a
-  time. A later change can skip edges whose endpoints sit in the same
-  desired-depends SCC of currently-altered facts.
-
-- **Deferred — transitive `depends` (column default → unchanged domain
-  → enum being ADD VALUEd).** The new walk matches the produces walk:
-  one hop on `outgoingEdges(subject)`. A default `'c'::dst` over an
-  unchanged domain whose base type is the enum records `default →
-  domain`, so ADD VALUE still falls through to the weight tie-break and
-  can 22P02. Same hole already exists for CREATE of a new column/default
-  through that domain. Fixing it properly is a transitive walk (or
-  reachability-to-alterer) on **both** sides, with the SCC skip above,
-  not an alter-only special case.
-
-- **Deferred — action-graph cycle via a newly produced consumer
-  (domain default ← sequence, new column of that domain, sequence
-  OWNED BY the new column).** Desired `depends` is acyclic (`c → d →
-  q`); extract deliberately omits the OWNED BY auto-edge because it
-  would cycle with the column default. The new alter-after-dep edge
-  (`q ALTER → d ALTER`) plus the existing produces walk (`d ALTER →
-  ADD c`) plus OWNED BY consuming the new column (`ADD c → q ALTER`)
-  closes a 3-action cycle. Parent planner emitted ALTER DOMAIN, ADD
-  COLUMN, ALTER SEQUENCE. Same loud `topoSort` failure class as the
-  n-ring; the "don't add an edge that closes a cycle" check they want
-  is general action-graph reachability, not another one-off guard.
-  Round 3 of the same contract.
+- **Fixed — n-cycles of in-place-altered facts.** Closing edge of a
+  3-domain default ring is dropped when the other two already give a
+  path; `topoSort` no longer throws.
+- **Fixed — transitive `depends` (column default → unchanged domain →
+  enum ADD VALUE).** The alter-after-dep walk continues through
+  unchanged facts until it hits an in-place alterer.
+- **Fixed — OWNED BY sandwich cycle.** `q ALTER → d ALTER` is skipped
+  because `d ALTER → ADD c → q ALTER` already exists; apply order stays
+  ALTER DOMAIN, ADD COLUMN, ALTER SEQUENCE.

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/a.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/a.sql
@@ -1,0 +1,8 @@
+CREATE TYPE public.st AS ENUM ('a', 'b');
+
+CREATE DOMAIN public.dst AS public.st;
+
+CREATE TABLE public.t (
+  id integer PRIMARY KEY,
+  s public.dst DEFAULT 'a'
+);

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/b.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/b.sql
@@ -1,0 +1,11 @@
+-- 'c' is a NEW enum value used as the NEW DEFAULT of an EXISTING column
+-- whose type is an UNCHANGED domain over the enum. The default depends on
+-- the domain, not the enum; ADD VALUE must still run (and commit) first.
+CREATE TYPE public.st AS ENUM ('a', 'b', 'c');
+
+CREATE DOMAIN public.dst AS public.st;
+
+CREATE TABLE public.t (
+  id integer PRIMARY KEY,
+  s public.dst DEFAULT 'c'
+);

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/seed-b.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/seed-b.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.t (id, s) VALUES (1, 'a'), (2, 'b');

--- a/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/seed.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-add-value-used-in-domain-default/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.t (id, s) VALUES (1, 'a'), (2, 'b');

--- a/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
+++ b/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
@@ -83,8 +83,7 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
     // ALTER DOMAIN … SET DEFAULT once both exist), both defaults changing in
     // one plan. Neither order is derivable from the fact graph and either
     // works at apply (both types exist throughout), so the edge must not be
-    // added in both directions — that would be an unsortable action graph
-    // where the previous behavior emitted both alters (Codex P2, PR #455).
+    // added in both directions — that would be an unsortable action graph.
     const d1: StableId = { kind: "domain", schema: "public", name: "d1" };
     const d2: StableId = { kind: "domain", schema: "public", name: "d2" };
     const domains = (def1: string, def2: string) =>
@@ -148,10 +147,22 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
           { from: d3, to: d1, kind: "depends" },
         ],
       );
-    const source = domains("(1)::public.d2", "(1)::public.d3", "(1)::public.d1");
-    const desired = domains("(2)::public.d2", "(2)::public.d3", "(2)::public.d1");
+    const source = domains(
+      "(1)::public.d2",
+      "(1)::public.d3",
+      "(1)::public.d1",
+    );
+    const desired = domains(
+      "(2)::public.d2",
+      "(2)::public.d3",
+      "(2)::public.d1",
+    );
     expect(() => plan(source, desired)).not.toThrow();
-    expect(plan(source, desired).actions.map((a) => a.sql).toSorted()).toEqual([
+    expect(
+      plan(source, desired)
+        .actions.map((a) => a.sql)
+        .toSorted(),
+    ).toEqual([
       `ALTER DOMAIN "public"."d1" SET DEFAULT (2)::public.d2`,
       `ALTER DOMAIN "public"."d2" SET DEFAULT (2)::public.d3`,
       `ALTER DOMAIN "public"."d3" SET DEFAULT (2)::public.d1`,
@@ -159,7 +170,11 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
   });
 
   test("SET DEFAULT through an unchanged domain is ordered after ADD VALUE", () => {
-    const domainId: StableId = { kind: "domain", schema: "public", name: "dst" };
+    const domainId: StableId = {
+      kind: "domain",
+      schema: "public",
+      name: "dst",
+    };
     const throughDomain = (values: string[], defaultValue: string) =>
       buildFactBase(
         [
@@ -211,7 +226,9 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
       table: "t",
       name: "c",
     };
-    const seqPayload = (ownedBy: unknown) => ({
+    const seqPayload = (
+      ownedBy: { schema: string; table: string; column: string } | null,
+    ) => ({
       dataType: "bigint",
       increment: "1",
       minValue: "1",

--- a/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
+++ b/packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts
@@ -117,4 +117,161 @@ describe("plan() — in-place alter of a dependent follows its dependency's alte
       ]
     `);
   });
+
+  test("a three-domain default ring does not form a cycle", () => {
+    const d1: StableId = { kind: "domain", schema: "public", name: "d1" };
+    const d2: StableId = { kind: "domain", schema: "public", name: "d2" };
+    const d3: StableId = { kind: "domain", schema: "public", name: "d3" };
+    const domains = (a: string, b: string, c: string) =>
+      buildFactBase(
+        [
+          { id: schemaId, payload: {} },
+          {
+            id: d1,
+            parent: schemaId,
+            payload: { baseType: "integer", notNull: false, default: a },
+          },
+          {
+            id: d2,
+            parent: schemaId,
+            payload: { baseType: "integer", notNull: false, default: b },
+          },
+          {
+            id: d3,
+            parent: schemaId,
+            payload: { baseType: "integer", notNull: false, default: c },
+          },
+        ] satisfies Fact[],
+        [
+          { from: d1, to: d2, kind: "depends" },
+          { from: d2, to: d3, kind: "depends" },
+          { from: d3, to: d1, kind: "depends" },
+        ],
+      );
+    const source = domains("(1)::public.d2", "(1)::public.d3", "(1)::public.d1");
+    const desired = domains("(2)::public.d2", "(2)::public.d3", "(2)::public.d1");
+    expect(() => plan(source, desired)).not.toThrow();
+    expect(plan(source, desired).actions.map((a) => a.sql).toSorted()).toEqual([
+      `ALTER DOMAIN "public"."d1" SET DEFAULT (2)::public.d2`,
+      `ALTER DOMAIN "public"."d2" SET DEFAULT (2)::public.d3`,
+      `ALTER DOMAIN "public"."d3" SET DEFAULT (2)::public.d1`,
+    ]);
+  });
+
+  test("SET DEFAULT through an unchanged domain is ordered after ADD VALUE", () => {
+    const domainId: StableId = { kind: "domain", schema: "public", name: "dst" };
+    const throughDomain = (values: string[], defaultValue: string) =>
+      buildFactBase(
+        [
+          { id: schemaId, payload: {} },
+          {
+            id: typeId,
+            parent: schemaId,
+            payload: { variant: "enum", values },
+          },
+          {
+            id: domainId,
+            parent: schemaId,
+            payload: { baseType: "public.st", notNull: false, default: null },
+          },
+          { id: tableId, parent: schemaId, payload: { persistence: "p" } },
+          {
+            id: columnId,
+            parent: tableId,
+            payload: { type: "public.dst", notNull: false },
+          },
+          {
+            id: defaultId,
+            parent: columnId,
+            payload: { expr: `'${defaultValue}'::public.dst` },
+          },
+        ] satisfies Fact[],
+        [
+          { from: columnId, to: domainId, kind: "depends" },
+          { from: defaultId, to: domainId, kind: "depends" },
+          { from: domainId, to: typeId, kind: "depends" },
+        ],
+      );
+    const source = throughDomain(["a", "b"], "a");
+    const desired = throughDomain(["a", "b", "c"], "c");
+    const sql = plan(source, desired).actions.map((a) => a.sql);
+    const addValue = sql.findIndex((s) => s.includes("ADD VALUE 'c'"));
+    const setDefault = sql.findIndex((s) => s.includes("SET DEFAULT 'c'"));
+    expect(addValue).toBeGreaterThanOrEqual(0);
+    expect(setDefault).toBeGreaterThanOrEqual(0);
+    expect(addValue).toBeLessThan(setDefault);
+  });
+
+  test("OWNED BY a new column of a domain whose default uses the sequence stays sortable", () => {
+    const domainId: StableId = { kind: "domain", schema: "public", name: "d" };
+    const seqId: StableId = { kind: "sequence", schema: "public", name: "q" };
+    const newCol: StableId = {
+      kind: "column",
+      schema: "public",
+      table: "t",
+      name: "c",
+    };
+    const seqPayload = (ownedBy: unknown) => ({
+      dataType: "bigint",
+      increment: "1",
+      minValue: "1",
+      maxValue: "9223372036854775807",
+      start: "1",
+      cache: "1",
+      cycle: false,
+      ownedBy,
+    });
+    const source = buildFactBase(
+      [
+        { id: schemaId, payload: {} },
+        { id: tableId, parent: schemaId, payload: { persistence: "p" } },
+        {
+          id: domainId,
+          parent: schemaId,
+          payload: { baseType: "bigint", notNull: false, default: "1" },
+        },
+        { id: seqId, parent: schemaId, payload: seqPayload(null) },
+      ] satisfies Fact[],
+      [],
+    );
+    const desired = buildFactBase(
+      [
+        { id: schemaId, payload: {} },
+        { id: tableId, parent: schemaId, payload: { persistence: "p" } },
+        {
+          id: domainId,
+          parent: schemaId,
+          payload: {
+            baseType: "bigint",
+            notNull: false,
+            default: `nextval('public.q'::regclass)`,
+          },
+        },
+        {
+          id: seqId,
+          parent: schemaId,
+          payload: seqPayload({
+            schema: "public",
+            table: "t",
+            column: "c",
+          }),
+        },
+        {
+          id: newCol,
+          parent: tableId,
+          payload: { type: "public.d", notNull: false },
+        },
+      ] satisfies Fact[],
+      [
+        { from: domainId, to: seqId, kind: "depends" },
+        { from: newCol, to: domainId, kind: "depends" },
+      ],
+    );
+    expect(() => plan(source, desired)).not.toThrow();
+    expect(plan(source, desired).actions.map((a) => a.sql)).toEqual([
+      `ALTER DOMAIN "public"."d" SET DEFAULT nextval('public.q'::regclass)`,
+      `ALTER TABLE "public"."t" ADD COLUMN "c" public.d`,
+      `ALTER SEQUENCE "public"."q" OWNED BY "public"."t"."c"`,
+    ]);
+  });
 });

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -269,6 +269,7 @@ export function buildActionGraph(
     alterersOf.set(key, list);
   });
 
+  const alterAfterDep: Array<[before: number, after: number]> = [];
   actions.forEach((action, index) => {
     for (const id of action.releases) {
       const destroyer = destroyerOf.get(remember(id));
@@ -349,39 +350,49 @@ export function buildActionGraph(
         );
       }
     }
-    // An in-place ALTER of a dependent runs AFTER the in-place alterers of what
-    // its subject depends on — the alter-side mirror of the produces-walk rule
-    // below ("create the dependent against its FINAL state"). An alter produces
-    // nothing, so without this edge the pair fell through to the weight
-    // tie-break: `ALTER TABLE … SET DEFAULT 'c'::st` (default, weight 6) sorted
-    // before `ALTER TYPE st ADD VALUE 'c'` (type, weight 7) and apply failed
-    // with 22P02 (the NEW column case never hit it — its default is CREATED).
-    // Same guard as the produces side: a dependency alterer that itself
-    // consumes our subject needs us first, so it is skipped. A dependency this
-    // plan (re)produces orders through the producer edge above, not here.
-    // RECIPROCAL dependencies (two domains whose defaults reference each
-    // other — possible via ALTER DOMAIN … SET DEFAULT once both exist) derive
-    // no order from the fact graph, and either order applies since both
-    // objects exist throughout: adding the edge from both sides would make a
-    // valid fact cycle an unsortable action graph, so such pairs fall through
-    // to the tie-break as before (Codex P2, PR #455).
+    // An in-place ALTER of a dependent runs AFTER in-place alterers of what
+    // its subject depends on — including through unchanged facts (a column
+    // default over a domain whose base enum is ADD VALUEd). Candidates are
+    // applied after this loop so produces/consumes edges already exist; an
+    // edge that would close an action-graph cycle is dropped (the remaining
+    // path is the runnable order). A mutual pair of altered facts is skipped
+    // here so both directions do not force an order; either apply works.
     if (action.verb === "alter") {
       const subject = action.consumes[0];
       if (subject !== undefined && desired.has(subject)) {
         const subjectKey = encodeId(subject);
-        for (const edge of desired.outgoingEdges(subject)) {
-          const targetKey = remember(edge.to);
-          if (producerOf.has(targetKey)) continue;
-          const reciprocal = desired
-            .outgoingEdges(edge.to)
-            .some((back) => encodeId(back.to) === subjectKey);
-          if (reciprocal) continue;
-          for (const alterer of alterersOf.get(targetKey) ?? []) {
-            if (alterer === index) continue;
-            const altererConsumesSubject = (
-              actions[alterer] as Action
-            ).consumes.some((c) => encodeId(c) === subjectKey);
-            if (!altererConsumesSubject) edges.push([alterer, index]);
+        const seen = new Set<string>([subjectKey]);
+        const queue: StableId[] = [subject];
+        while (queue.length > 0) {
+          const current = queue.shift() as StableId;
+          const fromSubject = encodeId(current) === subjectKey;
+          for (const edge of desired.outgoingEdges(current)) {
+            const targetKey = remember(edge.to);
+            if (seen.has(targetKey)) continue;
+            seen.add(targetKey);
+            if (producerOf.has(targetKey)) continue;
+            const alterers = alterersOf.get(targetKey) ?? [];
+            if (alterers.length > 0) {
+              if (
+                fromSubject &&
+                desired
+                  .outgoingEdges(edge.to)
+                  .some((back) => encodeId(back.to) === subjectKey)
+              ) {
+                continue;
+              }
+              for (const alterer of alterers) {
+                if (alterer === index) continue;
+                const altererConsumesSubject = (
+                  actions[alterer] as Action
+                ).consumes.some((c) => encodeId(c) === subjectKey);
+                if (!altererConsumesSubject) {
+                  alterAfterDep.push([alterer, index]);
+                }
+              }
+              continue;
+            }
+            queue.push(edge.to);
           }
         }
       }
@@ -543,7 +554,37 @@ export function buildActionGraph(
     }
   });
 
+  for (const [before, after] of alterAfterDep) {
+    if (!actionReaches(edges, after, before)) edges.push([before, after]);
+  }
   return edges;
+}
+
+/** True when `from` can reach `to` following `[before, after]` action edges. */
+function actionReaches(
+  edges: readonly [before: number, after: number][],
+  from: number,
+  to: number,
+): boolean {
+  if (from === to) return true;
+  const adj = new Map<number, number[]>();
+  for (const [u, v] of edges) {
+    const list = adj.get(u) ?? [];
+    list.push(v);
+    adj.set(u, list);
+  }
+  const seen = new Set<number>([from]);
+  const queue = [from];
+  while (queue.length > 0) {
+    const cur = queue.shift() as number;
+    for (const next of adj.get(cur) ?? []) {
+      if (next === to) return true;
+      if (seen.has(next)) continue;
+      seen.add(next);
+      queue.push(next);
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/pg-delta/tests/expected-red.ts
+++ b/packages/pg-delta/tests/expected-red.ts
@@ -27,4 +27,9 @@ export const EXPECTED_RED: ReadonlyMap<string, RedPin> = new Map<
   // reverse (teardown) direction is expected-red ON PG16+ ONLY — pre-16 has no
   // dependent tracking, plain REVOKE succeeds, and the scenario passes.
   ["role-membership-dedup--multi-grantor:reverse", { minMajor: 16 }],
+  // Reverse is an enum value-set rebuild (drop 'c') while DOMAIN dst still
+  // depends on the enum — the planner refuses that, same as any domain-over-enum
+  // shrink. Forward (ADD VALUE + SET DEFAULT through the domain) is the hole
+  // this pin's sibling scenario covers.
+  ["type-ops--enum-add-value-used-in-domain-default:reverse", {}],
 ]);


### PR DESCRIPTION
## Summary

Stacked on #455. That PR orders an in-place ALTER after the in-place ALTER of a **direct** dependency (SET DEFAULT after enum ADD VALUE). Three follow-ups that still failed at plan/apply time:

- A 3-domain default ring (`d1→d2→d3→d1`) threw `dependency cycle among 3 actions` because pairwise reciprocal skip is one hop.
- A column default `'c'::dst` over an **unchanged** domain whose base enum was ADD VALUEd still emitted SET DEFAULT first (`22P02`).
- Domain default → `nextval(q)` + new column of that domain + `q OWNED BY` the new column closed an action-graph cycle (`d ALTER → ADD c → q ALTER` plus the new `q ALTER → d ALTER`).

**Fix.** Collect alter-after-dep candidates, walk through unchanged facts until an in-place alterer, then add `[before, after]` only when `after` cannot already reach `before`. Skipping a cycle-closing edge does not invent an un-runnable script — it drops the edge that would force the impossible order.

RED → GREEN:

1. `test(pg-delta): add failing regressions for alter-after-dep cycles and transitive defaults` — 3-ring / OWNED BY threw `dependency cycle among 3 actions`; transitive default had ADD VALUE after SET DEFAULT (`Received 1, Expected < 0`).
2. `fix(pg-delta): walk transitive alter-after-dep edges and skip cycle-closing ones` — same tests pass.

Forward corpus `type-ops--enum-add-value-used-in-domain-default` proves the `22P02` hole is closed. Reverse (drop the enum value while `DOMAIN dst` still depends on it) is a pre-existing unsupported rebuild and is pinned in `EXPECTED_RED`.

Refs #455

## Linked issue

No GitHub issue; follow-up to #455.

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Test plan

- [x] `bun test packages/pg-delta/src/plan/alter-after-dependency-alter.test.ts` (5/5)
- [x] `cd packages/pg-delta && bun test src/` (1394 pass)
- [x] Forward + reverse (pinned) of `type-ops--enum-add-value-used-in-domain-default` on `postgres:17-alpine`
- [ ] Full corpus on `postgres:17-alpine` after this PR's CI (parent #455 already 664/664; this adds one scenario)
- [ ] `bun run format-and-lint` / `check-types` / `knip` (ran locally)


Made with [Cursor](https://cursor.com)