### PR TITLE
fix(pg-delta): guard checked-out clients from connection errors

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,6 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Keep checked-out PostgreSQL clients protected by an error listener until
+release.

--- a/packages/pg-delta/src/apply/apply.test.ts
+++ b/packages/pg-delta/src/apply/apply.test.ts
@@ -137,9 +137,17 @@ async function expectObserverLatencyExcluded(
       return Promise.resolve({ rows: [] });
     },
     release: () => {},
+    on: () => {},
+    removeListener: () => {},
   };
   const pool = {
-    connect: () => Promise.resolve(client),
+    connect: (
+      callback: (
+        error: undefined,
+        connectedClient: typeof client,
+        release: typeof client.release,
+      ) => void,
+    ) => callback(undefined, client, client.release),
   } as unknown as Pool;
 
   try {
@@ -194,10 +202,18 @@ function scriptedApplyClient(failingSql: ReadonlySet<string>): ScriptedApply {
         : Promise.resolve({ rows: [] });
     },
     release: (error?: Error | boolean) => releases.push(error),
+    on: () => {},
+    removeListener: () => {},
   };
   return {
     pool: {
-      connect: () => Promise.resolve(client),
+      connect: (
+        callback: (
+          error: undefined,
+          connectedClient: typeof client,
+          release: typeof client.release,
+        ) => void,
+      ) => callback(undefined, client, client.release),
     } as unknown as Pool,
     queries,
     releases,

--- a/packages/pg-delta/src/apply/apply.ts
+++ b/packages/pg-delta/src/apply/apply.ts
@@ -13,6 +13,7 @@
  * inDoubt.
  */
 import type { Pool } from "pg";
+import { connectWithErrorListener } from "../pg-client.ts";
 import type { FactBase } from "../core/fact.ts";
 import { extract } from "../extract/extract.ts";
 import { assertPlanId } from "../plan/artifact.ts";
@@ -273,7 +274,7 @@ export async function apply(
   const segments = segmentActions(thePlan.actions);
   let appliedActions = 0;
 
-  const client = await target.connect();
+  const client = await connectWithErrorListener(target);
   let destroyClient = false;
   try {
     const onEvent = options?.onEvent;

--- a/packages/pg-delta/src/extract/extract.ts
+++ b/packages/pg-delta/src/extract/extract.ts
@@ -39,6 +39,7 @@
  */
 import createDebug from "debug";
 import type { Pool, PoolClient } from "pg";
+import { connectWithErrorListener } from "../pg-client.ts";
 import type { Diagnostic } from "../core/diagnostic.ts";
 import {
   buildFactBase,
@@ -345,7 +346,7 @@ export async function extract(
   // Validated BEFORE a client is checked out, so a bad option can never leak a
   // connection or an open transaction.
   const streams = resolveStreamCount(options.concurrency, pool.options?.max);
-  const client = await pool.connect();
+  const client = await connectWithErrorListener(pool);
   try {
     const result = await extractOnClient(
       client,

--- a/packages/pg-delta/src/extract/parallel.ts
+++ b/packages/pg-delta/src/extract/parallel.ts
@@ -32,6 +32,7 @@
  */
 import createDebug from "debug";
 import type { Pool, PoolClient } from "pg";
+import { connectWithErrorListener } from "../pg-client.ts";
 import {
   makeBatchRunner,
   makeQueryRunner,
@@ -183,7 +184,7 @@ export async function reserveWorkerClients(
   const wanted = Math.min(count, spareCapacity(pool));
   if (wanted <= 0) return [];
   const settled = await Promise.allSettled(
-    Array.from({ length: wanted }, () => pool.connect()),
+    Array.from({ length: wanted }, () => connectWithErrorListener(pool)),
   );
   const clients: PoolClient[] = [];
   for (const outcome of settled) {

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -53,6 +53,7 @@
  * Extension-owned relations (pg_depend deptype 'e') are always out of scope.
  */
 import type { Pool, PoolClient, QueryResult } from "pg";
+import { connectWithErrorListener } from "../pg-client.ts";
 import type { Diagnostic } from "../core/diagnostic.ts";
 import { qid } from "../plan/render.ts";
 import { buildFactBase, type FactBase } from "../core/fact.ts";
@@ -1144,7 +1145,7 @@ export async function loadSqlFiles(
   let failuresBeforeReconnect: LoadFailure[] = [];
   let earlierSessionSettings: LoadAssistLocation[] = [];
   let failuresBeforeReorder: LoadFailure[] = [];
-  let client: PoolClient = await shadow.connect();
+  let client: PoolClient = await connectWithErrorListener(shadow);
   let clientOpen = true;
   const releaseClient = async (discard = false): Promise<void> => {
     if (!clientOpen) return;
@@ -1316,7 +1317,7 @@ export async function loadSqlFiles(
             persistentSessionSettingLocations,
           );
           await releaseClient(true);
-          client = await shadow.connect();
+          client = await connectWithErrorListener(shadow);
           clientOpen = true;
           await applyPreamble(client);
           reconnected = true;

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -5,6 +5,7 @@
  */
 import type { Pool } from "pg";
 import type { ApplyOptions } from "../apply/apply.ts";
+import { connectWithErrorListener } from "../pg-client.ts";
 import type { Diagnostic } from "../core/diagnostic.ts";
 import type { StableId } from "../core/stable-id.ts";
 import {
@@ -79,7 +80,7 @@ export async function probeUnmodeledIdentitiesPinned(
   pool: Pool,
   major: number,
 ): Promise<UnmodeledIdentities> {
-  const client = await pool.connect();
+  const client = await connectWithErrorListener(pool);
   try {
     await client.query("BEGIN");
     await client.query("SET LOCAL search_path TO pg_catalog");
@@ -567,7 +568,7 @@ export async function planSchemaFiles(
         ...(ctx.susetGucs !== undefined ? { susetGucs: ctx.susetGucs } : {}),
       });
       if (seed.sql !== "") {
-        const seedClient = await shadowPool.connect();
+        const seedClient = await connectWithErrorListener(shadowPool);
         try {
           // Same PG 16+ CREATEROLE non-superuser grant as loadSqlFiles: seed SQL
           // may CREATE SCHEMA … AUTHORIZATION for assumed owners.

--- a/packages/pg-delta/src/pg-client.test.ts
+++ b/packages/pg-delta/src/pg-client.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { Pool, PoolClient } from "pg";
+import { connectWithErrorListener } from "./pg-client.ts";
+
+function fakeClient(): {
+  client: PoolClient;
+  releases: unknown[][];
+  release: PoolClient["release"];
+} {
+  const releases: unknown[][] = [];
+  const release = (...args: Parameters<PoolClient["release"]>): void => {
+    releases.push(args);
+  };
+  const client = Object.assign(new EventEmitter(), {
+    release,
+  }) as unknown as PoolClient;
+  return { client, releases, release };
+}
+
+function callbackPool(
+  client: PoolClient,
+  release: PoolClient["release"],
+): Pool {
+  return {
+    connect(
+      callback: (
+        error: Error | undefined,
+        client: PoolClient,
+        release: PoolClient["release"],
+      ) => void,
+    ) {
+      callback(undefined, client, release);
+    },
+  } as unknown as Pool;
+}
+
+describe("connectWithErrorListener", () => {
+  test("guards a checked-out client until it is released", async () => {
+    const { client, releases, release } = fakeClient();
+
+    const checkedOut = await connectWithErrorListener(
+      callbackPool(client, release),
+    );
+
+    expect(checkedOut.listenerCount("error")).toBe(1);
+    expect(() =>
+      checkedOut.emit("error", new Error("connection dropped")),
+    ).not.toThrow();
+
+    checkedOut.release(true);
+    expect(checkedOut.listenerCount("error")).toBe(0);
+    expect(releases).toEqual([[true]]);
+  });
+
+  test("does not accumulate listeners when a client is reused", async () => {
+    const { client, releases, release } = fakeClient();
+    const pool = callbackPool(client, release);
+
+    const first = await connectWithErrorListener(pool);
+    first.release();
+    const second = await connectWithErrorListener(pool);
+
+    expect(second.listenerCount("error")).toBe(1);
+    const releaseError = new Error("discard");
+    second.release(releaseError);
+    expect(second.listenerCount("error")).toBe(0);
+    expect(releases).toEqual([[], [releaseError]]);
+  });
+
+  test("rejects a failed checkout", async () => {
+    const connectError = new Error("connect failed");
+    const pool = {
+      connect(callback: (error: Error) => void) {
+        callback(connectError);
+      },
+    } as unknown as Pool;
+
+    expect(connectWithErrorListener(pool)).rejects.toBe(connectError);
+  });
+});

--- a/packages/pg-delta/src/pg-client.ts
+++ b/packages/pg-delta/src/pg-client.ts
@@ -1,0 +1,27 @@
+import type { Pool, PoolClient } from "pg";
+
+const ignoreClientError = (): void => {};
+
+/** Check out a client without leaving connection errors temporarily unhandled. */
+export function connectWithErrorListener(pool: Pool): Promise<PoolClient> {
+  return new Promise((resolve, reject) => {
+    pool.connect((error, client, release) => {
+      if (error !== undefined) {
+        reject(error);
+        return;
+      }
+      if (client === undefined) {
+        reject(new Error("pool checkout returned no client"));
+        return;
+      }
+
+      client.on("error", ignoreClientError);
+      client.release = (...args: Parameters<PoolClient["release"]>): void => {
+        client.removeListener("error", ignoreClientError);
+        client.release = release;
+        release(...args);
+      };
+      resolve(client);
+    });
+  });
+}

--- a/packages/pg-delta/tests/extract-jit-off.test.ts
+++ b/packages/pg-delta/tests/extract-jit-off.test.ts
@@ -64,33 +64,33 @@ afterAll(async () => {
   await db.drop();
 });
 
-/** Wrap the next-checked-out client's `query` to record every statement text,
- *  run `fn`, then restore `pool.connect`. Mirrors the monkeypatch pattern in
- *  scripts/benchmark.ts's `withPerQueryTiming` — measurement only, never
- *  touches the library. */
+/** Observe checked-out clients to record every statement text while `fn` runs,
+ *  then restore their query methods — measurement only, never touches the library. */
 async function withQueryLog<T>(
   pool: pg.Pool,
   fn: () => Promise<T>,
 ): Promise<{ result: T; statements: string[] }> {
   const statements: string[] = [];
-  const origConnect = pool.connect.bind(pool);
-  (pool as { connect: unknown }).connect = async (...args: unknown[]) => {
-    const client = await (
-      origConnect as (...a: unknown[]) => Promise<pg.PoolClient>
-    )(...args);
+  const patched = new Map<pg.PoolClient, unknown>();
+  const onAcquire = (client: pg.PoolClient): void => {
+    if (patched.has(client)) return;
+    patched.set(client, (client as { query: unknown }).query);
     const origQuery = client.query.bind(client) as (...a: unknown[]) => unknown;
     (client as { query: unknown }).query = (...qa: unknown[]) => {
       const sql = typeof qa[0] === "string" ? qa[0] : String(qa[0]);
       statements.push(sql);
       return origQuery(...qa);
     };
-    return client;
   };
   try {
+    pool.on("acquire", onAcquire);
     const result = await fn();
     return { result, statements };
   } finally {
-    (pool as { connect: unknown }).connect = origConnect;
+    pool.off("acquire", onAcquire);
+    for (const [client, query] of patched) {
+      (client as { query: unknown }).query = query;
+    }
   }
 }
 
@@ -108,19 +108,14 @@ async function withRejectedStatement<T>(
   makeError: () => Error,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const origConnect = pool.connect.bind(pool);
   // Patched clients go BACK into the pool when extract() releases them, so the
   // patch must be undone on exit or a later checkout of the same client would
   // still inject errors into an unrelated test.
   const patched = new Map<pg.PoolClient, unknown>();
-  (pool as { connect: unknown }).connect = async (...args: unknown[]) => {
-    const client = await (
-      origConnect as (...a: unknown[]) => Promise<pg.PoolClient>
-    )(...args);
+  const onAcquire = (client: pg.PoolClient): void => {
+    if (patched.has(client)) return;
     const origQuery = client.query.bind(client) as (...a: unknown[]) => unknown;
-    if (!patched.has(client)) {
-      patched.set(client, (client as { query: unknown }).query);
-    }
+    patched.set(client, (client as { query: unknown }).query);
     (client as { query: unknown }).query = (...qa: unknown[]) => {
       const sql = typeof qa[0] === "string" ? qa[0] : String(qa[0]);
       if (pattern.test(sql)) {
@@ -128,12 +123,12 @@ async function withRejectedStatement<T>(
       }
       return origQuery(...qa);
     };
-    return client;
   };
+  pool.on("acquire", onAcquire);
   try {
     return await fn();
   } finally {
-    (pool as { connect: unknown }).connect = origConnect;
+    pool.off("acquire", onAcquire);
     for (const [client, query] of patched) {
       (client as { query: unknown }).query = query;
     }

--- a/packages/pg-delta/tests/extract-roundtrips.test.ts
+++ b/packages/pg-delta/tests/extract-roundtrips.test.ts
@@ -18,32 +18,34 @@ afterAll(async () => {
   await Promise.all(dbs.map((d) => d.drop().catch(() => {})));
 });
 
-/** Wrap every client checked out from `pool` for the duration of `fn`, counting
- *  queries whose SQL matches `/server_version/`. Restores `pool.connect` when
- *  done — measurement only, never touches the library. */
+/** Observe every client checked out from `pool` for the duration of `fn`, counting
+ *  queries whose SQL matches `/server_version/`. Restores instrumented clients
+ *  when done — measurement only, never touches the library. */
 async function withServerVersionProbeCount<T>(
   pool: pg.Pool,
   fn: () => Promise<T>,
 ): Promise<{ result: T; count: number }> {
   let count = 0;
-  const origConnect = pool.connect.bind(pool);
-  (pool as { connect: unknown }).connect = async (...args: unknown[]) => {
-    const client = await (
-      origConnect as (...a: unknown[]) => Promise<pg.PoolClient>
-    )(...args);
+  const patched = new Map<pg.PoolClient, unknown>();
+  const onAcquire = (client: pg.PoolClient): void => {
+    if (patched.has(client)) return;
+    patched.set(client, (client as { query: unknown }).query);
     const origQuery = client.query.bind(client) as (...a: unknown[]) => unknown;
     (client as { query: unknown }).query = (...qa: unknown[]) => {
       const sql = typeof qa[0] === "string" ? qa[0] : String(qa[0]);
       if (/server_version/.test(sql)) count++;
       return origQuery(...qa);
     };
-    return client;
   };
   try {
+    pool.on("acquire", onAcquire);
     const result = await fn();
     return { result, count };
   } finally {
-    (pool as { connect: unknown }).connect = origConnect;
+    pool.off("acquire", onAcquire);
+    for (const [client, query] of patched) {
+      (client as { query: unknown }).query = query;
+    }
   }
 }
 

--- a/packages/pg-delta/tests/parallel-extract.test.ts
+++ b/packages/pg-delta/tests/parallel-extract.test.ts
@@ -193,20 +193,26 @@ const isSetupCall = (sql: string): boolean =>
  */
 function countRoundTrips(pool: pg.Pool): () => number {
   let calls = 0;
-  const realConnect = pool.connect.bind(pool);
-  // oxlint-disable-next-line no-explicit-any -- test double
-  (pool as any).connect = async () => {
-    const client = await realConnect();
+  const patched = new Map<pg.PoolClient, unknown>();
+  const onAcquire = (client: pg.PoolClient): void => {
+    if (patched.has(client)) return;
     const realQuery = client.query.bind(client);
+    patched.set(client, (client as { query: unknown }).query);
     // oxlint-disable-next-line no-explicit-any -- passthrough test double
     (client as any).query = (...args: any[]) => {
       if (typeof args[0] === "string") calls++;
       // oxlint-disable-next-line no-explicit-any -- passthrough test double
       return (realQuery as any)(...args);
     };
-    return client;
   };
-  return () => calls;
+  pool.on("acquire", onAcquire);
+  return () => {
+    pool.off("acquire", onAcquire);
+    for (const [client, query] of patched) {
+      (client as { query: unknown }).query = query;
+    }
+    return calls;
+  };
 }
 
 /** The GUCs and transaction characteristics that define the canonical extraction
@@ -226,7 +232,7 @@ interface ClientTrace {
 }
 
 /**
- * Wrap `pool.connect` so every checked-out client reports (a) how many setup
+ * Observe every checked-out client to report (a) how many setup
  * round trips it paid and (b) the session state it was left in — captured lazily,
  * immediately before its first non-setup query, which is the only moment where
  * "setup finished" is observable from outside without changing the ordering that
@@ -234,13 +240,13 @@ interface ClientTrace {
  */
 function traceSetup(pool: pg.Pool): () => ClientTrace[] {
   const traces: ClientTrace[] = [];
-  const realConnect = pool.connect.bind(pool);
-  // oxlint-disable-next-line no-explicit-any -- test double
-  (pool as any).connect = async () => {
-    const client = await realConnect();
+  const patched = new Map<pg.PoolClient, unknown>();
+  const onAcquire = (client: pg.PoolClient): void => {
+    if (patched.has(client)) return;
     const trace: ClientTrace = { setupCalls: 0 };
     traces.push(trace);
     const realQuery = client.query.bind(client);
+    patched.set(client, (client as { query: unknown }).query);
     let capturing = false;
     // oxlint-disable-next-line no-explicit-any -- passthrough test double
     (client as any).query = async (...args: any[]) => {
@@ -257,9 +263,15 @@ function traceSetup(pool: pg.Pool): () => ClientTrace[] {
       // oxlint-disable-next-line no-explicit-any -- passthrough test double
       return (realQuery as any)(...args);
     };
-    return client;
   };
-  return () => traces;
+  pool.on("acquire", onAcquire);
+  return () => {
+    pool.off("acquire", onAcquire);
+    for (const [client, query] of patched) {
+      (client as { query: unknown }).query = query;
+    }
+    return traces;
+  };
 }
 
 let db: TestDb;
@@ -358,10 +370,7 @@ describe("extract: bounded-parallel extraction", () => {
     // to run it. The rest of the streams are mid-query when it blows up, so this
     // is the "worker fails while others are in flight" cleanup path.
     const boom = new Error("poisoned pg_policy read");
-    const realConnect = pool.connect.bind(pool);
-    // oxlint-disable-next-line no-explicit-any -- test double, narrow on purpose
-    (pool as any).connect = async () => {
-      const client = await realConnect();
+    pool.on("acquire", (client) => {
       const realQuery = client.query.bind(client);
       // oxlint-disable-next-line no-explicit-any -- passthrough test double
       (client as any).query = (...args: any[]) => {
@@ -371,13 +380,12 @@ describe("extract: bounded-parallel extraction", () => {
         // oxlint-disable-next-line no-explicit-any -- passthrough test double
         return (realQuery as any)(...args);
       };
-      return client;
-    };
+    });
 
     expect(await rejection(extract(pool, { concurrency: 4 }))).toBe(boom);
     expectPoolDrained(pool, 5);
     // and the released clients are genuinely usable — no transaction left open
-    const probe = await realConnect();
+    const probe = await pool.connect();
     expect((await probe.query("SELECT 1 AS ok")).rows[0]).toEqual({ ok: 1 });
     probe.release();
     await pool.end();
@@ -423,10 +431,10 @@ describe("extract: bounded-parallel extraction", () => {
     // this also pins that the reservation has exactly one owner).
     const pool = new pg.Pool({ connectionString: db.uri, max: 5 });
     pool.on("error", () => {});
-    const realConnect = pool.connect.bind(pool);
-    // oxlint-disable-next-line no-explicit-any -- test double
-    (pool as any).connect = async () => {
-      const client = await realConnect();
+    const patched = new WeakSet<pg.PoolClient>();
+    const refuseSnapshot = (client: pg.PoolClient): void => {
+      if (patched.has(client)) return;
+      patched.add(client);
       const realQuery = client.query.bind(client);
       // oxlint-disable-next-line no-explicit-any -- passthrough test double
       (client as any).query = (...args: any[]) => {
@@ -446,11 +454,17 @@ describe("extract: bounded-parallel extraction", () => {
         // oxlint-disable-next-line no-explicit-any -- passthrough test double
         return (realQuery as any)(...args);
       };
-      return client;
     };
 
+    pool.on("acquire", refuseSnapshot);
     const serial = observe(await extract(db.pool));
-    const result = observe(await extract(pool, { concurrency: 4 }));
+    const result = await (async () => {
+      try {
+        return observe(await extract(pool, { concurrency: 4 }));
+      } finally {
+        pool.off("acquire", refuseSnapshot);
+      }
+    })();
     expect(result.rootHash).toBe(serial.rootHash);
     expect(result.facts).toEqual(serial.facts);
     expect(result.edges).toEqual(serial.edges);


### PR DESCRIPTION
## Summary

- add a shared callback-based checkout helper that installs a client error listener before Promise handoff
- remove the listener before forwarding normal and destructive releases, preserving node-pg reuse and double-release semantics
- route every published pg-delta runtime checkout through the helper and update checkout instrumentation to use the `acquire` event

## RED evidence

`bun test src/pg-client.test.ts` failed before the implementation with:

```text
Cannot find module './pg-client.ts'
0 pass, 1 fail, 1 error
```

## Validation

- `bun test src/pg-client.test.ts` — 3/3 passed
- `bun run test:pg-delta` — 1,397/1,397 passed
- focused PostgreSQL 17 integration tests — 20/20 passed
- PostgreSQL 17 corpus — 666/666 passed
- `bun run build`
- `bun run check-types`
- `bun run format-and-lint:fix`
- `bun run knip`
- same-harness and three-frontier cross-review — no findings

Fixes [CLI-2295](https://linear.app/supabase/issue/CLI-2295/fixpg-delta-checked-out-pg-clients-have-no-error-listener-a-dropped)
