### PR TITLE
fix(pg-delta): do not plan a duplicate create for owner-asymmetric platform event triggers

### DIFF
--- a/.changeset/event-trigger-owner-asymmetry.md
+++ b/.changeset/event-trigger-owner-asymmetry.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): do not plan a duplicate CREATE for a platform event trigger hidden by owner on one side only, and project out event triggers whose function is superuser-owned when the applier is not a superuser (CLI-2341)

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -145,6 +145,11 @@ cleanly:
   **leaf fact** — projecting them out of the view converges with no ripple. So a
   non-superuser's FDW ACLs are projected out (`capabilityExcludedRoots`). This
   derives the exclusion the Supabase policy hard-codes as Rule 9.
+- **Event triggers whose function is superuser-owned** are the same shape
+  (supautils `T_CreateEventTrigStmt`; PostgreSQL rejects the create as a
+  duplicate or as an ownership violation). The function's `owner` edge and
+  the role fact's `superuser` payload decide; gated on `!isSuperuser` so the
+  corpus is a no-op.
 - **Ownership** (`ALTER … OWNER TO R` needs superuser or membership in R) **can
   NOT** be silently skipped: leaving an object applier-owned ripples into its
   acldefault-normalized ACL (owner-relative), so the state would not converge.
@@ -378,3 +383,23 @@ the multi-step `plan → apply/prove` flow this needs **capability persisted in 
 Plan artifact** (like `policy` is), so a separate `prove`/`apply` invocation
 recovers the same view (`ApplierCapability.memberOf` serialized as an array).
 The engine mechanism + the parity conclusion above stand without it.
+
+### Follow-up 3 — owner-asymmetric identities are scoped by identity (CLI-2341)
+
+Owner-based exclusion (Supabase Rule 6) is evaluated **per side**. A
+same-identity object owned by `postgres` on one catalog and `supabase_admin`
+on the other is therefore in the view on one side and out on the other, and
+the differ emits a false create or drop.
+
+`resolveView` is `view(facts, policy, capability)` — one catalog, no
+cross-side dependency. Evaluating owner exclusion on the *union* of both
+sides would break that (proof / fingerprint would depend on the other
+catalog). So a platform object that can wear either owner must be excluded
+**by identity**, the same way `assumedPublications` names `supabase_realtime`.
+
+Platform event triggers (`issue_*` / `pgrst_*` / `graphql_watch_*`) are
+hard-excluded by name. They have no user-managed children (unlike
+publication membership), so reference-only would only add owner/comment
+noise. The capability rule above is the general, policy-agnostic half: any
+non-superuser applier loses event triggers whose function is
+superuser-owned, whether or not the name is in that set.

--- a/packages/pg-delta/src/policy/capability.test.ts
+++ b/packages/pg-delta/src/policy/capability.test.ts
@@ -2,11 +2,12 @@
  * Applier-capability-restricted view (docs/architecture/managed-view-architecture.md move 6).
  *
  * The managed view is a function of (facts, policy, applier capability). An
- * operation the applier cannot execute is projected out — currently FDW ACLs,
- * which require superuser to GRANT/REVOKE. This is additive: the Supabase
- * Rule 9 (`{ acl, target fdw } → exclude`) still stands; capability derives the
- * same exclusion for ANY non-superuser applier. With no capability (or a
- * superuser), the view is unrestricted — the corpus path is unchanged.
+ * operation the applier cannot execute is projected out — currently FDW ACLs
+ * (superuser GRANT/REVOKE) and event triggers whose function is superuser-owned
+ * (supautils T_CreateEventTrigStmt / PostgreSQL: a non-superuser cannot own an
+ * event trigger on a superuser-owned function). Additive: Supabase Rule 9 still
+ * stands for FDW ACLs. With no capability (or a superuser), the view is
+ * unrestricted — the corpus path is unchanged.
  */
 import { describe, expect, test } from "bun:test";
 import { buildFactBase, type Fact } from "../core/fact.ts";
@@ -59,6 +60,98 @@ describe("ApplierCapability — capability-restricted view (move 6)", () => {
     expect(capabilityExcludedRoots(fb, superuser).size).toBe(0);
     const roots = capabilityExcludedRoots(fb, nonSuper);
     expect(roots.size).toBe(1);
+  });
+});
+
+describe("ApplierCapability — event trigger on a superuser-owned function", () => {
+  // supautils (and PostgreSQL without it): a non-superuser may create an event
+  // trigger only if its function is not superuser-owned. Expressed on facts:
+  // the function's owner edge → role.payload.superuser.
+  const suRole: StableId = { kind: "role", name: "su" };
+  const appRole: StableId = { kind: "role", name: "app" };
+  const suFn: StableId = {
+    kind: "function",
+    schema: "public",
+    name: "on_ddl",
+    args: [],
+  };
+  const appFn: StableId = {
+    kind: "function",
+    schema: "public",
+    name: "user_fn",
+    args: [],
+  };
+  const suEt: StableId = { kind: "eventTrigger", name: "on_ddl_end" };
+  const appEt: StableId = { kind: "eventTrigger", name: "user_et" };
+
+  const role = (id: StableId, isSuper: boolean): Fact => ({
+    id,
+    payload: { superuser: isSuper },
+  });
+  const et = (id: StableId, fn: StableId): Fact => ({
+    id,
+    payload: {
+      event: "ddl_command_end",
+      enabled: "O",
+      tags: [],
+      functionSchema: (fn as { schema: string }).schema,
+      functionName: (fn as { name: string }).name,
+    },
+  });
+
+  const fb = buildFactBase(
+    [
+      role(suRole, true),
+      role(appRole, false),
+      f(suFn),
+      f(appFn),
+      et(suEt, suFn),
+      et(appEt, appFn),
+    ],
+    [
+      { from: suFn, to: suRole, kind: "owner" },
+      { from: appFn, to: appRole, kind: "owner" },
+    ],
+  );
+
+  test("non-superuser projects out an event trigger whose function is superuser-owned", () => {
+    const view = resolveView(fb, undefined, nonSuper);
+    expect(view.get(suEt)).toBeUndefined();
+    expect(view.get(appEt)).toBeDefined();
+    expect(view.get(suFn)).toBeDefined();
+  });
+
+  test("superuser and no-capability keep the event trigger (corpus path)", () => {
+    expect(resolveView(fb, undefined, superuser).get(suEt)).toBeDefined();
+    expect(resolveView(fb, undefined, undefined).get(suEt)).toBeDefined();
+  });
+
+  test("baseline-identical function/role still project the event trigger out", () => {
+    // subtractBaseline drops unchanged function + superuser role before
+    // capability runs; the lookup must still see them on the raw catalog.
+    const baseline = buildFactBase(
+      [role(suRole, true), f(suFn)],
+      [{ from: suFn, to: suRole, kind: "owner" }],
+    );
+    const view = resolveView(fb, undefined, nonSuper, baseline);
+    expect(view.get(suEt)).toBeUndefined();
+    expect(view.get(appEt)).toBeDefined();
+  });
+
+  test("non-superuser plan omits CREATE EVENT TRIGGER for the superuser-backed trigger", () => {
+    // Functions already present on both sides so the only deltas are the ETs.
+    const source = buildFactBase(
+      [role(suRole, true), role(appRole, false), f(suFn), f(appFn)],
+      [
+        { from: suFn, to: suRole, kind: "owner" },
+        { from: appFn, to: appRole, kind: "owner" },
+      ],
+    );
+    const sql = plan(source, fb, { capability: nonSuper })
+      .actions.map((a) => a.sql)
+      .join("\n");
+    expect(sql).not.toMatch(/CREATE EVENT TRIGGER "on_ddl_end"/);
+    expect(sql).toMatch(/CREATE EVENT TRIGGER "user_et"/);
   });
 });
 

--- a/packages/pg-delta/src/policy/capability.ts
+++ b/packages/pg-delta/src/policy/capability.ts
@@ -8,14 +8,19 @@
  * probed from the applier connection and threaded into plan()/prove() as an
  * option. Absent, the view is unrestricted (the default — superuser/CI path).
  *
- * v1 restriction: FDW ACLs. `GRANT`/`REVOKE ON FOREIGN DATA WRAPPER` requires
- * superuser, so a non-superuser applier cannot replay them. This derives, for
- * ANY non-superuser, the exclusion the Supabase policy hard-codes as Rule 9 —
- * additively (Rule 9 stays until the derivation is proven at parity).
+ * Restrictions for a non-superuser:
+ *   - FDW ACLs (`GRANT`/`REVOKE ON FOREIGN DATA WRAPPER` is superuser-only).
+ *     Derives, for ANY non-superuser, the exclusion Supabase hard-codes as
+ *     Rule 9 — additively (Rule 9 stays until the derivation is proven at
+ *     parity).
+ *   - Event triggers whose backing function is superuser-owned. That is
+ *     supautils' `T_CreateEventTrigStmt` rule (and PostgreSQL's without it):
+ *     a non-superuser may create an event trigger only if the function is
+ *     not superuser-owned. Read off the function fact's `owner` edge.
  */
 import type { Pool } from "pg";
-import type { FactBase } from "../core/fact.ts";
-import { encodeId } from "../core/stable-id.ts";
+import type { Fact, FactBase } from "../core/fact.ts";
+import { encodeId, type StableId } from "../core/stable-id.ts";
 
 export interface ApplierCapability {
   /** the role the migration is applied as (current_user) */
@@ -53,21 +58,46 @@ export async function probeApplierCapability(
   };
 }
 
+const CAPABILITY_FDW_ACL = "capability.fdw-acl";
+const CAPABILITY_EVENT_TRIGGER_SUPERUSER_FUNCTION =
+  "capability.event-trigger-superuser-function";
+
+function eventTriggerFunctionOwnedBySuperuser(
+  fb: FactBase,
+  fact: Fact,
+): boolean {
+  const schema = fact.payload["functionSchema"];
+  const name = fact.payload["functionName"];
+  if (typeof schema !== "string" || typeof name !== "string") return false;
+  const fnId: StableId = { kind: "function", schema, name, args: [] };
+  const fn = fb.get(fnId);
+  if (fn === undefined) return false;
+  const owner = fb.outgoingEdges(fn.id).find((e) => e.kind === "owner");
+  if (owner === undefined || owner.to.kind !== "role") return false;
+  return fb.get(owner.to)?.payload["superuser"] === true;
+}
+
 /**
- * Fact-id keys to project out for a given capability — the facts whose
- * corresponding action the applier cannot execute. A superuser is unrestricted.
- * Currently: FDW ACL facts (GRANT/REVOKE on a FOREIGN DATA WRAPPER is
- * superuser-only).
+ * Fact-id keys to project out for a given capability, mapped to the audit
+ * reason. A superuser is unrestricted. Currently: FDW ACL facts, and event
+ * triggers whose function is owned by a superuser.
  */
 export function capabilityExcludedRoots(
   fb: FactBase,
   cap: ApplierCapability,
-): Set<string> {
-  const roots = new Set<string>();
+): Map<string, string> {
+  const roots = new Map<string, string>();
   if (cap.isSuperuser) return roots;
   for (const fact of fb.facts()) {
     if (fact.id.kind === "acl" && fact.id.target.kind === "fdw") {
-      roots.add(encodeId(fact.id));
+      roots.set(encodeId(fact.id), CAPABILITY_FDW_ACL);
+      continue;
+    }
+    if (
+      fact.id.kind === "eventTrigger" &&
+      eventTriggerFunctionOwnedBySuperuser(fb, fact)
+    ) {
+      roots.set(encodeId(fact.id), CAPABILITY_EVENT_TRIGGER_SUPERUSER_FUNCTION);
     }
   }
   return roots;

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -1174,25 +1174,34 @@ export function resolveView(
     }
   }
   // capability restriction (move 6): project out facts whose action the applier
-  // cannot execute. Additive; default unrestricted. FDW ACLs are superuser-only
-  // GRANTs and a leaf fact, so they project out cleanly. (The owner residue is
-  // NOT projected — it can't be skipped without an ACL ripple — it fail-fasts
-  // in plan() instead; see capability.canSetOwner.)
+  // cannot execute. Additive; default unrestricted. FDW ACLs and event
+  // triggers on a superuser-owned function project out cleanly. (The owner
+  // residue is NOT projected — it can't be skipped without an ACL ripple — it
+  // fail-fasts in plan() instead; see capability.canSetOwner.)
   if (capability !== undefined) {
-    const capRoots = capabilityExcludedRoots(base, capability);
+    // Classify on the RAW catalog: a baseline-identical function / superuser
+    // role is already subtracted from `base`, but an event trigger that
+    // survived (owner or payload differs) still needs that lookup.
+    const capRoots = new Map<string, string>();
+    for (const [key, reasonCode] of capabilityExcludedRoots(fb, capability)) {
+      if (base.getByEncoded(key) !== undefined) capRoots.set(key, reasonCode);
+    }
     if (capRoots.size > 0) {
       const before = base;
-      base = excludeFactsAndDescendants(base, capRoots);
+      base = excludeFactsAndDescendants(base, new Set(capRoots.keys()));
       if (collectSuppression !== undefined) {
-        const attribution: ProjectionSuppressionAttribution = {
-          stage: "capability",
-          reasonCode: "capability.fdw-acl",
-          classification: "acknowledged",
-        };
+        const attribution = new Map<string, ProjectionSuppressionAttribution>();
+        for (const [key, reasonCode] of capRoots) {
+          attribution.set(key, {
+            stage: "capability",
+            reasonCode,
+            classification: "acknowledged",
+          });
+        }
         collectRemovedSuppressions(
           before,
           base,
-          new Map([...capRoots].map((key) => [key, attribution])),
+          attribution,
           collectSuppression,
         );
       }

--- a/packages/pg-delta/src/policy/projection-audit.test.ts
+++ b/packages/pg-delta/src/policy/projection-audit.test.ts
@@ -502,6 +502,47 @@ describe("attributed projection audit", () => {
     expect(audit.summary.baseline).toBe(1);
   });
 
+  test("capability restriction attributes an event trigger on a superuser-owned function", () => {
+    const suRole: StableId = { kind: "role", name: "su" };
+    const fn: StableId = {
+      kind: "function",
+      schema: "public",
+      name: "on_ddl",
+      args: [],
+    };
+    const et: StableId = { kind: "eventTrigger", name: "on_ddl_end" };
+    const etFact = fact(et, {
+      event: "ddl_command_end",
+      enabled: "O",
+      tags: [],
+      functionSchema: "public",
+      functionName: "on_ddl",
+    });
+    const shared = [fact(suRole, { superuser: true }), fact(fn)] as const;
+    const owner = { from: fn, to: suRole, kind: "owner" } as const;
+    const source = buildFactBase([...shared], [owner]);
+    const desired = buildFactBase([...shared, etFact], [owner]);
+    const capability: ApplierCapability = {
+      role: "app",
+      isSuperuser: false,
+      memberOf: [],
+    };
+
+    expect(
+      auditManagedViewProjection(source, desired, { capability }).entries[0],
+    ).toMatchObject({
+      subject: { kind: "fact", id: et },
+      classification: "acknowledged",
+      suppressions: [
+        {
+          side: "desired",
+          stage: "capability",
+          reasonCode: "capability.event-trigger-superuser-function",
+        },
+      ],
+    });
+  });
+
   test("capability restriction attributes a differing FDW ACL", () => {
     const wrapper: StableId = { kind: "fdw", name: "remote" };
     const acl: StableId = { kind: "acl", target: wrapper, grantee: "reader" };

--- a/packages/pg-delta/src/policy/supabase-platform-event-triggers.test.ts
+++ b/packages/pg-delta/src/policy/supabase-platform-event-triggers.test.ts
@@ -1,0 +1,86 @@
+/**
+ * CLI-2341: a platform event trigger owned by `postgres` on one side and
+ * `supabase_admin` on the other must not become a create/drop. Rule 6 is
+ * owner-based and per-side, so the `postgres`-owned copy stays managed and
+ * the planner emits CREATE of a trigger that already exists. Exclude the
+ * platform name set (`issue_*` / `pgrst_*` / `graphql_watch_*`) by identity.
+ * Pure policy level — no DB.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import type { StableId } from "../core/stable-id.ts";
+import { plan } from "../plan/plan.ts";
+import { resolveView } from "./policy.ts";
+import { supabasePolicy } from "./supabase.ts";
+
+const postgres: StableId = { kind: "role", name: "postgres" };
+const admin: StableId = { kind: "role", name: "supabase_admin" };
+const issueEt: StableId = {
+  kind: "eventTrigger",
+  name: "issue_pg_graphql_access",
+};
+const pgrstEt: StableId = { kind: "eventTrigger", name: "pgrst_drop_watch" };
+const gqlEt: StableId = { kind: "eventTrigger", name: "graphql_watch_ddl" };
+const userEt: StableId = { kind: "eventTrigger", name: "my_ddl_logger" };
+
+function role(id: StableId, superuser: boolean): Fact {
+  return { id, payload: { superuser } };
+}
+
+function et(id: StableId): Fact {
+  return {
+    id,
+    payload: {
+      event: "ddl_command_end",
+      enabled: "O",
+      tags: ["CREATE FUNCTION"],
+      functionSchema: "extensions",
+      functionName: "grant_pg_graphql_access",
+    },
+  };
+}
+
+function world(owner: StableId) {
+  return buildFactBase(
+    [
+      role(postgres, false),
+      role(admin, true),
+      et(issueEt),
+      et(pgrstEt),
+      et(gqlEt),
+      et(userEt),
+    ],
+    [
+      { from: issueEt, to: owner, kind: "owner" },
+      { from: pgrstEt, to: owner, kind: "owner" },
+      { from: gqlEt, to: owner, kind: "owner" },
+      { from: userEt, to: postgres, kind: "owner" },
+    ],
+  );
+}
+
+describe("supabase policy — platform event triggers (CLI-2341)", () => {
+  test("excludes issue_*/pgrst_*/graphql_watch_* even when owned by postgres", () => {
+    const view = resolveView(world(postgres), supabasePolicy);
+    expect(view.get(issueEt)).toBeUndefined();
+    expect(view.get(pgrstEt)).toBeUndefined();
+    expect(view.get(gqlEt)).toBeUndefined();
+    expect(view.get(userEt)).toBeDefined();
+  });
+
+  test("still excludes the same names when owned by supabase_admin (Rule 6)", () => {
+    const view = resolveView(world(admin), supabasePolicy);
+    expect(view.get(issueEt)).toBeUndefined();
+    expect(view.get(userEt)).toBeDefined();
+  });
+
+  test("owner-asymmetric platform trigger does not plan CREATE or DROP", () => {
+    const sql = plan(world(admin), world(postgres), { policy: supabasePolicy })
+      .actions.map((a) => a.sql)
+      .join("\n");
+    expect(sql).not.toMatch(/CREATE EVENT TRIGGER "issue_pg_graphql_access"/);
+    expect(sql).not.toMatch(/DROP EVENT TRIGGER "issue_pg_graphql_access"/);
+    expect(sql).not.toMatch(/CREATE EVENT TRIGGER "pgrst_drop_watch"/);
+    expect(sql).not.toMatch(/CREATE EVENT TRIGGER "graphql_watch_ddl"/);
+  });
+});

--- a/packages/pg-delta/src/policy/supabase.ts
+++ b/packages/pg-delta/src/policy/supabase.ts
@@ -537,6 +537,26 @@ export const supabasePolicy: Policy = {
       action: "exclude",
     },
 
+    // Platform event triggers (`issue_*` / `pgrst_*` / `graphql_watch_*`).
+    // Identity, not owner: Rule 6 hides a supabase_admin-owned copy and keeps
+    // a postgres-owned copy, so a same-named trigger becomes a false CREATE
+    // (CLI-2341). Hard-exclude — nothing user-managed hangs off these, unlike
+    // assumedPublications. Capability separately projects out any event
+    // trigger whose function is superuser-owned when restrictToApplier is on.
+    {
+      match: {
+        all: [
+          { kind: "eventTrigger" },
+          { name: ["issue_*", "pgrst_*", "graphql_watch_*"] },
+        ],
+      },
+      action: "exclude",
+      audit: {
+        reasonCode: "supabase.platform-event-trigger",
+        classification: "acknowledged",
+      },
+    },
+
     // Rule 6 (old rule): exclude objects whose payload owner is a system role.
     // Covers tables, views, schemas, sequences, etc. that are managed by
     // Supabase system roles.

--- a/packages/pg-delta/tests/supabase-applier-baseline.test.ts
+++ b/packages/pg-delta/tests/supabase-applier-baseline.test.ts
@@ -1,0 +1,90 @@
+/**
+ * CLI-2341 E2: both catalogs already have `issue_pg_graphql_access`; the
+ * branch copy is owned by `supabase_admin` (Rule 6 hides it) and the base
+ * copy is owned by `postgres` (old-project shape). Apply as the non-superuser
+ * `postgres` must not emit CREATE of the trigger that already exists.
+ *
+ * Same shape as the CLI baseline apply: branch is SOURCE, base is DESIRED,
+ * apply as `postgres`. Gated on `runSupabaseBareTests`.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import pg from "pg";
+import { apply } from "../src/apply/apply.ts";
+import { resolveProfile } from "../src/integrations/profile.ts";
+import { supabaseProfile } from "../src/integrations/supabase.ts";
+import { plan } from "../src/plan/plan.ts";
+import {
+  runSupabaseBareTests,
+  supabaseCluster,
+  type Cluster,
+  type TestDb,
+} from "./containers.ts";
+
+describe.skipIf(!runSupabaseBareTests)(
+  "supabase profile — baseline applied as the non-superuser postgres",
+  () => {
+    let cluster: Cluster;
+
+    beforeAll(async () => {
+      cluster = await supabaseCluster();
+    }, 180_000);
+
+    test("E2: postgres-owned platform event trigger is not re-created on the branch", async () => {
+      const branch: TestDb = await cluster.createDb("e2_branch");
+      const base: TestDb = await cluster.createDb("e2_base");
+      const applier = new pg.Pool({
+        connectionString: branch.postgresUri!,
+        max: 1,
+      });
+      applier.on("error", () => {});
+      try {
+        // createDb templates template1, which does not carry the image's
+        // platform event triggers (those live on the postgres database).
+        // Seed the production shape on both sides: supabase_admin-owned
+        // function in assumed `extensions`, trigger of the issue_* set.
+        for (const db of [branch, base]) {
+          await db.pool.query(`
+            CREATE SCHEMA IF NOT EXISTS extensions;
+            CREATE OR REPLACE FUNCTION extensions.grant_pg_graphql_access()
+              RETURNS event_trigger LANGUAGE plpgsql AS $$ BEGIN END $$;
+            ALTER FUNCTION extensions.grant_pg_graphql_access() OWNER TO supabase_admin;
+            CREATE EVENT TRIGGER issue_pg_graphql_access
+              ON ddl_command_end WHEN TAG IN ('CREATE FUNCTION')
+              EXECUTE FUNCTION extensions.grant_pg_graphql_access();
+          `);
+        }
+        // ALTER EVENT TRIGGER … OWNER TO a non-superuser is refused; this is
+        // the only way to reproduce the old-project catalog shape.
+        const owned = await base.pool.query(
+          `UPDATE pg_event_trigger SET evtowner = 'postgres'::regrole WHERE evtname = 'issue_pg_graphql_access'`,
+        );
+        expect(owned.rowCount).toBe(1);
+
+        const profile = await resolveProfile(applier, supabaseProfile);
+        const [src, desired] = await Promise.all([
+          profile.extract(applier),
+          profile.extract(base.pool),
+        ]);
+        const migration = plan(src.factBase, desired.factBase, {
+          ...profile.planOptions,
+          renames: "off",
+          compact: true,
+        });
+        const report = await apply(migration, applier, {
+          ...profile.applyOptions,
+        });
+
+        expect(report.status).toBe("applied");
+        expect(migration.actions.map((a) => a.sql)).not.toContainEqual(
+          expect.stringMatching(
+            /CREATE EVENT TRIGGER "issue_pg_graphql_access"/,
+          ),
+        );
+      } finally {
+        await applier.end().catch(() => {});
+        await branch.drop();
+        await base.drop();
+      }
+    }, 120_000);
+  },
+);


### PR DESCRIPTION
## Summary

- A platform event trigger owned by `postgres` on one side and `supabase_admin` on the other was hidden by Rule 6 on one side only, so the planner emitted `CREATE EVENT TRIGGER` of a trigger that already exists (supautils then rejected it).
- Exclude the platform name set (`issue_*` / `pgrst_*` / `graphql_watch_*`) by identity so the same trigger cannot become a create/drop.
- For a non-superuser applier, project out any event trigger whose function is superuser-owned (supautils `T_CreateEventTrigStmt`), classified on the raw catalog so a baseline-identical function/role still resolves.

## Linked issue

[CLI-2341](https://linear.app/supabase/issue/CLI-2341/fixpg-delta-event-trigger-hidden-by-owner-on-one-side-only-is-planned)

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Test plan

- [ ] `cd packages/pg-delta && bun test src/policy/capability.test.ts src/policy/supabase-platform-event-triggers.test.ts src/policy/projection-audit.test.ts`
- [ ] `PGDELTA_NEXT_SUPABASE_TESTS=1 bun test tests/supabase-applier-baseline.test.ts` (Docker + pinned Supabase image)
- [ ] Corpus on one PG version: `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts`