### PR TITLE
fix(pg-delta): do not plan a duplicate create for owner-asymmetric platform event triggers

### DIFF
--- a/.changeset/event-trigger-owner-asymmetry.md
+++ b/.changeset/event-trigger-owner-asymmetry.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): do not plan a duplicate CREATE for a platform event trigger hidden by owner on one side only (CLI-2341)

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -378,3 +378,21 @@ the multi-step `plan → apply/prove` flow this needs **capability persisted in 
 Plan artifact** (like `policy` is), so a separate `prove`/`apply` invocation
 recovers the same view (`ApplierCapability.memberOf` serialized as an array).
 The engine mechanism + the parity conclusion above stand without it.
+
+### Follow-up 3 — owner-asymmetric identities are scoped by identity (CLI-2341)
+
+Owner-based exclusion (Supabase Rule 6) is evaluated **per side**. A
+same-identity object owned by `postgres` on one catalog and `supabase_admin`
+on the other is therefore in the view on one side and out on the other, and
+the differ emits a false create or drop.
+
+`resolveView` is `view(facts, policy, capability)` — one catalog, no
+cross-side dependency. Evaluating owner exclusion on the *union* of both
+sides would break that (proof / fingerprint would depend on the other
+catalog). So a platform object that can wear either owner must be excluded
+**by identity**, the same way `assumedPublications` names `supabase_realtime`.
+
+Platform event triggers (`issue_*` / `pgrst_*` / `graphql_watch_*`) are
+hard-excluded by name. They have no user-managed children (unlike
+publication membership), so reference-only would only add owner/comment
+noise.

--- a/packages/pg-delta/src/policy/supabase-platform-event-triggers.test.ts
+++ b/packages/pg-delta/src/policy/supabase-platform-event-triggers.test.ts
@@ -1,0 +1,86 @@
+/**
+ * CLI-2341: a platform event trigger owned by `postgres` on one side and
+ * `supabase_admin` on the other must not become a create/drop. Rule 6 is
+ * owner-based and per-side, so the `postgres`-owned copy stays managed and
+ * the planner emits CREATE of a trigger that already exists. Exclude the
+ * platform name set (`issue_*` / `pgrst_*` / `graphql_watch_*`) by identity.
+ * Pure policy level — no DB.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import type { StableId } from "../core/stable-id.ts";
+import { plan } from "../plan/plan.ts";
+import { resolveView } from "./policy.ts";
+import { supabasePolicy } from "./supabase.ts";
+
+const postgres: StableId = { kind: "role", name: "postgres" };
+const admin: StableId = { kind: "role", name: "supabase_admin" };
+const issueEt: StableId = {
+  kind: "eventTrigger",
+  name: "issue_pg_graphql_access",
+};
+const pgrstEt: StableId = { kind: "eventTrigger", name: "pgrst_drop_watch" };
+const gqlEt: StableId = { kind: "eventTrigger", name: "graphql_watch_ddl" };
+const userEt: StableId = { kind: "eventTrigger", name: "my_ddl_logger" };
+
+function role(id: StableId, superuser: boolean): Fact {
+  return { id, payload: { superuser } };
+}
+
+function et(id: StableId): Fact {
+  return {
+    id,
+    payload: {
+      event: "ddl_command_end",
+      enabled: "O",
+      tags: ["CREATE FUNCTION"],
+      functionSchema: "extensions",
+      functionName: "grant_pg_graphql_access",
+    },
+  };
+}
+
+function world(owner: StableId) {
+  return buildFactBase(
+    [
+      role(postgres, false),
+      role(admin, true),
+      et(issueEt),
+      et(pgrstEt),
+      et(gqlEt),
+      et(userEt),
+    ],
+    [
+      { from: issueEt, to: owner, kind: "owner" },
+      { from: pgrstEt, to: owner, kind: "owner" },
+      { from: gqlEt, to: owner, kind: "owner" },
+      { from: userEt, to: postgres, kind: "owner" },
+    ],
+  );
+}
+
+describe("supabase policy — platform event triggers (CLI-2341)", () => {
+  test("excludes issue_*/pgrst_*/graphql_watch_* even when owned by postgres", () => {
+    const view = resolveView(world(postgres), supabasePolicy);
+    expect(view.get(issueEt)).toBeUndefined();
+    expect(view.get(pgrstEt)).toBeUndefined();
+    expect(view.get(gqlEt)).toBeUndefined();
+    expect(view.get(userEt)).toBeDefined();
+  });
+
+  test("still excludes the same names when owned by supabase_admin (Rule 6)", () => {
+    const view = resolveView(world(admin), supabasePolicy);
+    expect(view.get(issueEt)).toBeUndefined();
+    expect(view.get(userEt)).toBeDefined();
+  });
+
+  test("owner-asymmetric platform trigger does not plan CREATE or DROP", () => {
+    const sql = plan(world(admin), world(postgres), { policy: supabasePolicy })
+      .actions.map((a) => a.sql)
+      .join("\n");
+    expect(sql).not.toMatch(/CREATE EVENT TRIGGER "issue_pg_graphql_access"/);
+    expect(sql).not.toMatch(/DROP EVENT TRIGGER "issue_pg_graphql_access"/);
+    expect(sql).not.toMatch(/CREATE EVENT TRIGGER "pgrst_drop_watch"/);
+    expect(sql).not.toMatch(/CREATE EVENT TRIGGER "graphql_watch_ddl"/);
+  });
+});

--- a/packages/pg-delta/src/policy/supabase.ts
+++ b/packages/pg-delta/src/policy/supabase.ts
@@ -537,6 +537,25 @@ export const supabasePolicy: Policy = {
       action: "exclude",
     },
 
+    // Platform event triggers (`issue_*` / `pgrst_*` / `graphql_watch_*`).
+    // Identity, not owner: Rule 6 hides a supabase_admin-owned copy and keeps
+    // a postgres-owned copy, so a same-named trigger becomes a false CREATE
+    // (CLI-2341). Hard-exclude — nothing user-managed hangs off these, unlike
+    // assumedPublications.
+    {
+      match: {
+        all: [
+          { kind: "eventTrigger" },
+          { name: ["issue_*", "pgrst_*", "graphql_watch_*"] },
+        ],
+      },
+      action: "exclude",
+      audit: {
+        reasonCode: "supabase.platform-event-trigger",
+        classification: "acknowledged",
+      },
+    },
+
     // Rule 6 (old rule): exclude objects whose payload owner is a system role.
     // Covers tables, views, schemas, sequences, etc. that are managed by
     // Supabase system roles.

--- a/packages/pg-delta/tests/supabase-applier-baseline.test.ts
+++ b/packages/pg-delta/tests/supabase-applier-baseline.test.ts
@@ -1,0 +1,90 @@
+/**
+ * CLI-2341 E2: both catalogs already have `issue_pg_graphql_access`; the
+ * branch copy is owned by `supabase_admin` (Rule 6 hides it) and the base
+ * copy is owned by `postgres` (old-project shape). Apply as the non-superuser
+ * `postgres` must not emit CREATE of the trigger that already exists.
+ *
+ * Same shape as the CLI baseline apply: branch is SOURCE, base is DESIRED,
+ * apply as `postgres`. Gated on `runSupabaseBareTests`.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import pg from "pg";
+import { apply } from "../src/apply/apply.ts";
+import { resolveProfile } from "../src/integrations/profile.ts";
+import { supabaseProfile } from "../src/integrations/supabase.ts";
+import { plan } from "../src/plan/plan.ts";
+import {
+  runSupabaseBareTests,
+  supabaseCluster,
+  type Cluster,
+  type TestDb,
+} from "./containers.ts";
+
+describe.skipIf(!runSupabaseBareTests)(
+  "supabase profile — baseline applied as the non-superuser postgres",
+  () => {
+    let cluster: Cluster;
+
+    beforeAll(async () => {
+      cluster = await supabaseCluster();
+    }, 180_000);
+
+    test("E2: postgres-owned platform event trigger is not re-created on the branch", async () => {
+      const branch: TestDb = await cluster.createDb("e2_branch");
+      const base: TestDb = await cluster.createDb("e2_base");
+      const applier = new pg.Pool({
+        connectionString: branch.postgresUri!,
+        max: 1,
+      });
+      applier.on("error", () => {});
+      try {
+        // createDb templates template1, which does not carry the image's
+        // platform event triggers (those live on the postgres database).
+        // Seed the production shape on both sides: supabase_admin-owned
+        // function in assumed `extensions`, trigger of the issue_* set.
+        for (const db of [branch, base]) {
+          await db.pool.query(`
+            CREATE SCHEMA IF NOT EXISTS extensions;
+            CREATE OR REPLACE FUNCTION extensions.grant_pg_graphql_access()
+              RETURNS event_trigger LANGUAGE plpgsql AS $$ BEGIN END $$;
+            ALTER FUNCTION extensions.grant_pg_graphql_access() OWNER TO supabase_admin;
+            CREATE EVENT TRIGGER issue_pg_graphql_access
+              ON ddl_command_end WHEN TAG IN ('CREATE FUNCTION')
+              EXECUTE FUNCTION extensions.grant_pg_graphql_access();
+          `);
+        }
+        // ALTER EVENT TRIGGER … OWNER TO a non-superuser is refused; this is
+        // the only way to reproduce the old-project catalog shape.
+        const owned = await base.pool.query(
+          `UPDATE pg_event_trigger SET evtowner = 'postgres'::regrole WHERE evtname = 'issue_pg_graphql_access'`,
+        );
+        expect(owned.rowCount).toBe(1);
+
+        const profile = await resolveProfile(applier, supabaseProfile);
+        const [src, desired] = await Promise.all([
+          profile.extract(applier),
+          profile.extract(base.pool),
+        ]);
+        const migration = plan(src.factBase, desired.factBase, {
+          ...profile.planOptions,
+          renames: "off",
+          compact: true,
+        });
+        const report = await apply(migration, applier, {
+          ...profile.applyOptions,
+        });
+
+        expect(report.status).toBe("applied");
+        expect(migration.actions.map((a) => a.sql)).not.toContainEqual(
+          expect.stringMatching(
+            /CREATE EVENT TRIGGER "issue_pg_graphql_access"/,
+          ),
+        );
+      } finally {
+        await applier.end().catch(() => {});
+        await branch.drop();
+        await base.drop();
+      }
+    }, 120_000);
+  },
+);


### PR DESCRIPTION
<!--
Before opening this PR, confirm the linked issue is open and carries the
`open-for-contribution` label. PRs from external contributors that don't follow the
workflow in CONTRIBUTING.md are closed automatically.
@supabase members working from Linear tickets are exempt.
-->

## Summary

- A platform event trigger owned by `postgres` on one side and `supabase_admin` on the other was hidden by Rule 6 on one side only, so the planner emitted `CREATE EVENT TRIGGER` of a trigger that already exists (supautils then rejected it).
- Exclude the platform name set (`issue_*` / `pgrst_*` / `graphql_watch_*`) by identity so the same trigger cannot become a create/drop.
- Split from #463: this PR is the production fix only. Capability (event triggers on superuser-owned functions) is stacked in #465.

## Linked issue

[CLI-2341](https://linear.app/supabase/issue/CLI-2341/fixpg-delta-event-trigger-hidden-by-owner-on-one-side-only-is-planned)

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Test plan

- [ ] `cd packages/pg-delta && bun test src/policy/supabase-platform-event-triggers.test.ts`
- [ ] `PGDELTA_NEXT_SUPABASE_TESTS=1 bun test tests/supabase-applier-baseline.test.ts` (Docker + pinned Supabase image)
- [ ] Corpus on one PG version: `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts`