### PR TITLE
fix(pg-delta): hide event triggers on superuser-owned functions from non-superuser appliers

### DIFF
--- a/.changeset/event-trigger-superuser-function.md
+++ b/.changeset/event-trigger-superuser-function.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): project out event triggers whose function is superuser-owned when the applier is not a superuser

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -146,10 +146,10 @@ cleanly:
   non-superuser's FDW ACLs are projected out (`capabilityExcludedRoots`). This
   derives the exclusion the Supabase policy hard-codes as Rule 9.
 - **Event triggers whose function is superuser-owned** are the same shape
-  (supautils `T_CreateEventTrigStmt`; PostgreSQL rejects the create as a
-  duplicate or as an ownership violation). The function's `owner` edge and
+  under supautils (`T_CreateEventTrigStmt`). The function's `owner` edge and
   the role fact's `superuser` payload decide; gated on `!isSuperuser` so the
-  corpus is a no-op.
+  corpus is a no-op. Stock PostgreSQL has no function-owner carve-out —
+  `CREATE EVENT TRIGGER` is superuser-only there.
 - **Ownership** (`ALTER … OWNER TO R` needs superuser or membership in R) **can
   NOT** be silently skipped: leaving an object applier-owned ripples into its
   acldefault-normalized ACL (owner-relative), so the state would not converge.

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -145,6 +145,11 @@ cleanly:
   **leaf fact** — projecting them out of the view converges with no ripple. So a
   non-superuser's FDW ACLs are projected out (`capabilityExcludedRoots`). This
   derives the exclusion the Supabase policy hard-codes as Rule 9.
+- **Event triggers whose function is superuser-owned** are the same shape
+  (supautils `T_CreateEventTrigStmt`; PostgreSQL rejects the create as a
+  duplicate or as an ownership violation). The function's `owner` edge and
+  the role fact's `superuser` payload decide; gated on `!isSuperuser` so the
+  corpus is a no-op.
 - **Ownership** (`ALTER … OWNER TO R` needs superuser or membership in R) **can
   NOT** be silently skipped: leaving an object applier-owned ripples into its
   acldefault-normalized ACL (owner-relative), so the state would not converge.
@@ -395,4 +400,6 @@ catalog). So a platform object that can wear either owner must be excluded
 Platform event triggers (`issue_*` / `pgrst_*` / `graphql_watch_*`) are
 hard-excluded by name. They have no user-managed children (unlike
 publication membership), so reference-only would only add owner/comment
-noise.
+noise. The capability rule above is the general, policy-agnostic half: any
+non-superuser applier loses event triggers whose function is
+superuser-owned, whether or not the name is in that set.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1570,3 +1570,28 @@ Codex P2s:
 - **Fixed — OWNED BY sandwich cycle.** `q ALTER → d ALTER` is skipped
   because `d ALTER → ADD c → q ALTER` already exists; apply order stays
   ALTER DOMAIN, ADD COLUMN, ALTER SEQUENCE.
+
+## PR #465 review triage (Codex) — event-trigger capability
+
+Capability projects out event triggers whose function is superuser-owned
+when `restrictToApplier` is on (supautils `T_CreateEventTrigStmt`). Two
+Codex findings were deferred; the stock-PostgreSQL wording in the
+capability header was fixed in-PR.
+
+- **Deferred — owner-asymmetric capability projection (P1).** Same
+  event-trigger identity on both sides, backing-function owner (or that
+  role's `superuser` flag) differs: one side is projected out, the other
+  is not, so `plan` can emit `CREATE EVENT TRIGGER` of a trigger that
+  already exists. `resolveView` is `view(facts, policy, capability)` per
+  catalog — classifying on the union of both sides would make
+  proof/fingerprint depend on the other catalog (the CLI-2341 design
+  constraint). Production platform names are covered by the identity
+  exclude in #464 and do not need capability. A user trigger under
+  `restrictToApplier` with a one-sided function-owner flip is still open.
+  Do not invent a cross-side capability view to close it.
+
+- **Deferred — project out every event trigger on stock PostgreSQL (P2).**
+  Vanilla `CREATE`/`ALTER`/`DROP EVENT TRIGGER` is superuser-only; this
+  layer only encodes the supautils function-owner exception. Hiding all
+  event triggers for a non-superuser on raw PG is a later capability
+  expansion and would change `restrictToApplier` beyond CLI-2341.

--- a/packages/pg-delta/src/policy/capability.test.ts
+++ b/packages/pg-delta/src/policy/capability.test.ts
@@ -4,8 +4,8 @@
  * The managed view is a function of (facts, policy, applier capability). An
  * operation the applier cannot execute is projected out — currently FDW ACLs
  * (superuser GRANT/REVOKE) and event triggers whose function is superuser-owned
- * (supautils T_CreateEventTrigStmt / PostgreSQL: a non-superuser cannot own an
- * event trigger on a superuser-owned function). Additive: Supabase Rule 9 still
+ * (supautils T_CreateEventTrigStmt; stock PostgreSQL has no function-owner
+ * carve-out). Additive: Supabase Rule 9 still
  * stands for FDW ACLs. With no capability (or a superuser), the view is
  * unrestricted — the corpus path is unchanged.
  */
@@ -64,9 +64,9 @@ describe("ApplierCapability — capability-restricted view (move 6)", () => {
 });
 
 describe("ApplierCapability — event trigger on a superuser-owned function", () => {
-  // supautils (and PostgreSQL without it): a non-superuser may create an event
-  // trigger only if its function is not superuser-owned. Expressed on facts:
-  // the function's owner edge → role.payload.superuser.
+  // supautils T_CreateEventTrigStmt: a privileged non-superuser may create an
+  // event trigger only if its function is not superuser-owned. Expressed on
+  // facts: the function's owner edge → role.payload.superuser.
   const suRole: StableId = { kind: "role", name: "su" };
   const appRole: StableId = { kind: "role", name: "app" };
   const suFn: StableId = {

--- a/packages/pg-delta/src/policy/capability.test.ts
+++ b/packages/pg-delta/src/policy/capability.test.ts
@@ -2,11 +2,12 @@
  * Applier-capability-restricted view (docs/architecture/managed-view-architecture.md move 6).
  *
  * The managed view is a function of (facts, policy, applier capability). An
- * operation the applier cannot execute is projected out — currently FDW ACLs,
- * which require superuser to GRANT/REVOKE. This is additive: the Supabase
- * Rule 9 (`{ acl, target fdw } → exclude`) still stands; capability derives the
- * same exclusion for ANY non-superuser applier. With no capability (or a
- * superuser), the view is unrestricted — the corpus path is unchanged.
+ * operation the applier cannot execute is projected out — currently FDW ACLs
+ * (superuser GRANT/REVOKE) and event triggers whose function is superuser-owned
+ * (supautils T_CreateEventTrigStmt / PostgreSQL: a non-superuser cannot own an
+ * event trigger on a superuser-owned function). Additive: Supabase Rule 9 still
+ * stands for FDW ACLs. With no capability (or a superuser), the view is
+ * unrestricted — the corpus path is unchanged.
  */
 import { describe, expect, test } from "bun:test";
 import { buildFactBase, type Fact } from "../core/fact.ts";
@@ -59,6 +60,98 @@ describe("ApplierCapability — capability-restricted view (move 6)", () => {
     expect(capabilityExcludedRoots(fb, superuser).size).toBe(0);
     const roots = capabilityExcludedRoots(fb, nonSuper);
     expect(roots.size).toBe(1);
+  });
+});
+
+describe("ApplierCapability — event trigger on a superuser-owned function", () => {
+  // supautils (and PostgreSQL without it): a non-superuser may create an event
+  // trigger only if its function is not superuser-owned. Expressed on facts:
+  // the function's owner edge → role.payload.superuser.
+  const suRole: StableId = { kind: "role", name: "su" };
+  const appRole: StableId = { kind: "role", name: "app" };
+  const suFn: StableId = {
+    kind: "function",
+    schema: "public",
+    name: "on_ddl",
+    args: [],
+  };
+  const appFn: StableId = {
+    kind: "function",
+    schema: "public",
+    name: "user_fn",
+    args: [],
+  };
+  const suEt: StableId = { kind: "eventTrigger", name: "on_ddl_end" };
+  const appEt: StableId = { kind: "eventTrigger", name: "user_et" };
+
+  const role = (id: StableId, isSuper: boolean): Fact => ({
+    id,
+    payload: { superuser: isSuper },
+  });
+  const et = (id: StableId, fn: StableId): Fact => ({
+    id,
+    payload: {
+      event: "ddl_command_end",
+      enabled: "O",
+      tags: [],
+      functionSchema: (fn as { schema: string }).schema,
+      functionName: (fn as { name: string }).name,
+    },
+  });
+
+  const fb = buildFactBase(
+    [
+      role(suRole, true),
+      role(appRole, false),
+      f(suFn),
+      f(appFn),
+      et(suEt, suFn),
+      et(appEt, appFn),
+    ],
+    [
+      { from: suFn, to: suRole, kind: "owner" },
+      { from: appFn, to: appRole, kind: "owner" },
+    ],
+  );
+
+  test("non-superuser projects out an event trigger whose function is superuser-owned", () => {
+    const view = resolveView(fb, undefined, nonSuper);
+    expect(view.get(suEt)).toBeUndefined();
+    expect(view.get(appEt)).toBeDefined();
+    expect(view.get(suFn)).toBeDefined();
+  });
+
+  test("superuser and no-capability keep the event trigger (corpus path)", () => {
+    expect(resolveView(fb, undefined, superuser).get(suEt)).toBeDefined();
+    expect(resolveView(fb, undefined, undefined).get(suEt)).toBeDefined();
+  });
+
+  test("baseline-identical function/role still project the event trigger out", () => {
+    // subtractBaseline drops unchanged function + superuser role before
+    // capability runs; the lookup must still see them on the raw catalog.
+    const baseline = buildFactBase(
+      [role(suRole, true), f(suFn)],
+      [{ from: suFn, to: suRole, kind: "owner" }],
+    );
+    const view = resolveView(fb, undefined, nonSuper, baseline);
+    expect(view.get(suEt)).toBeUndefined();
+    expect(view.get(appEt)).toBeDefined();
+  });
+
+  test("non-superuser plan omits CREATE EVENT TRIGGER for the superuser-backed trigger", () => {
+    // Functions already present on both sides so the only deltas are the ETs.
+    const source = buildFactBase(
+      [role(suRole, true), role(appRole, false), f(suFn), f(appFn)],
+      [
+        { from: suFn, to: suRole, kind: "owner" },
+        { from: appFn, to: appRole, kind: "owner" },
+      ],
+    );
+    const sql = plan(source, fb, { capability: nonSuper })
+      .actions.map((a) => a.sql)
+      .join("\n");
+    expect(sql).not.toMatch(/CREATE EVENT TRIGGER "on_ddl_end"/);
+    expect(sql).toMatch(/CREATE EVENT TRIGGER "user_et"/);
   });
 });
 

--- a/packages/pg-delta/src/policy/capability.ts
+++ b/packages/pg-delta/src/policy/capability.ts
@@ -8,14 +8,19 @@
  * probed from the applier connection and threaded into plan()/prove() as an
  * option. Absent, the view is unrestricted (the default — superuser/CI path).
  *
- * v1 restriction: FDW ACLs. `GRANT`/`REVOKE ON FOREIGN DATA WRAPPER` requires
- * superuser, so a non-superuser applier cannot replay them. This derives, for
- * ANY non-superuser, the exclusion the Supabase policy hard-codes as Rule 9 —
- * additively (Rule 9 stays until the derivation is proven at parity).
+ * Restrictions for a non-superuser:
+ *   - FDW ACLs (`GRANT`/`REVOKE ON FOREIGN DATA WRAPPER` is superuser-only).
+ *     Derives, for ANY non-superuser, the exclusion Supabase hard-codes as
+ *     Rule 9 — additively (Rule 9 stays until the derivation is proven at
+ *     parity).
+ *   - Event triggers whose backing function is superuser-owned. That is
+ *     supautils' `T_CreateEventTrigStmt` rule (and PostgreSQL's without it):
+ *     a non-superuser may create an event trigger only if the function is
+ *     not superuser-owned. Read off the function fact's `owner` edge.
  */
 import type { Pool } from "pg";
-import type { FactBase } from "../core/fact.ts";
-import { encodeId } from "../core/stable-id.ts";
+import type { Fact, FactBase } from "../core/fact.ts";
+import { encodeId, type StableId } from "../core/stable-id.ts";
 
 export interface ApplierCapability {
   /** the role the migration is applied as (current_user) */
@@ -53,21 +58,46 @@ export async function probeApplierCapability(
   };
 }
 
+const CAPABILITY_FDW_ACL = "capability.fdw-acl";
+const CAPABILITY_EVENT_TRIGGER_SUPERUSER_FUNCTION =
+  "capability.event-trigger-superuser-function";
+
+function eventTriggerFunctionOwnedBySuperuser(
+  fb: FactBase,
+  fact: Fact,
+): boolean {
+  const schema = fact.payload["functionSchema"];
+  const name = fact.payload["functionName"];
+  if (typeof schema !== "string" || typeof name !== "string") return false;
+  const fnId: StableId = { kind: "function", schema, name, args: [] };
+  const fn = fb.get(fnId);
+  if (fn === undefined) return false;
+  const owner = fb.outgoingEdges(fn.id).find((e) => e.kind === "owner");
+  if (owner === undefined || owner.to.kind !== "role") return false;
+  return fb.get(owner.to)?.payload["superuser"] === true;
+}
+
 /**
- * Fact-id keys to project out for a given capability — the facts whose
- * corresponding action the applier cannot execute. A superuser is unrestricted.
- * Currently: FDW ACL facts (GRANT/REVOKE on a FOREIGN DATA WRAPPER is
- * superuser-only).
+ * Fact-id keys to project out for a given capability, mapped to the audit
+ * reason. A superuser is unrestricted. Currently: FDW ACL facts, and event
+ * triggers whose function is owned by a superuser.
  */
 export function capabilityExcludedRoots(
   fb: FactBase,
   cap: ApplierCapability,
-): Set<string> {
-  const roots = new Set<string>();
+): Map<string, string> {
+  const roots = new Map<string, string>();
   if (cap.isSuperuser) return roots;
   for (const fact of fb.facts()) {
     if (fact.id.kind === "acl" && fact.id.target.kind === "fdw") {
-      roots.add(encodeId(fact.id));
+      roots.set(encodeId(fact.id), CAPABILITY_FDW_ACL);
+      continue;
+    }
+    if (
+      fact.id.kind === "eventTrigger" &&
+      eventTriggerFunctionOwnedBySuperuser(fb, fact)
+    ) {
+      roots.set(encodeId(fact.id), CAPABILITY_EVENT_TRIGGER_SUPERUSER_FUNCTION);
     }
   }
   return roots;

--- a/packages/pg-delta/src/policy/capability.ts
+++ b/packages/pg-delta/src/policy/capability.ts
@@ -14,9 +14,10 @@
  *     Rule 9 — additively (Rule 9 stays until the derivation is proven at
  *     parity).
  *   - Event triggers whose backing function is superuser-owned. That is
- *     supautils' `T_CreateEventTrigStmt` rule (and PostgreSQL's without it):
- *     a non-superuser may create an event trigger only if the function is
- *     not superuser-owned. Read off the function fact's `owner` edge.
+ *     supautils' `T_CreateEventTrigStmt`: a privileged non-superuser may
+ *     create an event trigger only if the function is not superuser-owned.
+ *     Stock PostgreSQL has no such carve-out (CREATE EVENT TRIGGER is
+ *     superuser-only). Read off the function fact's `owner` edge.
  */
 import type { Pool } from "pg";
 import type { Fact, FactBase } from "../core/fact.ts";

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -1174,25 +1174,34 @@ export function resolveView(
     }
   }
   // capability restriction (move 6): project out facts whose action the applier
-  // cannot execute. Additive; default unrestricted. FDW ACLs are superuser-only
-  // GRANTs and a leaf fact, so they project out cleanly. (The owner residue is
-  // NOT projected — it can't be skipped without an ACL ripple — it fail-fasts
-  // in plan() instead; see capability.canSetOwner.)
+  // cannot execute. Additive; default unrestricted. FDW ACLs and event
+  // triggers on a superuser-owned function project out cleanly. (The owner
+  // residue is NOT projected — it can't be skipped without an ACL ripple — it
+  // fail-fasts in plan() instead; see capability.canSetOwner.)
   if (capability !== undefined) {
-    const capRoots = capabilityExcludedRoots(base, capability);
+    // Classify on the RAW catalog: a baseline-identical function / superuser
+    // role is already subtracted from `base`, but an event trigger that
+    // survived (owner or payload differs) still needs that lookup.
+    const capRoots = new Map<string, string>();
+    for (const [key, reasonCode] of capabilityExcludedRoots(fb, capability)) {
+      if (base.getByEncoded(key) !== undefined) capRoots.set(key, reasonCode);
+    }
     if (capRoots.size > 0) {
       const before = base;
-      base = excludeFactsAndDescendants(base, capRoots);
+      base = excludeFactsAndDescendants(base, new Set(capRoots.keys()));
       if (collectSuppression !== undefined) {
-        const attribution: ProjectionSuppressionAttribution = {
-          stage: "capability",
-          reasonCode: "capability.fdw-acl",
-          classification: "acknowledged",
-        };
+        const attribution = new Map<string, ProjectionSuppressionAttribution>();
+        for (const [key, reasonCode] of capRoots) {
+          attribution.set(key, {
+            stage: "capability",
+            reasonCode,
+            classification: "acknowledged",
+          });
+        }
         collectRemovedSuppressions(
           before,
           base,
-          new Map([...capRoots].map((key) => [key, attribution])),
+          attribution,
           collectSuppression,
         );
       }

--- a/packages/pg-delta/src/policy/projection-audit.test.ts
+++ b/packages/pg-delta/src/policy/projection-audit.test.ts
@@ -502,6 +502,47 @@ describe("attributed projection audit", () => {
     expect(audit.summary.baseline).toBe(1);
   });
 
+  test("capability restriction attributes an event trigger on a superuser-owned function", () => {
+    const suRole: StableId = { kind: "role", name: "su" };
+    const fn: StableId = {
+      kind: "function",
+      schema: "public",
+      name: "on_ddl",
+      args: [],
+    };
+    const et: StableId = { kind: "eventTrigger", name: "on_ddl_end" };
+    const etFact = fact(et, {
+      event: "ddl_command_end",
+      enabled: "O",
+      tags: [],
+      functionSchema: "public",
+      functionName: "on_ddl",
+    });
+    const shared = [fact(suRole, { superuser: true }), fact(fn)] as const;
+    const owner = { from: fn, to: suRole, kind: "owner" } as const;
+    const source = buildFactBase([...shared], [owner]);
+    const desired = buildFactBase([...shared, etFact], [owner]);
+    const capability: ApplierCapability = {
+      role: "app",
+      isSuperuser: false,
+      memberOf: [],
+    };
+
+    expect(
+      auditManagedViewProjection(source, desired, { capability }).entries[0],
+    ).toMatchObject({
+      subject: { kind: "fact", id: et },
+      classification: "acknowledged",
+      suppressions: [
+        {
+          side: "desired",
+          stage: "capability",
+          reasonCode: "capability.event-trigger-superuser-function",
+        },
+      ],
+    });
+  });
+
   test("capability restriction attributes a differing FDW ACL", () => {
     const wrapper: StableId = { kind: "fdw", name: "remote" };
     const acl: StableId = { kind: "acl", target: wrapper, grantee: "reader" };

--- a/packages/pg-delta/src/policy/supabase.ts
+++ b/packages/pg-delta/src/policy/supabase.ts
@@ -541,7 +541,8 @@ export const supabasePolicy: Policy = {
     // Identity, not owner: Rule 6 hides a supabase_admin-owned copy and keeps
     // a postgres-owned copy, so a same-named trigger becomes a false CREATE
     // (CLI-2341). Hard-exclude — nothing user-managed hangs off these, unlike
-    // assumedPublications.
+    // assumedPublications. Capability separately projects out any event
+    // trigger whose function is superuser-owned when restrictToApplier is on.
     {
       match: {
         all: [


### PR DESCRIPTION
<!--
Before opening this PR, confirm the linked issue is open and carries the
`open-for-contribution` label. PRs from external contributors that don't follow the
workflow in CONTRIBUTING.md are closed automatically.
@supabase members working from Linear tickets are exempt.
-->

## Summary

- For a non-superuser applier, project out any event trigger whose function is superuser-owned (supautils `T_CreateEventTrigStmt`).
- Classify on the raw catalog so a baseline-identical function/role still resolves.
- Stacked on #464 (the Supabase name-filter fix). Default `applyBaseline` does not pass `restrictToApplier`; this path is idle until that flag is on.

## Linked issue

Refs [CLI-2341](https://linear.app/supabase/issue/CLI-2341/fixpg-delta-event-trigger-hidden-by-owner-on-one-side-only-is-planned) (acceptance: non-superuser never plans `CREATE` of an event trigger on a superuser-owned function).

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Test plan

- [ ] `cd packages/pg-delta && bun test src/policy/capability.test.ts src/policy/projection-audit.test.ts`
- [ ] Corpus on one PG version: `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts`