### PR TITLE
fix(pg-delta): stop probing assumed schemas (CLI-2319)

### DIFF
--- a/.changeset/dml-probe-skips-assumed-schemas.md
+++ b/.changeset/dml-probe-skips-assumed-schemas.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): the shadow loader's DML observation no longer probes tables in the active policy's assumed (platform) schemas

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -273,7 +273,8 @@ re-implemented inside an imperative diff.
     default, warned on rather than rejected.** DML would succeed in the
     shadow and then silently vanish from the schema-only plan. After
     loading, the loader checks for observable data: any managed
-    non-extension table with rows, never by parsing SQL. In an
+    non-extension table with rows (tables in the active policy's assumed
+    platform schemas are never probed), never by parsing SQL. In an
     isolated-cluster shadow (the default there), tables that already held
     rows *before* the load are exempt via `allowPreExistingRows` — a
     name-based exemption; row contents are never compared, so an INSERT

--- a/packages/pg-delta/src/cli/main.ts
+++ b/packages/pg-delta/src/cli/main.ts
@@ -148,7 +148,8 @@ Notes:
     into one-statement units and topologically pre-sorts them so authoring
     order within a file no longer matters.
   --strict-data-statements (schema apply): fail (instead of warn) when
-    declarative files leave rows in managed user tables. By default a
+    declarative files leave rows in managed user tables (tables in the
+    profile's assumed platform schemas are never probed). By default a
     populated table observed after loading is either exempt (pre-existing
     rows in --isolated-shadow mode, reported on the result) or downgraded to
     a "data_statement" warning diagnostic, and the load proceeds with a

--- a/packages/pg-delta/src/frontends/load-sql-files.ts
+++ b/packages/pg-delta/src/frontends/load-sql-files.ts
@@ -50,7 +50,8 @@
  * schema, so refusing to read the schema back would block every directory that
  * carries incidental data. Set `strictDataStatements: true` (CLI
  * `--strict-data-statements`) to restore the fatal `ShadowLoadError` for CI.
- * Extension-owned relations (pg_depend deptype 'e') are always out of scope.
+ * Extension-owned relations (pg_depend deptype 'e') and the policy's assumed
+ * schemas (`assumedSchemas`) are always out of scope.
  */
 import type { Pool, PoolClient, QueryResult } from "pg";
 import { connectWithErrorListener } from "../pg-client.ts";
@@ -695,10 +696,10 @@ export interface LoadResult {
   pgVersion: string;
   diagnostics: Diagnostic[];
   rounds: number;
-  /** Managed non-extension tables that already held rows BEFORE the load, as
-   *  `"schema"."table"`, and are therefore exempt from the post-load DML
-   *  observation. Empty unless `allowPreExistingRows` is in effect (it defaults
-   *  to true in `"isolatedCluster"` mode). */
+  /** Managed non-extension tables (outside `assumedSchemas`) that already held
+   *  rows BEFORE the load, as `"schema"."table"`, and are therefore exempt from
+   *  the post-load DML observation. Empty unless `allowPreExistingRows` is in
+   *  effect (it defaults to true in `"isolatedCluster"` mode). */
   preExistingPopulatedTables: string[];
   /** Files that could not commit atomically and were demoted to per-statement
    *  apply this load. Empty when `statementFallback` is off or every file
@@ -820,20 +821,28 @@ async function restoreScratchClusterState(
  *
  * "Managed user table" must mean the SAME thing the diff path manages, so reuse
  * the extraction scope predicate (USER_SCHEMA_FILTER drops pg_catalog /
- * information_schema / pg_toast / pg_temp) and exclude extension-owned relations
- * (pg_depend deptype 'e'). Otherwise a declarative file that installs an
- * extension whose CREATE EXTENSION seeds internal config rows — or a platform
- * object — is wrongly read as if the user wrote DML (P2).
+ * information_schema / pg_toast / pg_temp), exclude extension-owned relations
+ * (pg_depend deptype 'e'), and skip the policy's assumed schemas — the one
+ * scope axis the loader can honour without a fact base (filter rules act on
+ * facts). Otherwise a declarative file that installs an extension that seeds
+ * internal config rows — or a platform object — is wrongly read as if the user
+ * wrote DML (P2), and a platform table the connecting role cannot read fails
+ * the whole load (supabase/cli#6453, `_realtime.schema_migrations`).
  */
 async function listPopulatedManagedTables(
   db: Pick<PoolClient, "query">,
+  assumedSchemas: readonly string[],
 ): Promise<string[]> {
-  const tables = await db.query(`
+  const tables = await db.query(
+    `
     SELECT n.nspname AS schema, c.relname AS name
     FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relkind = 'r'
       AND ${USER_SCHEMA_FILTER}
-      AND ${notExtensionMember("pg_class", "c.oid")}`);
+      AND n.nspname <> ALL($1::text[])
+      AND ${notExtensionMember("pg_class", "c.oid")}`,
+    [assumedSchemas],
+  );
   const populated: string[] = [];
   for (const row of tables.rows as { schema: string; name: string }[]) {
     const qualified = `"${row.schema.replaceAll('"', '""')}"."${row.name.replaceAll('"', '""')}"`;
@@ -887,13 +896,13 @@ export interface LoadSqlFilesOptions {
    *  dedicated shadow may be pre-provisioned by a platform — the Supabase CLI
    *  boots auth / storage / realtime against it, and those services write their
    *  own migration bookkeeping rows — long before declarative SQL is loaded.
-   *  When enabled the loader snapshots which managed non-extension tables are
-   *  populated before the load and exempts exactly those from the post-load DML
-   *  observation, silently; the exempted set is returned as
-   *  {@link LoadResult.preExistingPopulatedTables}. Exemption is by qualified
-   *  table NAME (no data comparison, ever), so a pre-populated table stays
-   *  exempt even if a declarative file inserts into it — an accepted limitation
-   *  of observing rather than parsing. */
+   *  When enabled the loader snapshots which managed non-extension tables
+   *  (outside `assumedSchemas`) are populated before the load and exempts
+   *  exactly those from the post-load DML observation, silently; the exempted
+   *  set is returned as {@link LoadResult.preExistingPopulatedTables}.
+   *  Exemption is by qualified table NAME (no data comparison, ever), so a
+   *  pre-populated table stays exempt even if a declarative file inserts into
+   *  it — an accepted limitation of observing rather than parsing. */
   allowPreExistingRows?: boolean;
   /** Escalate the post-load DML observation back to a fatal error (default
    *  `false`). By default a managed non-extension table holding rows the load
@@ -907,6 +916,12 @@ export interface LoadSqlFilesOptions {
    *  CLI adapter must pass `true` so declarative DML is rejected rather than
    *  warned. */
   strictDataStatements?: boolean;
+  /** Schemas the active policy assumes but does not manage
+   *  (`Policy.assumedSchemas`). Never probed by the DML observation, in either
+   *  the pre-load snapshot or the post-load check: their rows are platform
+   *  state, and the connecting role may not be allowed to read them
+   *  (supabase/cli#6453). */
+  assumedSchemas?: string[];
   /** After a file-atomic apply fails with a Postgres error, replay statements
    *  one at a time and retry only the remainder (default `true`). `false`
    *  restores whole-file rollback + whole-file retry. Policy
@@ -1008,6 +1023,7 @@ export async function loadSqlFiles(
   const seededRoutines = options.seededRoutines;
   const strictFunctionBodies = options.strictFunctionBodies ?? false;
   const strictDataStatements = options.strictDataStatements ?? false;
+  const assumedSchemas = options.assumedSchemas ?? [];
   // A dedicated (isolatedCluster) shadow may legitimately arrive pre-provisioned
   // with a platform baseline whose services already wrote bookkeeping rows — the
   // Supabase CLI declarative seam. A co-located scratch database never can (the
@@ -1040,7 +1056,7 @@ export async function loadSqlFiles(
   // declarative files, so attributing them to the user's SQL would be wrong.
   // Exemption is exact string-set subtraction against the identical query.
   const preExistingPopulatedTables = allowPreExistingRows
-    ? await listPopulatedManagedTables(shadow)
+    ? await listPopulatedManagedTables(shadow, assumedSchemas)
     : [];
   const preExistingPopulatedSet = new Set(preExistingPopulatedTables);
 
@@ -1721,9 +1737,9 @@ export async function loadSqlFiles(
     // tables that already held rows before the load (see the pre-load snapshot).
     // Tables exempted there are dropped SILENTLY — their rows are not the user's
     // DML, so there is nothing to tell the caller about.
-    const populated = (await listPopulatedManagedTables(client)).filter(
-      (t) => !preExistingPopulatedSet.has(t),
-    );
+    const populated = (
+      await listPopulatedManagedTables(client, assumedSchemas)
+    ).filter((t) => !preExistingPopulatedSet.has(t));
     if (populated.length > 0) {
       // FATAL only under the strictDataStatements opt-in. By default this is a
       // loud warning and the load proceeds: pg-delta diffs schema only, so rows

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -537,12 +537,12 @@ export async function planSchemaFiles(
           .map((f) => (f.id as { name: string }).name)
       : [];
 
+  const flatProfile = ctx.planOptions.policy
+    ? flattenPolicy(ctx.planOptions.policy)
+    : undefined;
   let seededSchemas: string[] = [];
   let seededRoutines = new Map<string, string>();
   if (options.seedAssumedSchemas === true) {
-    const flatProfile = ctx.planOptions.policy
-      ? flattenPolicy(ctx.planOptions.policy)
-      : undefined;
     const profileAssumedSchemas = flatProfile?.assumedSchemas ?? [];
     const profileAssumedPublications = flatProfile?.assumedPublications ?? [];
     // gate on EITHER assumed kind: a profile assuming only publications still
@@ -643,6 +643,8 @@ export async function planSchemaFiles(
     loadResult = await loadSqlFiles(loadInput, shadowPool, {
       extract: (p, o) => ctx.extract(p, { ...o, redactSecrets }),
       ...(seededSchemas.length > 0 ? { seededSchemas, seededRoutines } : {}),
+      // assumed (platform) schemas are not the user's to manage — never probed
+      assumedSchemas: flatProfile?.assumedSchemas ?? [],
       strictFunctionBodies: options.strictFunctionBodies === true,
       strictDataStatements: options.strictDataStatements === true,
       // undefined = let the loader default it from the mode

--- a/packages/pg-delta/tests/load-sql-files.test.ts
+++ b/packages/pg-delta/tests/load-sql-files.test.ts
@@ -1,5 +1,6 @@
 /** Stage-7 shadow loader: ordering convergence + the rejection behaviors. */
 import { describe, expect, test } from "bun:test";
+import pg from "pg";
 import {
   loadSqlFiles,
   ShadowLoadError,
@@ -487,6 +488,53 @@ describe("loadSqlFiles (shadow frontend)", () => {
       expect(dml[0]?.message).toContain(`"public"."widgets"`);
     } finally {
       await shadow.drop();
+    }
+  }, 90_000);
+
+  test("isolatedCluster mode: the DML probe never reads a table in an assumed (unmanaged) schema (supabase/cli#6453)", async () => {
+    const [clusterA] = await isolatedClusterPair();
+    const rolesBefore = await clusterA.listRoles();
+    const applier = `shadow_applier_${Date.now().toString(36)}`;
+    const shadow = await clusterA.createDb("shadow_assumed_unreadable");
+    let applierPool: pg.Pool | undefined;
+    try {
+      await clusterA.adminPool.query(
+        `CREATE ROLE "${applier}" LOGIN NOSUPERUSER PASSWORD 'applier'`,
+      );
+      await shadow.pool.query(`
+        CREATE SCHEMA _realtime;
+        CREATE TABLE _realtime.schema_migrations (
+          version bigint PRIMARY KEY, inserted_at timestamp(0));
+        INSERT INTO _realtime.schema_migrations VALUES (20210706140551, now());
+        CREATE TABLE _realtime.tenants (id integer PRIMARY KEY);
+        INSERT INTO _realtime.tenants VALUES (1);
+        GRANT USAGE ON SCHEMA _realtime TO "${applier}";
+        GRANT SELECT ON _realtime.tenants TO "${applier}";
+        GRANT ALL ON SCHEMA public TO "${applier}";
+      `);
+      const url = new URL(shadow.uri);
+      url.username = applier;
+      url.password = "applier";
+      applierPool = new pg.Pool({ connectionString: url.toString(), max: 5 });
+      applierPool.on("error", () => {});
+      const result = await loadSqlFiles(
+        [
+          {
+            name: "app.sql",
+            sql: "CREATE TABLE public.widgets (id integer PRIMARY KEY); INSERT INTO public.widgets VALUES (1);",
+          },
+        ],
+        applierPool,
+        { mode: "isolatedCluster", assumedSchemas: ["_realtime"] },
+      );
+      expect(result.preExistingPopulatedTables).toEqual([]);
+      const dml = result.diagnostics.filter((d) => d.code === "data_statement");
+      expect(dml).toHaveLength(1);
+      expect(dml[0]?.message).toContain(`"public"."widgets"`);
+    } finally {
+      await applierPool?.end();
+      await shadow.drop();
+      await clusterA.dropRolesExcept(rolesBefore, { strict: true });
     }
   }, 90_000);
 

--- a/packages/pg-delta/tests/schema-frontends.test.ts
+++ b/packages/pg-delta/tests/schema-frontends.test.ts
@@ -193,6 +193,83 @@ describe("public schema frontends", () => {
     }
   }, 120_000);
 
+  test("planSchemaFiles never probes the profile's assumed schemas in an isolated shadow (supabase/cli#6453)", async () => {
+    const platformProfile: IntegrationProfile = {
+      id: "test-platform-unreadable",
+      handlers: [],
+      policy: {
+        id: "test-platform-unreadable",
+        filter: [
+          {
+            match: { any: [{ schema: "_realtime" }, { name: "_realtime" }] },
+            action: "exclude",
+          },
+          {
+            match: {
+              all: [
+                { kind: ["acl", "comment", "securityLabel"] },
+                {
+                  any: [
+                    { target: { schema: "_realtime" } },
+                    { target: { kind: "schema", name: "_realtime" } },
+                  ],
+                },
+              ],
+            },
+            action: "exclude",
+          },
+        ],
+        assumedSchemas: ["_realtime"],
+      },
+    };
+    const [clusterA, clusterB] = await isolatedClusterPair();
+    const rolesBeforeA = await clusterA.listRoles();
+    const rolesBeforeB = await clusterB.listRoles();
+    const applier = `frontend_applier_${Date.now().toString(36)}`;
+    const target = await clusterA.createDb("frontend_unreadable_target");
+    const shadow = await clusterB.createDb("frontend_unreadable_shadow");
+    let applierPool: pg.Pool | undefined;
+    try {
+      const USER_SQL = "CREATE TABLE public.widgets (id integer PRIMARY KEY);";
+      await target.pool.query(`
+        CREATE ROLE "${applier}";
+        GRANT ALL ON SCHEMA public TO "${applier}";
+        ${USER_SQL}
+        ALTER TABLE public.widgets OWNER TO "${applier}";
+      `);
+      await clusterB.adminPool.query(
+        `CREATE ROLE "${applier}" LOGIN NOSUPERUSER PASSWORD 'applier'`,
+      );
+      await shadow.pool.query(`
+        CREATE SCHEMA _realtime;
+        CREATE TABLE _realtime.schema_migrations (version bigint PRIMARY KEY);
+        INSERT INTO _realtime.schema_migrations VALUES (20210706140551);
+        GRANT USAGE ON SCHEMA _realtime TO "${applier}";
+        GRANT ALL ON SCHEMA public TO "${applier}";
+      `);
+      const url = new URL(shadow.uri);
+      url.username = applier;
+      url.password = "applier";
+      applierPool = new pg.Pool({ connectionString: url.toString(), max: 5 });
+      applierPool.on("error", () => {});
+      const files: SqlFile[] = [{ name: "app.sql", sql: USER_SQL }];
+      const planned = await planSchemaFiles(target.pool, applierPool, files, {
+        profile: platformProfile,
+        scope: "database",
+        isolatedShadow: true,
+        strictDataStatements: true,
+      });
+      expect(planned.plan.actions).toEqual([]);
+    } finally {
+      await applierPool?.end();
+      await Promise.all([target.drop(), shadow.drop()]);
+      await Promise.all([
+        clusterA.dropRolesExcept(rolesBeforeA, { strict: true }),
+        clusterB.dropRolesExcept(rolesBeforeB, { strict: true }),
+      ]);
+    }
+  }, 120_000);
+
   test("planSchemaFiles permits a non-isolated database-scope sibling from the same lineage", async () => {
     const cluster = await sharedCluster();
     const target = await cluster.createDb("frontend_sibling_target");


### PR DESCRIPTION
## TL;DR
fixes `supabase db schema declarative sync` failing with `permission denied for table schema_migrations`,
 caused by the shadow loader's data statement probe reading platform tables the policy never manages.

## whats hurting?
With Realtime enabled, the sync fails on an in sync tree with an error about a table the user never wrote, and the only workaround is disabling Realtime. 
The probe selects from every user schema table as the connecting session, so Realtime's `_realtime.schema_migrations`, owned by `supabase_admin` with no grants, fails the whole plan whenever that session cannot read it...

## now fixed by:
The probe skips the active policy's assumed schemas, in both the pre-load exemption snapshot and the post-load observation. 
`loadSqlFiles` gains an optional `assumedSchemas`, empty by default so existing callers are unchanged, and `planSchemaFiles` forwards the profile policy's set. 
Rows in assumed platform schemas are now never observed, even with `--strict-data-statements`.
 Rows in user managed tables are reported exactly as before...

## ref:
- closes: https://github.com/supabase/cli/issues/6453