### PR TITLE
feat(pg-delta): opt in to batched transactional apply

### DIFF
--- a/.changeset/batched-apply-round-trips.md
+++ b/.changeset/batched-apply-round-trips.md
@@ -1,0 +1,10 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Apply can send each transactional segment as bounded multi-statement
+simple-protocol queries (plus a separate COMMIT). This is opt-in
+(`batchTransactional` / `--batch-transactional`); the default remains one
+query per action. Mid-batch failures are attributed from error.position
+when Postgres sends it, otherwise CommandComplete count. Non-transactional
+segments and `inDoubt` COMMIT semantics are unchanged.

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -498,7 +498,12 @@ valid when nothing else reads the target during apply. A single action
 that still exceeds the budget stays in its own segment; Postgres may still
 fail mid-statement. Parallel DDL stays rejected — `ACCESS EXCLUSIVE` locks
 make it a deadlock machine, and the transaction is the atomicity contract.
-Per-statement error attribution replaces a joined-string megaquery.
+Transactional segments default to one query per action. Opt-in
+`batchTransactional` sends a segment as bounded simple-protocol batches;
+the failing statement is the slot that contains `error.position` when
+Postgres sends it, otherwise the first that did not emit CommandComplete.
+`COMMIT` stays its own round trip so a lost commit is still the only
+`inDoubt` case.
 
 ### 3.9 Integrations: a policy layer over deltas
 

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1616,3 +1616,27 @@ target). Parked:
   run (typically ~2 extra slots). Order and the required COMMIT after
   ADD VALUE are unchanged. Honoring the mark is a `segmentActions`
   contract change, not a packer fix.
+
+## CLI-2296 — batched transactional apply
+
+`apply()` can send each transactional segment as one or more bounded
+simple-protocol batches (`BEGIN` + preamble + actions, 500 statements /
+1 MiB) with `COMMIT` as its own round trip so `inDoubt` stays “lost
+COMMIT only”. This is **opt-in** (`batchTransactional` /
+`--batch-transactional`); the default remains one query per action.
+Failure attribution prefers `error.position` through join offsets when
+Postgres sends it; otherwise CommandComplete count, with walk-off
+blaming the last action. No replay. Non-transactional segments are
+unchanged. Lock-table exhaustion is still #462 / `splitPlan` /
+`--split-to-fit` — batching does not widen that budget.
+
+Fixed in-PR: UTF-8 byte cap (not UTF-16 `length`); do not count
+`EmptyQueryResponse` as a slot; strip trailing `;` before join so a
+planner `CREATE …;` does not emit `;;`; put `;` on its own line so a
+trailing `--` cannot swallow the next action; map `error.position`
+through Postgres-character join offsets (not only when `completed === 0`);
+when CommandComplete walks off the end of the batch (multi-statement
+`action.sql` and no position), blame the last action instead of `BEGIN`;
+queue `actionStart` before submit and set `actionEnd.ms` to the batch
+duration; settle `CountingQuery` via `callback` so a client
+`query_timeout` cannot hang.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1639,4 +1639,17 @@ when CommandComplete walks off the end of the batch (multi-statement
 `action.sql` and no position), blame the last action instead of `BEGIN`;
 queue `actionStart` before submit and set `actionEnd.ms` to the batch
 duration; settle `CountingQuery` via `callback` so a client
-`query_timeout` cannot hang.
+`query_timeout` cannot hang; reject empty / transaction-control action
+SQL before connecting so a later-segment invariant failure cannot
+commit earlier segments and then throw without an `ApplyReport`.
+
+Deferred:
+
+- **CommandComplete → action (not slot) when `POSITION` is absent.**
+  Without a SQL parser we cannot know how many completions one
+  `action.sql` emits. `POSITION` is the primary path; completions are
+  1:1 best-effort, and walk-off-end blames the last action instead of
+  `BEGIN`. A `;` heuristic would be another regex over SQL.
+- **CodeQL `js/polynomial-redos` on `/;+\s*$/`.** End-anchored strip of
+  trailing semicolons. Dismissed: planner SQL is not a `;` bomb, and
+  the match cannot slide over the rest of the string.

--- a/packages/pg-delta/src/apply/apply.test.ts
+++ b/packages/pg-delta/src/apply/apply.test.ts
@@ -13,6 +13,7 @@ import {
   planSegments,
   segmentActions,
 } from "./apply.ts";
+import { joinStatements } from "./batch-query.ts";
 
 const txn = (newSegmentBefore = false) => ({
   transactionality: "transactional" as const,
@@ -191,15 +192,51 @@ interface ScriptedApply {
   releases: Array<Error | boolean | undefined>;
 }
 
+function queryText(sql: unknown): string {
+  if (typeof sql === "string") return sql;
+  if (
+    sql !== null &&
+    typeof sql === "object" &&
+    "text" in sql &&
+    typeof (sql as { text: unknown }).text === "string"
+  ) {
+    return (sql as { text: string }).text;
+  }
+  return String(sql);
+}
+
+function markCompleted(query: unknown, n: number): void {
+  if (query !== null && typeof query === "object" && "completed" in query) {
+    (query as { completed: number }).completed = n;
+  }
+}
+
 function scriptedApplyClient(failingSql: ReadonlySet<string>): ScriptedApply {
   const queries: string[] = [];
   const releases: Array<Error | boolean | undefined> = [];
   const client = {
-    query: (sql: string) => {
-      queries.push(sql);
-      return failingSql.has(sql)
-        ? Promise.reject(new Error(`scripted failure: ${sql}`))
-        : Promise.resolve({ rows: [] });
+    query: (sql: unknown) => {
+      const text = queryText(sql);
+      queries.push(text);
+      const parts = text.includes("\n;")
+        ? text
+            .split(/\n;\n\n/)
+            .map((part) => part.replace(/\n;$/, "").trim())
+            .filter((part) => part.length > 0)
+        : [text.trim()].filter((part) => part.length > 0);
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i]!;
+        if (failingSql.has(part)) {
+          markCompleted(sql, i);
+          return Promise.reject(
+            Object.assign(new Error(`scripted failure: ${part}`), {
+              completedBeforeError: i,
+            }),
+          );
+        }
+      }
+      markCompleted(sql, parts.length);
+      return Promise.resolve({ rows: [] });
     },
     release: (error?: Error | boolean) => releases.push(error),
     on: () => {},
@@ -465,6 +502,25 @@ describe("apply control-error attribution", () => {
     expect(segmentOutcomes(events)).toEqual(["failed"]);
     expect(scripted.releases).toEqual([true]);
   });
+
+  test("rejects an action whose SQL is a transaction control statement", async () => {
+    const scripted = scriptedApplyClient(new Set());
+    const base = planWithAction("transactional");
+    const { planId: _planId, ...rest } = base;
+    const thePlan = stampPlanId({
+      ...rest,
+      actions: [{ ...rest.actions[0]!, sql: "BEGIN" }],
+    });
+    let error: unknown;
+    try {
+      await apply(thePlan, scripted.pool, { fingerprintGate: false });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/transaction control/);
+    expect(scripted.queries).toEqual([]);
+  });
 });
 
 describe("apply plan integrity", () => {
@@ -612,5 +668,47 @@ describe("apply plan integrity", () => {
     expect((error as Error).message).toMatch(/planId/);
     expect((error as Error).message).toMatch(/re-plan/);
     expect(connected).toBe(false);
+  });
+});
+
+describe("apply batchTransactional opt-in", () => {
+  test("is off by default: one query per statement", async () => {
+    const scripted = scriptedApplyClient(new Set());
+    await apply(planWithAction("transactional"), scripted.pool, {
+      fingerprintGate: false,
+    });
+    expect(scripted.queries).toEqual(["BEGIN", "SELECT 42", "COMMIT"]);
+  });
+
+  test("batches BEGIN and the action into one query when opted in", async () => {
+    const scripted = scriptedApplyClient(new Set());
+    await apply(planWithAction("transactional"), scripted.pool, {
+      fingerprintGate: false,
+      batchTransactional: true,
+    });
+    expect(scripted.queries).toEqual([
+      joinStatements(["BEGIN", "SELECT 42"]),
+      "COMMIT",
+    ]);
+  });
+
+  test("a batched BEGIN failure still names the control", async () => {
+    const scripted = scriptedApplyClient(new Set(["BEGIN"]));
+    const events: ApplyEvent[] = [];
+    const report = await apply(planWithAction("transactional"), scripted.pool, {
+      fingerprintGate: false,
+      batchTransactional: true,
+      onEvent: (event) => events.push(event),
+    });
+    expect(scripted.queries).toEqual([
+      joinStatements(["BEGIN", "SELECT 42"]),
+      "ROLLBACK",
+    ]);
+    expect(report.error).toMatchObject({
+      statementKind: "control",
+      sql: "BEGIN",
+    });
+    expect(events.some((event) => event.kind === "actionStart")).toBe(true);
+    expect(events.some((event) => event.kind === "actionEnd")).toBe(false);
   });
 });

--- a/packages/pg-delta/src/apply/apply.test.ts
+++ b/packages/pg-delta/src/apply/apply.test.ts
@@ -521,6 +521,26 @@ describe("apply control-error attribution", () => {
     expect((error as Error).message).toMatch(/transaction control/);
     expect(scripted.queries).toEqual([]);
   });
+
+  test("rejects a later-segment transaction-control action before applying earlier segments", async () => {
+    const scripted = scriptedApplyClient(new Set());
+    const base = planWithAction("transactional");
+    const { planId: _planId, ...rest } = base;
+    const good = rest.actions[0]!;
+    const thePlan = stampPlanId({
+      ...rest,
+      actions: [good, { ...good, sql: "BEGIN", newSegmentBefore: true }],
+    });
+    let error: unknown;
+    try {
+      await apply(thePlan, scripted.pool, { fingerprintGate: false });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/transaction control/);
+    expect(scripted.queries).toEqual([]);
+  });
 });
 
 describe("apply plan integrity", () => {

--- a/packages/pg-delta/src/apply/apply.ts
+++ b/packages/pg-delta/src/apply/apply.ts
@@ -6,6 +6,9 @@
  * Segmentation changes transaction boundaries only, never order.
  * Apply honors `newSegmentBefore` already on the plan and does not
  * probe or split. Callers who want extra COMMITs run `splitPlan` first.
+ * Transactional segments default to one query per statement. Opt in with
+ * `batchTransactional` to send BEGIN + preamble + actions as bounded
+ * simple-protocol batches; COMMIT is still its own round trip.
  *
  * Mid-plan failure semantics are explicit: every action is reported
  * applied / unapplied / inDoubt, and the error identifies whether an action
@@ -23,6 +26,14 @@ import { ENGINE_VERSION, type Plan } from "../plan/plan.ts";
 import { assertDestructionMetadataIntegrity } from "../plan/safety.ts";
 import { reconstructManagedView } from "../policy/reconstruct.ts";
 import { buildApplyPreamble } from "./apply-preamble.ts";
+import {
+  assertActionSqlBatchable,
+  completedBeforeError,
+  encodeBatch,
+  failedBatchIndex,
+  partitionByBatchBounds,
+  querySimpleBatch,
+} from "./batch-query.ts";
 
 export {
   computeLockTableBudget,
@@ -55,6 +66,10 @@ export interface ApplyError {
 type ApplyStatementKind = NonNullable<ApplyError["statementKind"]>;
 type ProducedApplyError = ApplyError & { statementKind: ApplyStatementKind };
 
+type BatchStatement =
+  | { kind: "control"; sql: string }
+  | { kind: "action"; sql: string; actionIndex: number };
+
 export interface ApplyReport {
   status: "applied" | "failed";
   /** count of actions in committed segments */
@@ -70,11 +85,14 @@ export interface ApplyReport {
  *
  *  The applied statements are planner-rendered atomic DDL, not the authored
  *  declarative SQL, so `actionStart`/`actionEnd` alone are not a complete
- *  record of the wire:   `control` covers every OTHER statement apply() sends
+ *  record of the wire: `control` covers every OTHER statement apply() sends
  *  on the same connection — `BEGIN`, each preamble `SET`/`SET LOCAL`,
- *  `COMMIT`, `ROLLBACK` (including best-effort rollbacks on an error path),
- *  and `RESET ALL` — so a `--verbose` trace shows exactly what ran,
- *  transaction framing included. */
+ *  each transactional simple-protocol batch when `batchTransactional` is
+ *  on (`BEGIN` + preamble + actions, split at 500 statements / 1 MiB),
+ *  `COMMIT` (its own round trip), `ROLLBACK` (including best-effort
+ *  rollbacks on an error path), and `RESET ALL`. When batched,
+ *  `actionStart` fires before the batch Query is submitted and
+ *  `actionEnd.ms` is that batch's duration. */
 export type ApplyEvent =
   | {
       kind: "segmentStart";
@@ -126,6 +144,10 @@ export interface ApplyOptions {
    *  boundaries as apply() executes. Purely additive — see `emit` below for
    *  the isolation guarantee. */
   onEvent?: (event: ApplyEvent) => void;
+  /** Opt-in: send each transactional segment as bounded simple-protocol
+   *  batches instead of one query per action. Default off so apply can
+   *  fall back to the classic path if batching mis-attributes a failure. */
+  batchTransactional?: boolean;
 }
 
 export interface Segment {
@@ -437,48 +459,186 @@ export async function apply(
         continue;
       }
 
-      let setupSql = "BEGIN";
-      try {
-        emit(onEvent, { kind: "control", sql: "BEGIN" });
-        await client.query("BEGIN");
-        for (const sql of buildApplyPreamble(thePlan, options, true)) {
-          setupSql = sql;
-          emit(onEvent, { kind: "control", sql });
-          await client.query(sql);
+      if (options?.batchTransactional !== true) {
+        for (let i = segment.start; i < segment.end; i++) {
+          assertActionSqlBatchable(thePlan.actions[i]!.sql);
         }
-      } catch (error) {
-        emit(onEvent, { kind: "control", sql: "ROLLBACK" });
+        let setupSql = "BEGIN";
         try {
-          await client.query("ROLLBACK");
-        } catch {
-          destroyClient = true;
-        }
-        emit(onEvent, {
-          kind: "segmentEnd",
-          segmentIndex: segIdx,
-          outcome: "failed",
-        });
-        return {
-          status: "failed",
-          appliedActions,
-          actionStatuses: statuses,
-          error: errorEntry(segment.start, "control", setupSql, error),
-        };
-      }
-      for (let i = segment.start; i < segment.end; i++) {
-        const action = thePlan.actions[i]!;
-        emit(onEvent, { kind: "actionStart", actionIndex: i, sql: action.sql });
-        const actionStartedAt = performance.now();
-        try {
-          await client.query(action.sql);
+          emit(onEvent, { kind: "control", sql: "BEGIN" });
+          await client.query("BEGIN");
+          for (const sql of buildApplyPreamble(thePlan, options, true)) {
+            setupSql = sql;
+            emit(onEvent, { kind: "control", sql });
+            await client.query(sql);
+          }
         } catch (error) {
+          emit(onEvent, { kind: "control", sql: "ROLLBACK" });
+          try {
+            await client.query("ROLLBACK");
+          } catch {
+            destroyClient = true;
+          }
+          emit(onEvent, {
+            kind: "segmentEnd",
+            segmentIndex: segIdx,
+            outcome: "failed",
+          });
+          return {
+            status: "failed",
+            appliedActions,
+            actionStatuses: statuses,
+            error: errorEntry(segment.start, "control", setupSql, error),
+          };
+        }
+        for (let i = segment.start; i < segment.end; i++) {
+          const action = thePlan.actions[i]!;
+          emit(onEvent, {
+            kind: "actionStart",
+            actionIndex: i,
+            sql: action.sql,
+          });
+          const actionStartedAt = performance.now();
+          try {
+            await client.query(action.sql);
+          } catch (error) {
+            const actionElapsedMs = performance.now() - actionStartedAt;
+            emit(onEvent, {
+              kind: "actionEnd",
+              actionIndex: i,
+              ok: false,
+              ms: actionElapsedMs,
+            });
+            emit(onEvent, { kind: "control", sql: "ROLLBACK" });
+            let rollbackSucceeded = true;
+            try {
+              await client.query("ROLLBACK");
+            } catch {
+              rollbackSucceeded = false;
+              destroyClient = true;
+            }
+            emit(onEvent, {
+              kind: "segmentEnd",
+              segmentIndex: segIdx,
+              outcome: rollbackSucceeded ? "rolledBack" : "failed",
+            });
+            return {
+              status: "failed",
+              appliedActions,
+              actionStatuses: statuses,
+              error: errorEntry(i, "action", action.sql, error),
+            };
+          }
           const actionElapsedMs = performance.now() - actionStartedAt;
           emit(onEvent, {
             kind: "actionEnd",
             actionIndex: i,
-            ok: false,
+            ok: true,
             ms: actionElapsedMs,
           });
+        }
+        try {
+          emit(onEvent, { kind: "control", sql: "COMMIT" });
+          await client.query("COMMIT");
+        } catch (error) {
+          // the commit itself failed: the segment's fate is unknown
+          for (let i = segment.start; i < segment.end; i++)
+            statuses[i] = "inDoubt";
+          emit(onEvent, { kind: "control", sql: "ROLLBACK" });
+          try {
+            await client.query("ROLLBACK");
+          } catch {
+            destroyClient = true;
+          }
+          emit(onEvent, {
+            kind: "segmentEnd",
+            segmentIndex: segIdx,
+            outcome: "inDoubt",
+          });
+          return {
+            status: "failed",
+            appliedActions,
+            actionStatuses: statuses,
+            error: errorEntry(segment.start, "control", "COMMIT", error),
+          };
+        }
+        for (let i = segment.start; i < segment.end; i++)
+          statuses[i] = "applied";
+        appliedActions += segment.end - segment.start;
+        emit(onEvent, {
+          kind: "segmentEnd",
+          segmentIndex: segIdx,
+          outcome: "committed",
+        });
+        continue;
+      }
+
+      const preamble = buildApplyPreamble(thePlan, options, true);
+      const batchStatements: BatchStatement[] = [
+        { kind: "control", sql: "BEGIN" },
+      ];
+      for (const sql of preamble) {
+        batchStatements.push({ kind: "control", sql });
+      }
+      for (let i = segment.start; i < segment.end; i++) {
+        const action = thePlan.actions[i]!;
+        assertActionSqlBatchable(action.sql);
+        batchStatements.push({
+          kind: "action",
+          sql: action.sql,
+          actionIndex: i,
+        });
+      }
+      const batches = partitionByBatchBounds(
+        batchStatements,
+        (statement) => statement.sql,
+      );
+      for (const batch of batches) {
+        const encoded = encodeBatch(batch.map((statement) => statement.sql));
+        emit(onEvent, { kind: "control", sql: encoded.text });
+        const batchActions: Extract<BatchStatement, { kind: "action" }>[] = [];
+        for (const statement of batch) {
+          if (statement.kind === "action") {
+            batchActions.push(statement);
+            emit(onEvent, {
+              kind: "actionStart",
+              actionIndex: statement.actionIndex,
+              sql: statement.sql,
+            });
+          }
+        }
+        const batchStartedAt = performance.now();
+        try {
+          await querySimpleBatch(
+            client,
+            batch.map((statement) => statement.sql),
+          );
+        } catch (error) {
+          const batchMs = performance.now() - batchStartedAt;
+          const failAt = failedBatchIndex(batch.length, error, encoded.ranges);
+          const failed =
+            failAt < batch.length
+              ? batch[failAt]
+              : (batchActions.at(-1) ?? batch.at(-1));
+          const ranBeforeFail = completedBeforeError(error) > 0;
+          for (const statement of batchActions) {
+            const slot = batch.indexOf(statement);
+            if (failed?.kind === "action" && statement === failed) {
+              emit(onEvent, {
+                kind: "actionEnd",
+                actionIndex: statement.actionIndex,
+                ok: false,
+                ms: batchMs,
+              });
+            } else if (ranBeforeFail && slot < Math.min(failAt, batch.length)) {
+              emit(onEvent, {
+                kind: "actionEnd",
+                actionIndex: statement.actionIndex,
+                ok: true,
+                ms: batchMs,
+              });
+            }
+          }
           emit(onEvent, { kind: "control", sql: "ROLLBACK" });
           let rollbackSucceeded = true;
           try {
@@ -490,28 +650,39 @@ export async function apply(
           emit(onEvent, {
             kind: "segmentEnd",
             segmentIndex: segIdx,
-            outcome: rollbackSucceeded ? "rolledBack" : "failed",
+            outcome:
+              failed?.kind === "action"
+                ? rollbackSucceeded
+                  ? "rolledBack"
+                  : "failed"
+                : "failed",
           });
           return {
             status: "failed",
             appliedActions,
             actionStatuses: statuses,
-            error: errorEntry(i, "action", action.sql, error),
+            error: errorEntry(
+              failed?.kind === "action" ? failed.actionIndex : segment.start,
+              failed?.kind === "action" ? "action" : "control",
+              failed?.sql ?? batch[0]?.sql ?? "BEGIN",
+              error,
+            ),
           };
         }
-        const actionElapsedMs = performance.now() - actionStartedAt;
-        emit(onEvent, {
-          kind: "actionEnd",
-          actionIndex: i,
-          ok: true,
-          ms: actionElapsedMs,
-        });
+        const batchMs = performance.now() - batchStartedAt;
+        for (const statement of batchActions) {
+          emit(onEvent, {
+            kind: "actionEnd",
+            actionIndex: statement.actionIndex,
+            ok: true,
+            ms: batchMs,
+          });
+        }
       }
       try {
         emit(onEvent, { kind: "control", sql: "COMMIT" });
         await client.query("COMMIT");
       } catch (error) {
-        // the commit itself failed: the segment's fate is unknown
         for (let i = segment.start; i < segment.end; i++)
           statuses[i] = "inDoubt";
         emit(onEvent, { kind: "control", sql: "ROLLBACK" });

--- a/packages/pg-delta/src/apply/apply.ts
+++ b/packages/pg-delta/src/apply/apply.ts
@@ -331,6 +331,12 @@ export async function apply(
   const statuses: ActionStatus[] = thePlan.actions.map(() => "unapplied");
   let appliedActions = 0;
 
+  // Plan invariant, not a mid-apply failure: refuse empty / txn-control
+  // SQL before connecting so a later segment cannot commit earlier ones.
+  for (const action of thePlan.actions) {
+    assertActionSqlBatchable(action.sql);
+  }
+
   const client = await connectWithErrorListener(target);
   let destroyClient = false;
   try {
@@ -460,9 +466,6 @@ export async function apply(
       }
 
       if (options?.batchTransactional !== true) {
-        for (let i = segment.start; i < segment.end; i++) {
-          assertActionSqlBatchable(thePlan.actions[i]!.sql);
-        }
         let setupSql = "BEGIN";
         try {
           emit(onEvent, { kind: "control", sql: "BEGIN" });
@@ -582,7 +585,6 @@ export async function apply(
       }
       for (let i = segment.start; i < segment.end; i++) {
         const action = thePlan.actions[i]!;
-        assertActionSqlBatchable(action.sql);
         batchStatements.push({
           kind: "action",
           sql: action.sql,

--- a/packages/pg-delta/src/apply/batch-query.test.ts
+++ b/packages/pg-delta/src/apply/batch-query.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertActionSqlBatchable,
+  encodeBatch,
+  failedBatchIndex,
+  joinStatements,
+  partitionByBatchBounds,
+} from "./batch-query.ts";
+
+describe("assertActionSqlBatchable", () => {
+  test("rejects empty and transaction-control text", () => {
+    expect(() => assertActionSqlBatchable("")).toThrow(/empty/);
+    expect(() => assertActionSqlBatchable("   ")).toThrow(/empty/);
+    expect(() => assertActionSqlBatchable("BEGIN")).toThrow(
+      /transaction control/,
+    );
+    expect(() => assertActionSqlBatchable("commit;")).toThrow(
+      /transaction control/,
+    );
+    expect(() => assertActionSqlBatchable("ROLLBACK TO save")).toThrow(
+      /transaction control/,
+    );
+    expect(() => assertActionSqlBatchable(";;;")).toThrow(/empty/);
+  });
+
+  test("accepts ordinary DDL", () => {
+    expect(() =>
+      assertActionSqlBatchable("CREATE TABLE app.t (id int)"),
+    ).not.toThrow();
+  });
+});
+
+describe("partitionByBatchBounds", () => {
+  test("keeps a small segment in one batch", () => {
+    expect(
+      partitionByBatchBounds(["BEGIN", "SELECT 1", "SELECT 2"], (s) => s),
+    ).toEqual([["BEGIN", "SELECT 1", "SELECT 2"]]);
+  });
+
+  test("splits at the statement cap", () => {
+    const items = Array.from({ length: 3 }, (_, i) => `S${String(i)}`);
+    expect(
+      partitionByBatchBounds(items, (s) => s, { maxStatements: 2 }),
+    ).toEqual([["S0", "S1"], ["S2"]]);
+  });
+
+  test("splits when the next statement would exceed the byte cap", () => {
+    // terminated "aa" is "aa\n;" (4 bytes); two of those plus "\n\n" is 10.
+    expect(
+      partitionByBatchBounds(["aa", "bb", "cc"], (s) => s, {
+        maxBytes: 10,
+      }),
+    ).toEqual([["aa", "bb"], ["cc"]]);
+  });
+
+  test("a single oversized statement is still its own batch", () => {
+    expect(
+      partitionByBatchBounds(["abcdefghij"], (s) => s, { maxBytes: 3 }),
+    ).toEqual([["abcdefghij"]]);
+  });
+
+  test("the byte cap is UTF-8, not UTF-16 code units", () => {
+    // "中\n;" is 5 UTF-8 bytes; two joined are 12. A 4-byte cap splits.
+    expect(
+      partitionByBatchBounds(["中", "中"], (s) => s, { maxBytes: 4 }),
+    ).toEqual([["中"], ["中"]]);
+  });
+});
+
+describe("joinStatements", () => {
+  test("puts the semicolon on its own line", () => {
+    expect(joinStatements(["BEGIN", "SELECT 1"])).toBe(
+      "BEGIN\n;\n\nSELECT 1\n;",
+    );
+  });
+
+  test("strips a trailing semicolon so join does not emit an empty query", () => {
+    expect(joinStatements(["BEGIN", "SELECT 1;"])).toBe(
+      "BEGIN\n;\n\nSELECT 1\n;",
+    );
+  });
+
+  test("a trailing line comment cannot swallow the separator", () => {
+    expect(joinStatements(["SELECT 1 -- leftover", "SELECT 2"])).toBe(
+      "SELECT 1 -- leftover\n;\n\nSELECT 2\n;",
+    );
+  });
+});
+
+describe("failedBatchIndex", () => {
+  const encoded = encodeBatch(["BEGIN", "SELECT 1", "SELCT 1"]);
+
+  test("a parse-time position maps to the slot that contains it", () => {
+    const pos = encoded.text.indexOf("SELCT") + 1;
+    expect(
+      failedBatchIndex(
+        3,
+        { completedBeforeError: 0, position: String(pos) },
+        encoded.ranges,
+      ),
+    ).toBe(2);
+  });
+
+  test("zero completions without a position name the first slot", () => {
+    expect(
+      failedBatchIndex(3, { completedBeforeError: 0 }, encoded.ranges),
+    ).toBe(0);
+  });
+
+  test("a mid-batch completion count is the failing slot", () => {
+    expect(
+      failedBatchIndex(3, { completedBeforeError: 1 }, encoded.ranges),
+    ).toBe(1);
+  });
+
+  test("completions past the last slot walk off the end", () => {
+    expect(
+      failedBatchIndex(3, { completedBeforeError: 3 }, encoded.ranges),
+    ).toBe(3);
+  });
+
+  test("a present position wins over a shifted CommandComplete count", () => {
+    const multi = encodeBatch([
+      "BEGIN",
+      "REVOKE ALL ON SCHEMA s FROM PUBLIC;\nGRANT USAGE ON SCHEMA s TO PUBLIC",
+      "CREATE TABLE s.t (id int)",
+    ]);
+    const pos = multi.text.indexOf("GRANT") + 1;
+    expect(
+      failedBatchIndex(
+        3,
+        { completedBeforeError: 2, position: String(pos) },
+        multi.ranges,
+      ),
+    ).toBe(1);
+  });
+
+  test("position mapping counts Postgres characters, not UTF-16 units", () => {
+    const withEmoji = encodeBatch(["😀".repeat(10), "SELCT 1"]);
+    expect(withEmoji.text.indexOf("SELCT") + 1).not.toBe(
+      withEmoji.ranges[1]!.start + 1,
+    );
+    expect(
+      failedBatchIndex(
+        2,
+        {
+          completedBeforeError: 0,
+          position: String(withEmoji.ranges[1]!.start + 1),
+        },
+        withEmoji.ranges,
+      ),
+    ).toBe(1);
+  });
+});

--- a/packages/pg-delta/src/apply/batch-query.ts
+++ b/packages/pg-delta/src/apply/batch-query.ts
@@ -107,8 +107,10 @@ export function assertActionSqlBatchable(sql: string): void {
   }
 }
 
+const TEXT_ENCODER = new TextEncoder();
+
 function utf8Bytes(text: string): number {
-  return Buffer.byteLength(text, "utf8");
+  return TEXT_ENCODER.encode(text).length;
 }
 
 function terminatedBytes(sql: string): number {

--- a/packages/pg-delta/src/apply/batch-query.ts
+++ b/packages/pg-delta/src/apply/batch-query.ts
@@ -1,0 +1,245 @@
+/**
+ * Simple-protocol multi-statement batches for apply(). Postgres lexes the
+ * entire Query string before any statement runs (protocol §54.2.2.1), then
+ * emits CommandComplete per finished statement and skips the rest on error.
+ * Semantic failures use the completion count. Parse failures emit none —
+ * map error.position through the join offsets we already know.
+ */
+import { Query } from "pg";
+
+const DEFAULT_BATCH_MAX_STATEMENTS = 500;
+const DEFAULT_BATCH_MAX_BYTES = 1024 * 1024;
+const JOIN_SEP = "\n\n";
+
+const TX_CONTROL = /^(BEGIN|COMMIT|ROLLBACK)\b/i;
+
+interface BatchBounds {
+  maxStatements?: number;
+  maxBytes?: number;
+}
+
+export interface BatchRange {
+  start: number;
+  end: number;
+}
+
+export interface EncodedBatch {
+  text: string;
+  ranges: BatchRange[];
+}
+
+interface QueryInternals {
+  handleCommandComplete(msg: unknown, connection: unknown): void;
+}
+
+/** node-pg Query that counts CommandComplete. EmptyQueryResponse is not a
+ *  batch slot — `;;` from a trailing semicolon on action.sql must not shift
+ *  the failing index. */
+class CountingQuery extends Query {
+  completed = 0;
+  callback?: (error: Error | undefined, result?: unknown) => void;
+
+  handleCommandComplete(msg: unknown, connection: unknown): void {
+    this.completed += 1;
+    (Query.prototype as unknown as QueryInternals).handleCommandComplete.call(
+      this,
+      msg,
+      connection,
+    );
+  }
+}
+
+function stripTrailingSemicolons(sql: string): string {
+  return sql.replace(/;+\s*$/, "");
+}
+
+/** Semicolon on its own line so a trailing `--` cannot swallow the separator. */
+function terminate(sql: string): string {
+  return `${stripTrailingSemicolons(sql).trimEnd()}\n;`;
+}
+
+/** Postgres POSITION counts client-encoding characters, not UTF-16 units. */
+function pgChars(text: string): number {
+  let n = 0;
+  for (let i = 0; i < text.length; i++) {
+    const unit = text.charCodeAt(i);
+    if (unit >= 0xd800 && unit <= 0xdbff) i += 1;
+    n += 1;
+  }
+  return n;
+}
+
+export function encodeBatch(statements: readonly string[]): EncodedBatch {
+  const ranges: BatchRange[] = [];
+  let text = "";
+  let chars = 0;
+  for (let i = 0; i < statements.length; i++) {
+    if (i > 0) {
+      text += JOIN_SEP;
+      chars += pgChars(JOIN_SEP);
+    }
+    const start = chars;
+    const piece = terminate(statements[i]!);
+    text += piece;
+    chars += pgChars(piece);
+    ranges.push({ start, end: chars });
+  }
+  return { text, ranges };
+}
+
+export function joinStatements(statements: readonly string[]): string {
+  return encodeBatch(statements).text;
+}
+
+/** Action text that would collide with executor transaction framing. */
+export function assertActionSqlBatchable(sql: string): void {
+  const trimmed = sql
+    .trim()
+    .replace(/;+\s*$/, "")
+    .trim();
+  if (trimmed.length === 0) {
+    throw new Error("apply: action SQL must not be empty");
+  }
+  if (TX_CONTROL.test(trimmed)) {
+    throw new Error(
+      `apply: action SQL must not be a transaction control statement: ${trimmed}`,
+    );
+  }
+}
+
+function utf8Bytes(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+function terminatedBytes(sql: string): number {
+  return utf8Bytes(terminate(sql));
+}
+
+export function partitionByBatchBounds<T>(
+  items: readonly T[],
+  textOf: (item: T) => string,
+  bounds: BatchBounds = {},
+): T[][] {
+  const maxStatements = bounds.maxStatements ?? DEFAULT_BATCH_MAX_STATEMENTS;
+  const maxBytes = bounds.maxBytes ?? DEFAULT_BATCH_MAX_BYTES;
+  const batches: T[][] = [];
+  let current: T[] = [];
+  let bytes = 0;
+  for (const item of items) {
+    const piece = terminatedBytes(textOf(item));
+    const extra = current.length === 0 ? piece : utf8Bytes(JOIN_SEP) + piece;
+    if (
+      current.length > 0 &&
+      (current.length >= maxStatements || bytes + extra > maxBytes)
+    ) {
+      batches.push(current);
+      current = [];
+      bytes = 0;
+    }
+    if (current.length === 0) {
+      current = [item];
+      bytes = piece;
+    } else {
+      current.push(item);
+      bytes += extra;
+    }
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+export function completedBeforeError(error: unknown): number {
+  const tagged = (error as { completedBeforeError?: unknown })
+    .completedBeforeError;
+  if (typeof tagged === "number" && Number.isInteger(tagged) && tagged >= 0) {
+    return tagged;
+  }
+  return 0;
+}
+
+/** 0-based character index from Postgres POSITION (1-based, protocol field P). */
+function errorPosition(error: unknown): number | undefined {
+  const raw = (error as { position?: unknown }).position;
+  const n =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string" && /^\d+$/.test(raw)
+        ? Number(raw)
+        : undefined;
+  if (n === undefined || !Number.isInteger(n) || n < 1) return undefined;
+  return n - 1;
+}
+
+function slotAtChar(ranges: readonly BatchRange[], pos0: number): number {
+  for (let i = 0; i < ranges.length; i++) {
+    const range = ranges[i]!;
+    if (pos0 >= range.start && pos0 < range.end) return i;
+  }
+  for (let i = 0; i < ranges.length; i++) {
+    if (pos0 < ranges[i]!.start) return i;
+  }
+  return Math.max(0, ranges.length - 1);
+}
+
+/**
+ * Index of the failing batch slot, or `batchLength` when completions walked
+ * off the end (a prior slot emitted more than one CommandComplete).
+ */
+export function failedBatchIndex(
+  batchLength: number,
+  error: unknown,
+  ranges: readonly BatchRange[],
+): number {
+  const pos = errorPosition(error);
+  if (pos !== undefined && ranges.length > 0) {
+    return slotAtChar(ranges, pos);
+  }
+  const completed = completedBeforeError(error);
+  if (completed === 0) return 0;
+  if (completed < batchLength) return completed;
+  return batchLength;
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof (value as PromiseLike<unknown>).then === "function"
+  );
+}
+
+function tagCompleted(error: unknown, completed: number): void {
+  (error as { completedBeforeError?: number }).completedBeforeError ??=
+    completed;
+}
+
+export async function querySimpleBatch(
+  client: { query: (query: CountingQuery) => unknown },
+  statements: readonly string[],
+): Promise<{ completed: number }> {
+  const q = new CountingQuery(joinStatements(statements));
+  let settled = false;
+  const viaCallback = new Promise<{ completed: number }>((resolve, reject) => {
+    q.callback = (error: Error | undefined) => {
+      if (settled) return;
+      settled = true;
+      if (error) {
+        tagCompleted(error, q.completed);
+        reject(error);
+      } else {
+        resolve({ completed: q.completed });
+      }
+    };
+  });
+  try {
+    const maybe = client.query(q);
+    if (maybe !== q && isThenable(maybe)) {
+      await maybe;
+      return { completed: q.completed };
+    }
+    return await viaCallback;
+  } catch (error) {
+    tagCompleted(error, q.completed);
+    throw error;
+  }
+}

--- a/packages/pg-delta/src/cli/commands/apply.test.ts
+++ b/packages/pg-delta/src/cli/commands/apply.test.ts
@@ -59,6 +59,19 @@ function destructivePlan(): string {
   return path;
 }
 
+test("apply accepts --batch-transactional as a known flag", async () => {
+  const error = await captureError(
+    cmdApply([
+      "--plan",
+      "/no-such-plan.json",
+      "--target",
+      "postgres://unused.invalid:5432/none",
+      "--batch-transactional",
+    ]),
+  );
+  expect((error as Error).message).not.toMatch(/unknown/i);
+});
+
 test("apply rejects --max-locks before opening the target", async () => {
   const error = await captureError(
     cmdApply([

--- a/packages/pg-delta/src/cli/commands/apply.ts
+++ b/packages/pg-delta/src/cli/commands/apply.ts
@@ -35,11 +35,12 @@ export async function cmdApply(args: string[]): Promise<void> {
       "allow-data-loss": { type: "boolean" },
       "max-locks": { type: "value" },
       "split-to-fit": { type: "boolean" },
+      "batch-transactional": { type: "boolean" },
     });
   } catch (err) {
     if (err instanceof UsageError) {
       throw new UsageError(
-        `${err.message}\nUsage: pgdelta apply --plan <plan.json> --target <pg-url> [--profile ${PROFILE_IDS}] [--force] [--allow-data-loss] [--max-locks <n>] [--split-to-fit]`,
+        `${err.message}\nUsage: pgdelta apply --plan <plan.json> --target <pg-url> [--profile ${PROFILE_IDS}] [--force] [--allow-data-loss] [--max-locks <n>] [--split-to-fit] [--batch-transactional]`,
       );
     }
     throw err;
@@ -117,6 +118,9 @@ export async function cmdApply(args: string[]): Promise<void> {
       fingerprintGate: !force,
       ...ctx.applyOptions, // reextract (handler-aware) + baseline
       reextract: (p) => ctx.extract(p, { redactSecrets }),
+      ...(flags["batch-transactional"] === true
+        ? { batchTransactional: true }
+        : {}),
     });
 
     if (report.status === "applied") {

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -750,6 +750,7 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
       "allow-same-database-identity": { type: "boolean" },
       "max-locks": { type: "value" },
       "split-to-fit": { type: "boolean" },
+      "batch-transactional": { type: "boolean" },
     });
   } catch (err) {
     if (err instanceof UsageError) {
@@ -757,7 +758,7 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
         `${err.message}\nUsage: pgdelta schema apply --dir <dir> --target <pg-url> [--shadow <pg-url>] ` +
           `[--renames auto|prompt|off] [--force] [--accept-rename <from>=<to>] ... ` +
           `[--profile ${PROFILE_IDS}] [--restrict-to-applier] [--no-restrict-to-applier] [--strict-coverage] [--strict-function-bodies] [--strict-data-statements] [--no-reorder] [--unsafe-show-secrets] [--isolated-shadow] [--scope database|cluster] [--skip-cluster-ddl] [--keep-shadow] [--allow-data-loss] ` +
-          `[--trusted-local-host <hostname>]... [--allow-remote-shadow] [--allow-same-database-identity] [--max-locks <n>] [--split-to-fit]\n` +
+          `[--trusted-local-host <hostname>]... [--allow-remote-shadow] [--allow-same-database-identity] [--max-locks <n>] [--split-to-fit] [--batch-transactional]\n` +
           `  [--dry-run] (print the portable apply script to stdout; apply nothing; see pgdelta --help for execution requirements) [--verbose] (stream per-statement progress to stderr) [--out-plan <plan.json>] (write the plan artifact)\n` +
           `  --shadow omitted: a co-located shadow database is created on the target's cluster (database scope only) and dropped after.`,
       );
@@ -1230,8 +1231,9 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
               break;
             case "control":
               // every OTHER statement apply() sends on the wire — BEGIN,
-              // preamble SET/SET LOCAL, COMMIT, ROLLBACK, RESET ALL — prefixed
-              // to stay visually distinct from `[i/total] <action sql>` lines.
+              // preamble SET/SET LOCAL, transactional batches, COMMIT,
+              // ROLLBACK, RESET ALL — prefixed to stay visually distinct
+              // from `[i/total] <action sql>` lines.
               process.stderr.write(`  ; ${event.sql}\n`);
               break;
           }
@@ -1244,6 +1246,9 @@ export async function cmdSchemaApply(args: string[]): Promise<void> {
         planned.extract(p, { redactSecrets: planned.redactSecrets }),
       fingerprintGate: !force,
       ...(onEvent !== undefined ? { onEvent } : {}),
+      ...(flags["batch-transactional"] === true
+        ? { batchTransactional: true }
+        : {}),
     });
 
     if (report.status === "applied") {

--- a/packages/pg-delta/src/cli/main.ts
+++ b/packages/pg-delta/src/cli/main.ts
@@ -66,7 +66,7 @@ Commands:
                  [--renames auto|prompt|off] [--no-compact] [--out <plan.json>]
                  [--accept-rename <from>=<to>] ... [--max-locks <n>]
   apply          --plan <plan.json> --target <pg-url> [--force] [--allow-data-loss]
-                 [--max-locks <n>] [--split-to-fit]
+                 [--max-locks <n>] [--split-to-fit] [--batch-transactional]
   render         --plan <plan.json> --out <base>.sql [--allow-drops]
   prove          --plan <plan.json> --clone <pg-url> --desired-snapshot <file>
                  [--strict-audit] [--audit-all]
@@ -87,7 +87,7 @@ Commands:
                  [--allow-same-database-identity]
                  [--accept-rename <from>=<to>] ... [--no-reorder]
                  [--dry-run] [--verbose] [--out-plan <plan.json>]
-                 [--max-locks <n>] [--split-to-fit]
+                 [--max-locks <n>] [--split-to-fit] [--batch-transactional]
   schema lint    --dir <dir>
 
 Notes:
@@ -193,6 +193,10 @@ Notes:
     pack with the remaining budget. Mutually exclusive with --max-locks.
     A single action that still exceeds the budget stays in its own
     segment; Postgres may still fail mid-statement.
+  --batch-transactional (apply, schema apply): opt-in. Send each
+    transactional segment as bounded simple-protocol batches instead of
+    one query per statement. COMMIT stays its own round trip. Default is
+    one query per statement.
   --unsafe-show-secrets (plan, diff, drift, snapshot, schema export, schema apply):
     emit REAL foreign-data option values and subscription conninfo instead of
     redacted placeholders. Off by default; raises a loud warning when set.
@@ -226,7 +230,7 @@ Subcommands:
                  [--allow-same-database-identity]
                  [--accept-rename <from>=<to>] ... [--no-reorder]
                  [--dry-run] [--verbose] [--out-plan <plan.json>]
-                 [--max-locks <n>] [--split-to-fit]
+                 [--max-locks <n>] [--split-to-fit] [--batch-transactional]
   schema lint    --dir <dir>
                  Statically check the SQL files (pg-topo) for shadow-load
                  cycles and other issues, without touching a database.

--- a/packages/pg-delta/tests/apply-batch-failure.test.ts
+++ b/packages/pg-delta/tests/apply-batch-failure.test.ts
@@ -51,7 +51,6 @@ describe("apply() batched failure attribution", () => {
     const { result, queries } = await withApplyQueries(db.pool, () =>
       apply(planFromActions(actions), db.pool, {
         fingerprintGate: false,
-        lockTableReserveConnections: 1,
         batchTransactional: true,
       }),
     );
@@ -124,7 +123,6 @@ describe("apply() batched failure attribution", () => {
 
     const result = await apply(planFromActions(actions), db.pool, {
       fingerprintGate: false,
-      lockTableReserveConnections: 1,
       batchTransactional: true,
     });
 
@@ -156,7 +154,6 @@ describe("apply() batched failure attribution", () => {
 
     const result = await apply(planFromActions(actions), db.pool, {
       fingerprintGate: false,
-      lockTableReserveConnections: 1,
       batchTransactional: true,
     });
 
@@ -184,7 +181,6 @@ describe("apply() batched failure attribution", () => {
 
     const result = await apply(planFromActions(actions), db.pool, {
       fingerprintGate: false,
-      lockTableReserveConnections: 1,
       batchTransactional: true,
     });
 
@@ -218,7 +214,6 @@ describe("apply() batched failure attribution", () => {
 
     const result = await apply(planFromActions(actions), db.pool, {
       fingerprintGate: false,
-      lockTableReserveConnections: 1,
       batchTransactional: true,
     });
 
@@ -276,7 +271,6 @@ describe("apply() batched failure attribution", () => {
     const { result, queries } = await withApplyQueries(db.pool, () =>
       apply(planFromActions(actions), db.pool, {
         fingerprintGate: false,
-        lockTableReserveConnections: 1,
         batchTransactional: true,
         onEvent: (event) => events.push(event),
       }),

--- a/packages/pg-delta/tests/apply-batch-failure.test.ts
+++ b/packages/pg-delta/tests/apply-batch-failure.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Mid-batch apply failures name the failing plan action from CommandComplete
+ * count (semantic errors) or error.position through join offsets (parse
+ * errors). COMMIT stays its own round trip so inDoubt semantics match
+ * today's executor.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { apply, type ApplyEvent } from "../src/apply/apply.ts";
+import {
+  completedBeforeError,
+  querySimpleBatch,
+} from "../src/apply/batch-query.ts";
+import type { Action } from "../src/plan/plan.ts";
+import { createTestDb, type TestDb } from "./containers.ts";
+import {
+  planFromActions,
+  txnAction,
+  withApplyQueries,
+} from "./apply-test-helpers.ts";
+
+const dbs: TestDb[] = [];
+afterAll(async () => {
+  await Promise.all(dbs.map((d) => d.drop().catch(() => {})));
+});
+
+describe("apply() batched failure attribution", () => {
+  test("a mid-segment failure names action k and rolls the segment back", async () => {
+    const db = await createTestDb("apply_batch_fail");
+    dbs.push(db);
+
+    const failSql = "SELECT 1 FROM batch_fail.does_not_exist";
+    const priorSql = "CREATE TABLE batch_fail.t3 (id int)";
+    const actions: Action[] = [
+      txnAction("CREATE SCHEMA batch_fail"),
+      txnAction("CREATE TABLE batch_fail.t0 (id int)", {
+        newSegmentBefore: true,
+      }),
+      txnAction("CREATE TABLE batch_fail.t1 (id int)"),
+      txnAction("CREATE TABLE batch_fail.t2 (id int)"),
+      txnAction(priorSql),
+      txnAction(failSql),
+      txnAction("CREATE TABLE batch_fail.t5 (id int)"),
+      txnAction("CREATE TABLE batch_fail.t6 (id int)"),
+      txnAction("CREATE TABLE batch_fail.t7 (id int)"),
+      txnAction("CREATE TABLE batch_fail.t8 (id int)"),
+      txnAction("CREATE TABLE batch_fail.t9 (id int)"),
+    ];
+    const failIndex = actions.findIndex((action) => action.sql === failSql);
+    expect(failIndex).toBe(5);
+
+    const { result, queries } = await withApplyQueries(db.pool, () =>
+      apply(planFromActions(actions), db.pool, {
+        fingerprintGate: false,
+        lockTableReserveConnections: 1,
+        batchTransactional: true,
+      }),
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.appliedActions).toBe(1);
+    expect(result.error).toMatchObject({
+      actionIndex: failIndex,
+      statementKind: "action",
+      sql: failSql,
+    });
+    expect(result.error?.message).toMatch(/does not exist/i);
+    expect(result.actionStatuses).toEqual([
+      "applied",
+      ...Array.from({ length: 10 }, () => "unapplied" as const),
+    ]);
+    // the failing statement rode in the same simple-protocol query as
+    // earlier actions in the segment — attribution is not "replay until
+    // it breaks".
+    expect(
+      queries.some((sql) => sql.includes(priorSql) && sql.includes(failSql)),
+    ).toBe(true);
+
+    const leftover = await db.pool.query<{ n: number }>(
+      `SELECT count(*)::int AS n
+       FROM pg_catalog.pg_class c
+       JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'batch_fail' AND c.relkind = 'r'`,
+    );
+    expect(leftover.rows[0]?.n).toBe(0);
+    const schemas = await db.pool.query<{ n: number }>(
+      `SELECT count(*)::int AS n
+       FROM pg_catalog.pg_namespace
+       WHERE nspname = 'batch_fail'`,
+    );
+    expect(schemas.rows[0]?.n).toBe(1);
+  }, 120_000);
+
+  test("EmptyQueryResponse does not consume a batch slot", async () => {
+    const db = await createTestDb("apply_batch_empty");
+    dbs.push(db);
+    const client = await db.pool.connect();
+    try {
+      await querySimpleBatch(client, [
+        "SELECT 1",
+        "   ",
+        "SELECT 1 FROM apply_batch_empty_missing",
+      ]);
+      throw new Error("expected the missing-relation statement to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).not.toMatch(/expected the missing/);
+      expect(completedBeforeError(error)).toBe(1);
+    } finally {
+      client.release();
+    }
+  }, 120_000);
+
+  test("a trailing semicolon on a prior action does not shift attribution", async () => {
+    const db = await createTestDb("apply_batch_semi");
+    dbs.push(db);
+
+    const priorSql = "CREATE TABLE batch_semi.t (id int);";
+    const failSql = "SELECT 1 FROM batch_semi.does_not_exist";
+    const actions: Action[] = [
+      txnAction("CREATE SCHEMA batch_semi"),
+      txnAction(priorSql, { newSegmentBefore: true }),
+      txnAction(failSql),
+    ];
+
+    const result = await apply(planFromActions(actions), db.pool, {
+      fingerprintGate: false,
+      lockTableReserveConnections: 1,
+      batchTransactional: true,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatchObject({
+      actionIndex: 2,
+      statementKind: "action",
+      sql: failSql,
+    });
+    expect(result.actionStatuses).toEqual([
+      "applied",
+      "unapplied",
+      "unapplied",
+    ]);
+  }, 120_000);
+
+  test("a trailing line comment does not swallow the next action", async () => {
+    const db = await createTestDb("apply_batch_dash");
+    dbs.push(db);
+
+    const failSql = "SELECT 1 FROM batch_dash.does_not_exist";
+    const actions: Action[] = [
+      txnAction("CREATE SCHEMA batch_dash"),
+      txnAction("CREATE TABLE batch_dash.t (id int) -- leftover", {
+        newSegmentBefore: true,
+      }),
+      txnAction(failSql),
+    ];
+
+    const result = await apply(planFromActions(actions), db.pool, {
+      fingerprintGate: false,
+      lockTableReserveConnections: 1,
+      batchTransactional: true,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatchObject({
+      actionIndex: 2,
+      statementKind: "action",
+      sql: failSql,
+    });
+  }, 120_000);
+
+  test("a syntax error in a later action is not reported as BEGIN", async () => {
+    const db = await createTestDb("apply_batch_syn");
+    dbs.push(db);
+
+    const failSql = "SELCT 1";
+    const actions: Action[] = [
+      txnAction("CREATE SCHEMA batch_syn"),
+      txnAction("CREATE TABLE batch_syn.t (id int)", {
+        newSegmentBefore: true,
+      }),
+      txnAction(failSql),
+      txnAction("CREATE TABLE batch_syn.u (id int)"),
+    ];
+
+    const result = await apply(planFromActions(actions), db.pool, {
+      fingerprintGate: false,
+      lockTableReserveConnections: 1,
+      batchTransactional: true,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatchObject({
+      actionIndex: 2,
+      statementKind: "action",
+      sql: failSql,
+    });
+    expect(result.error?.message).toMatch(/syntax error/i);
+    expect(result.actionStatuses).toEqual([
+      "applied",
+      "unapplied",
+      "unapplied",
+      "unapplied",
+    ]);
+  }, 120_000);
+
+  test("extra CommandCompletes from a multi-statement action do not blame BEGIN", async () => {
+    const db = await createTestDb("apply_batch_acl");
+    dbs.push(db);
+
+    const grantSql =
+      "REVOKE ALL ON SCHEMA batch_acl FROM PUBLIC;\nGRANT USAGE ON SCHEMA batch_acl TO PUBLIC";
+    const failSql = "SELECT 1 FROM batch_acl.does_not_exist";
+    const actions: Action[] = [
+      txnAction("CREATE SCHEMA batch_acl"),
+      txnAction(grantSql, { newSegmentBefore: true }),
+      txnAction(failSql),
+    ];
+
+    const result = await apply(planFromActions(actions), db.pool, {
+      fingerprintGate: false,
+      lockTableReserveConnections: 1,
+      batchTransactional: true,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatchObject({
+      actionIndex: 2,
+      statementKind: "action",
+      sql: failSql,
+    });
+    expect(result.error?.statementKind).not.toBe("control");
+  }, 120_000);
+
+  test("query_timeout on the client cannot hang a failing batch", async () => {
+    const db = await createTestDb("apply_batch_qto");
+    dbs.push(db);
+    const client = await db.pool.connect();
+    (
+      client as unknown as {
+        connectionParameters: { query_timeout?: number };
+      }
+    ).connectionParameters.query_timeout = 80;
+    const started = performance.now();
+    try {
+      await querySimpleBatch(client, ["SELECT pg_sleep(5)"]);
+      throw new Error("expected query_timeout to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(/timeout/i);
+      expect(performance.now() - started).toBeLessThan(4_000);
+    } finally {
+      client.release();
+    }
+  }, 15_000);
+
+  test("COMMIT failure (deferred constraint) is an in-doubt control error", async () => {
+    const db = await createTestDb("apply_batch_commit");
+    dbs.push(db);
+
+    const events: ApplyEvent[] = [];
+    const actions: Action[] = [
+      txnAction("CREATE SCHEMA batch_commit"),
+      txnAction(
+        `CREATE TABLE batch_commit.t (
+          id int PRIMARY KEY,
+          parent int,
+          CONSTRAINT t_parent_fk FOREIGN KEY (parent)
+            REFERENCES batch_commit.t (id)
+            DEFERRABLE INITIALLY DEFERRED
+        )`,
+        { newSegmentBefore: true },
+      ),
+      txnAction("INSERT INTO batch_commit.t (id, parent) VALUES (1, 999)"),
+    ];
+
+    const { result, queries } = await withApplyQueries(db.pool, () =>
+      apply(planFromActions(actions), db.pool, {
+        fingerprintGate: false,
+        lockTableReserveConnections: 1,
+        batchTransactional: true,
+        onEvent: (event) => events.push(event),
+      }),
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatchObject({
+      actionIndex: 1,
+      statementKind: "control",
+      sql: "COMMIT",
+    });
+    expect(result.error?.message).toMatch(/t_parent_fk|foreign key/i);
+    expect(result.actionStatuses).toEqual(["applied", "inDoubt", "inDoubt"]);
+    expect(queries.some((sql) => sql.trim() === "COMMIT")).toBe(true);
+    expect(
+      queries.some((sql) => sql.includes("BEGIN") && sql.includes("COMMIT")),
+    ).toBe(false);
+    expect(
+      events.some(
+        (event) => event.kind === "control" && event.sql === "COMMIT",
+      ),
+    ).toBe(true);
+    expect(
+      events.some(
+        (event) => event.kind === "segmentEnd" && event.outcome === "inDoubt",
+      ),
+    ).toBe(true);
+
+    const tables = await db.pool.query<{ n: number }>(
+      `SELECT count(*)::int AS n
+       FROM pg_catalog.pg_class c
+       JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'batch_commit' AND c.relkind = 'r'`,
+    );
+    expect(tables.rows[0]?.n).toBe(0);
+  }, 120_000);
+});

--- a/packages/pg-delta/tests/apply-observer.test.ts
+++ b/packages/pg-delta/tests/apply-observer.test.ts
@@ -70,10 +70,7 @@ describe("apply() onEvent observer", () => {
         expect(e?.kind === "actionEnd" && e.ms).toBeGreaterThanOrEqual(0);
       }
 
-      // events interleave in the order apply() executes them: every
-      // actionStart[i] is followed by its actionEnd[i] BEFORE the next
-      // actionStart[i+1] begins — a refactor that batches starts or ends
-      // would break the trace's statement-by-statement story.
+      // default apply interleaves start/end per action.
       const startPositions: number[] = [];
       const endPositions: number[] = [];
       events.forEach((e, pos) => {
@@ -131,7 +128,6 @@ describe("apply() onEvent observer", () => {
       ).toBe(true);
       expect(controlEvents.some((e) => e.sql === "COMMIT")).toBe(true);
 
-      // ordering: BEGIN -> preamble SET -> first actionStart ... last actionEnd -> COMMIT -> segmentEnd
       const beginPos = events.findIndex(
         (e) => e.kind === "control" && e.sql === "BEGIN",
       );

--- a/packages/pg-delta/tests/apply-roundtrips.test.ts
+++ b/packages/pg-delta/tests/apply-roundtrips.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Apply must send each transactional segment as O(1) round trips (bounded
+ * multi-statement batches + a separate COMMIT), not one query per action.
+ * The lock-table preflight is one extra RTT on this branch.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { apply } from "../src/apply/apply.ts";
+import { createTestDb, type TestDb } from "./containers.ts";
+import {
+  planFromActions,
+  txnAction,
+  withApplyQueries,
+} from "./apply-test-helpers.ts";
+
+const ACTION_COUNT = 200;
+/** probe + one transactional batch + COMMIT (sub-batches stay well under 500). */
+const MAX_ROUND_TRIPS = 4;
+
+const dbs: TestDb[] = [];
+afterAll(async () => {
+  await Promise.all(dbs.map((d) => d.drop().catch(() => {})));
+});
+
+describe("apply() transactional round trips", () => {
+  test("a single-segment plan is O(segments), not O(actions)", async () => {
+    const db = await createTestDb("apply_roundtrips");
+    dbs.push(db);
+
+    const thePlan = planFromActions(
+      Array.from({ length: ACTION_COUNT }, (_, i) =>
+        txnAction(`SELECT ${String(i)}`),
+      ),
+    );
+
+    const { result, queries } = await withApplyQueries(db.pool, () =>
+      apply(thePlan, db.pool, {
+        fingerprintGate: false,
+        lockTimeoutMs: 5000,
+        lockTableReserveConnections: 1,
+        batchTransactional: true,
+      }),
+    );
+
+    expect(result.status).toBe("applied");
+    expect(result.appliedActions).toBe(ACTION_COUNT);
+    expect(queries.length).toBeLessThanOrEqual(MAX_ROUND_TRIPS);
+    expect(queries.length).toBeLessThan(ACTION_COUNT);
+    expect(
+      queries.some((sql) => sql.includes("BEGIN") && sql.includes("SELECT 0")),
+    ).toBe(true);
+    expect(queries.some((sql) => sql.trim() === "COMMIT")).toBe(true);
+  }, 120_000);
+
+  test("the default path still pays one query per action", async () => {
+    const db = await createTestDb("apply_roundtrips_default");
+    dbs.push(db);
+
+    const count = 20;
+    const thePlan = planFromActions(
+      Array.from({ length: count }, (_, i) => txnAction(`SELECT ${String(i)}`)),
+    );
+
+    const { result, queries } = await withApplyQueries(db.pool, () =>
+      apply(thePlan, db.pool, {
+        fingerprintGate: false,
+        lockTimeoutMs: 5000,
+        lockTableReserveConnections: 1,
+      }),
+    );
+
+    expect(result.status).toBe("applied");
+    expect(queries.length).toBeGreaterThan(count);
+    expect(
+      queries.filter((sql) => /^SELECT \d+$/.test(sql.trim())).length,
+    ).toBe(count);
+  }, 120_000);
+});

--- a/packages/pg-delta/tests/apply-roundtrips.test.ts
+++ b/packages/pg-delta/tests/apply-roundtrips.test.ts
@@ -1,7 +1,7 @@
 /**
  * Apply must send each transactional segment as O(1) round trips (bounded
  * multi-statement batches + a separate COMMIT), not one query per action.
- * The lock-table preflight is one extra RTT on this branch.
+ * Lock-table packing (`splitPlan`) happens before apply, not on this wire.
  */
 import { afterAll, describe, expect, test } from "bun:test";
 import { apply } from "../src/apply/apply.ts";
@@ -13,8 +13,8 @@ import {
 } from "./apply-test-helpers.ts";
 
 const ACTION_COUNT = 200;
-/** probe + one transactional batch + COMMIT (sub-batches stay well under 500). */
-const MAX_ROUND_TRIPS = 4;
+/** one transactional batch + COMMIT (sub-batches stay well under 500). */
+const MAX_ROUND_TRIPS = 3;
 
 const dbs: TestDb[] = [];
 afterAll(async () => {
@@ -36,7 +36,6 @@ describe("apply() transactional round trips", () => {
       apply(thePlan, db.pool, {
         fingerprintGate: false,
         lockTimeoutMs: 5000,
-        lockTableReserveConnections: 1,
         batchTransactional: true,
       }),
     );
@@ -64,7 +63,6 @@ describe("apply() transactional round trips", () => {
       apply(thePlan, db.pool, {
         fingerprintGate: false,
         lockTimeoutMs: 5000,
-        lockTableReserveConnections: 1,
       }),
     );
 

--- a/packages/pg-delta/tests/apply-test-helpers.ts
+++ b/packages/pg-delta/tests/apply-test-helpers.ts
@@ -16,22 +16,41 @@ export function queryText(first: unknown): string {
   return String(first);
 }
 
+function tapQueries(client: pg.PoolClient, queries: string[]): void {
+  const origQuery = client.query.bind(client) as (...a: unknown[]) => unknown;
+  (client as { query: unknown }).query = (...qa: unknown[]) => {
+    queries.push(queryText(qa[0]));
+    return origQuery(...qa);
+  };
+}
+
 export async function withApplyQueries<T>(
   pool: pg.Pool,
   fn: () => Promise<T>,
 ): Promise<{ result: T; queries: string[] }> {
   const queries: string[] = [];
   const origConnect = pool.connect.bind(pool);
-  (pool as { connect: unknown }).connect = async (...args: unknown[]) => {
-    const client = await (
-      origConnect as (...a: unknown[]) => Promise<pg.PoolClient>
-    )(...args);
-    const origQuery = client.query.bind(client) as (...a: unknown[]) => unknown;
-    (client as { query: unknown }).query = (...qa: unknown[]) => {
-      queries.push(queryText(qa[0]));
-      return origQuery(...qa);
-    };
-    return client;
+  (pool as { connect: unknown }).connect = (
+    callback?: (
+      error?: Error,
+      client?: pg.PoolClient,
+      release?: (releaseError?: Error | boolean) => void,
+    ) => void,
+  ) => {
+    if (typeof callback === "function") {
+      return origConnect((error, client, release) => {
+        if (error !== undefined || client === undefined) {
+          callback(error, client, release);
+          return;
+        }
+        tapQueries(client, queries);
+        callback(undefined, client, release);
+      });
+    }
+    return origConnect().then((client) => {
+      tapQueries(client, queries);
+      return client;
+    });
   };
   try {
     return { result: await fn(), queries };

--- a/packages/pg-delta/tests/apply-test-helpers.ts
+++ b/packages/pg-delta/tests/apply-test-helpers.ts
@@ -1,0 +1,78 @@
+/** Shared fixtures for apply integration tests that wrap the pool. */
+import type pg from "pg";
+import type { Action, Plan } from "../src/plan/plan.ts";
+import { ENGINE_VERSION, stampPlanId } from "../src/plan/plan.ts";
+
+export function queryText(first: unknown): string {
+  if (typeof first === "string") return first;
+  if (
+    first !== null &&
+    typeof first === "object" &&
+    "text" in first &&
+    typeof (first as { text: unknown }).text === "string"
+  ) {
+    return (first as { text: string }).text;
+  }
+  return String(first);
+}
+
+export async function withApplyQueries<T>(
+  pool: pg.Pool,
+  fn: () => Promise<T>,
+): Promise<{ result: T; queries: string[] }> {
+  const queries: string[] = [];
+  const origConnect = pool.connect.bind(pool);
+  (pool as { connect: unknown }).connect = async (...args: unknown[]) => {
+    const client = await (
+      origConnect as (...a: unknown[]) => Promise<pg.PoolClient>
+    )(...args);
+    const origQuery = client.query.bind(client) as (...a: unknown[]) => unknown;
+    (client as { query: unknown }).query = (...qa: unknown[]) => {
+      queries.push(queryText(qa[0]));
+      return origQuery(...qa);
+    };
+    return client;
+  };
+  try {
+    return { result: await fn(), queries };
+  } finally {
+    (pool as { connect: unknown }).connect = origConnect;
+  }
+}
+
+export function txnAction(sql: string, extra: Partial<Action> = {}): Action {
+  return {
+    sql,
+    verb: "create",
+    produces: [],
+    consumes: [],
+    destroys: [],
+    releases: [],
+    transactionality: "transactional",
+    lockClass: "none",
+    newSegmentBefore: false,
+    dataLoss: "none",
+    rewriteRisk: false,
+    ...extra,
+  } as Action;
+}
+
+export function planFromActions(actions: Action[]): Plan {
+  return stampPlanId({
+    formatVersion: 1,
+    engineVersion: ENGINE_VERSION,
+    source: { fingerprint: "a".repeat(64) },
+    target: { fingerprint: "b".repeat(64) },
+    preamble: [],
+    deltas: [],
+    filteredDeltas: [],
+    renameCandidates: [],
+    actions,
+    safetyReport: {
+      destructiveActions: 0,
+      rewriteRiskActions: 0,
+      nonTransactionalActions: 0,
+      lockClasses: {},
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Opt-in `batchTransactional` / `--batch-transactional` sends each transactional apply segment as bounded simple-protocol batches (`BEGIN` + preamble + actions) so high-latency links stop paying one RTT per action. **Default remains one query per statement** so we can fall back if batching mis-attributes a failure. `COMMIT` stays its own round trip (`inDoubt` = lost COMMIT only).
- Failure attribution prefers Postgres `POSITION` through join offsets (parse-time and multi-statement actions), otherwise CommandComplete count. The joiner puts `;` on its own line so a trailing `--` cannot swallow the next statement.
- Stacked on #462 because both rewrite `apply.ts` (lock-table probe + this executor).

## Linked issue

Linear CLI-2296
Refs #462

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Test plan

- [ ] `cd packages/pg-delta && bun test src/apply/apply.test.ts src/apply/batch-query.test.ts`
- [ ] `cd packages/pg-delta && bun test tests/apply-roundtrips.test.ts tests/apply-batch-failure.test.ts tests/apply-observer.test.ts`
- [ ] Confirm default apply still emits one query per action; `--batch-transactional` collapses a 200-action segment to O(1) RTTs plus `COMMIT`