### PR TITLE
fix(pg-delta): skip default-privilege rows on temp and system schemas (CLI-2379)

### DIFF
--- a/.changeset/adp-skip-temp-schema-rows.md
+++ b/.changeset/adp-skip-temp-schema-rows.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Skip default-privilege rows scoped to system or per-session temp schemas (`ALTER DEFAULT PRIVILEGES … IN SCHEMA pg_temp_N`) at extract time. Such a row keyed a `defaultPrivilege` fact on a schema that exists on no target and no plan produces, so planning against a database carrying one failed in `buildActionGraph` with `missing requirement: … consumes schema:pg_temp_N`.

--- a/packages/pg-delta/src/extract/roles.ts
+++ b/packages/pg-delta/src/extract/roles.ts
@@ -1,5 +1,5 @@
 /** Cluster-level role state: roles, role memberships, and default privileges. */
-import type { CatalogFamily } from "./scope.ts";
+import { type CatalogFamily, USER_SCHEMA_FILTER } from "./scope.ts";
 
 // ── roles (cluster-level) ────────────────────────────────────────────
 const ROLES_SQL = `
@@ -133,6 +133,11 @@ const DEFAULT_PRIVILEGES_SQL = `
           OR (d.defaclnamespace = 0 AND EXISTS (SELECT 1 FROM stored s2))
         )
     ) acl
+    -- A per-schema row is a satellite of its schema: keep only the GLOBAL rows
+    -- and those on schemas the schema family extracts. A row on a system or
+    -- per-backend temp schema (IN SCHEMA pg_temp_N, owned by a live session)
+    -- would key a fact on a schema no target has and no plan produces.
+    WHERE d.defaclnamespace = 0 OR (${USER_SCHEMA_FILTER})
     ORDER BY 1, 2, 3, 4`;
 
 export const rolesAndGrantsFamily: CatalogFamily = {

--- a/packages/pg-delta/tests/default-privileges-temp-schema.test.ts
+++ b/packages/pg-delta/tests/default-privileges-temp-schema.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression (CLI-2379): a default-privileges row scoped to a per-session
+ * temp schema (`ALTER DEFAULT PRIVILEGES … IN SCHEMA pg_temp_N`) must not be
+ * extracted. `pg_temp_N` is a backend-scoped catalog artifact — the schema
+ * family never emits it (USER_SCHEMA_FILTER), it exists on no target, and no
+ * plan can produce it — so a `defaultPrivilege` fact keyed on it can only ever
+ * surface as a `missing requirement` in buildActionGraph.
+ *
+ * The row is only visible while the backend that owns the temp namespace is
+ * alive (Postgres drops it with the namespace contents at backend exit), so the
+ * test pins a dedicated client for the duration of the extraction.
+ *
+ * Docker required.
+ */
+import { describe, expect, test } from "bun:test";
+import { extract } from "../src/extract/extract.ts";
+import { plan } from "../src/plan/plan.ts";
+import { createTestDb } from "./containers.ts";
+
+describe("default privileges — pg_temp-scoped rows", () => {
+  test("a live session's pg_temp_N default ACL is invisible to extract and plan", async () => {
+    const source = await createTestDb("dptemp_src");
+    const desired = await createTestDb("dptemp_dst");
+    const session = await desired.pool.connect();
+    try {
+      await desired.pool.query("CREATE ROLE dptemp_reader NOLOGIN");
+      // The temp namespace only materializes once the session creates a temp
+      // object; its name is per-backend, hence the dynamic lookup.
+      await session.query("CREATE TEMP TABLE dptemp_scratch(x int)");
+      await session.query(`
+        DO $$ BEGIN
+          EXECUTE format(
+            'ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT ON TABLES TO dptemp_reader',
+            (SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema()));
+        END $$`);
+      const probe = await desired.pool.query(
+        `SELECT n.nspname FROM pg_default_acl d
+         JOIN pg_namespace n ON n.oid = d.defaclnamespace
+         WHERE n.nspname LIKE 'pg\\_temp%'`,
+      );
+      expect(probe.rows).toHaveLength(1);
+
+      const from = await extract(source.pool);
+      const to = await extract(desired.pool);
+
+      const tempScoped = to.factBase
+        .facts()
+        .filter(
+          (f) =>
+            f.id.kind === "defaultPrivilege" &&
+            (f.id.schema ?? "").startsWith("pg_temp"),
+        );
+      expect(tempScoped).toEqual([]);
+
+      const planned = plan(from.factBase, to.factBase);
+      expect(planned.actions.map((a) => a.sql)).toEqual([]);
+    } finally {
+      session.release();
+      await source.drop();
+      await desired.drop();
+      await desired.cluster.adminPool
+        .query("DROP ROLE IF EXISTS dptemp_reader")
+        .catch(() => {});
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Diffing against a database that carries a per-session default-ACL row (`ALTER DEFAULT PRIVILEGES … IN SCHEMA pg_temp_N`) failed at plan time in `buildActionGraph`:

```text
missing requirement: action "ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "pg_temp_14" REVOKE ALL ON TABLES FROM "algolia_supabase_connector_…"" consumes schema:pg_temp_14, which neither exists on the target nor is produced by this plan
```

**Root cause.** The default-privilege query in `src/extract/roles.ts` read `pg_default_acl` without the schema scoping every other catalog family applies. The schema family excludes `pg_catalog`, `information_schema`, `pg_toast%` and `pg_temp%` via `USER_SCHEMA_FILTER`, so a row a live session left on its per-backend temp namespace became a `defaultPrivilege` fact keyed on a schema that is never extracted, never present on any target, and never produced by a plan.

**Fix.** Filter `pg_default_acl` rows with the same `USER_SCHEMA_FILTER`, keeping GLOBAL rows (`defaclnamespace = 0`). This is the extract-side option from the ticket; the planner is untouched, per the "Postgres is the only elaborator, no per-object-type planner patching" rule.

**Test.** `tests/default-privileges-temp-schema.test.ts`. Postgres drops the row with the temp namespace when the owning backend exits, so the test pins a dedicated client for the session instead of using a corpus scenario (a static `a.sql`/`b.sql` cannot express a session-scoped artifact). RED/GREEN is split across the two commits: the first adds the test alone and fails with the fact extracted, and with that assertion skipped `plan()` throws the exact message above (captured in the commit message).

## Linked issue

Linear: [CLI-2379](https://linear.app/supabase/issue/CLI-2379/fixpg-delta-pg-temp-default-acl-revoke-is-planned-as-a-missing)
Sentry: https://supabase.sentry.io/issues/7665828836/

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Verification

- New regression test + `default-privileges-owner-self-revoke.test.ts`: 4 pass (postgres:17-alpine)
- Unit suite: 1400 pass
- Full corpus, postgres:17-alpine: 666 pass, 0 fail
- `bun run format-and-lint:fix`, `bun run check-types`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
