### PR TITLE
fix(pg-delta): cascade policy exclusion to satellites of excluded relations

### DIFF
--- a/.changeset/exclusion-cascade-satellites.md
+++ b/.changeset/exclusion-cascade-satellites.md
@@ -1,0 +1,13 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Cascade policy exclusion to dependents of hard-pruned facts (reverse `depends` /
+extension membership / seclabel provider), so a user trigger on an excluded
+system table and TCE artefacts of excluded `pgsodium` leave the managed view
+with an `excluded-by-cascade` diagnostic instead of throwing or planning
+unreplayable CREATE/DROP (CLI-2300, CLI-2342). User-owned objects in assumed
+schemas are hard-pruned; platform-provisioned ones stay reference-only.
+Image-provisioned system extensions (`supabase_vault`, `pg_graphql`,
+`pg_stat_statements`) are assumed rather than hard-pruned, so a user view over
+their members still plans.

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -440,9 +440,10 @@ view with the same diagnostic instead of planning a CREATE that fails at
 apply.
 
 Reverse-depends is per catalog. If the same identity exists on both sides and
-only one definition depends on an excluded object, `plan()` stamps that id
-and strips it from **both** views (parent-chain only — not a second reverse-
-`depends` walk). The object is left as-is; apply/prove replay the id list from
+only one definition depends on an excluded object (policy hard-prune,
+`managedBy`, or capability), `plan()` stamps that id and strips it from
+**both** views (parent-chain only — not a second reverse-`depends` walk). The
+object is left as-is; apply/prove replay the id list from
 `Plan.cascadeAlignedIds` so fingerprints match a one-catalog reconstruct. An
 identity cascaded on only one side (new or dropped) is not stamped, so apply
 does not hide later same-id drift in the source fingerprint.

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -438,3 +438,11 @@ This is the principled fix for CLI-2178 (a user view over a suppressed
 wrappers foreign table): the view's `depends` edge now pulls it out of the
 view with the same diagnostic instead of planning a CREATE that fails at
 apply.
+
+Reverse-depends is per catalog. If the same identity exists on both sides and
+only one definition depends on an excluded object, `plan()` stamps that id
+and strips it from **both** views (parent-chain only — not a second reverse-
+`depends` walk). The object is left as-is; apply/prove replay the id list from
+`Plan.cascadeAlignedIds` so fingerprints match a one-catalog reconstruct. An
+identity cascaded on only one side (new or dropped) is not stamped, so apply
+does not hide later same-id drift in the source fingerprint.

--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -396,3 +396,45 @@ Platform event triggers (`issue_*` / `pgrst_*` / `graphql_watch_*`) are
 hard-excluded by name. They have no user-managed children (unlike
 publication membership), so reference-only would only add owner/comment
 noise.
+
+### Follow-up 4 — exclusion cascades to dependents (CLI-2300 / CLI-2342)
+
+`computeExclusion` removes a hard-prune root, its parent-chain descendants,
+**and** every fact with a `depends` or `memberOfExtension` edge into the
+removed set, plus `securityLabel` facts whose `provider` equals a removed
+extension's name (`pg_seclabel` has no `pg_depend` to the provider).
+
+Without that reverse walk, a policy that hides a table or extension left its
+non-child dependents in the view after the edge was pruned: a user trigger
+on `supabase_migrations.schema_migrations` threw missing-requirement against
+an empty branch (CLI-2300), and TCE artefacts of excluded `pgsodium`
+(`decrypted_*` views, encrypt triggers, column defaults, security labels)
+were planned as CREATE on a branch that never gets the extension, or as DROP
+against a live catalog (CLI-2342 / CLI-1024).
+
+Assumed-schema **reference-only** is restricted to:
+
+- the assumed schema / publication / extension objects themselves;
+- objects in those schemas owned by a policy `assumedRoles` entry other than
+  `defaultOwner` (platform-provisioned: `auth.users` owned by
+  `supabase_admin`);
+- extension members in assumed schemas (`uuid-ossp` in `extensions`).
+
+A user-owned excluded relation (`postgres`-owned `schema_migrations`) is
+hard-pruned so include-protected satellites cascade out. User triggers on
+platform tables still attach to a reference-only parent.
+
+`pgsodium` and `wrappers` stay hard-pruned: they are not present on a fresh
+branch / are dashboard-conditional, so dependents cascade out with an
+`excluded-by-cascade` info diagnostic. Image-provisioned
+`SUPABASE_SYSTEM_EXTENSIONS` entries (`pg_graphql`, `pg_stat_statements`,
+`supabase_vault`) are `assumedExtensions` — reference-only — so a user view
+over `vault.decrypted_secrets` still plans. The user table without pgsodium
+defaults remains managed. Genuine missing-requirement throws still fire —
+the filter hint names this cascade so a leftover consumer is diagnosed as a
+real missing producer, not an unhandled filter.
+
+This is the principled fix for CLI-2178 (a user view over a suppressed
+wrappers foreign table): the view's `depends` edge now pulls it out of the
+view with the same diagnostic instead of planning a CREATE that fails at
+apply.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1594,6 +1594,28 @@ target). Parked:
   (P2).** `splitPlan` can mark ADD VALUE when the running estimate plus
   that action exceeds `maxLocks`, but `segmentActions` closes after the
   boundary and never reads the mark. ADD VALUE stays with the preceding
-  run (typically ~2 extra slots). Order and the required COMMIT after
+  run (typically ~2 extra slots). Order and   the required COMMIT after
   ADD VALUE are unchanged. Honoring the mark is a `segmentActions`
   contract change, not a packer fix.
+
+## PR #472 review triage (Codex) — exclusion cascade
+
+PR #472 walks reverse `depends` / extension membership / seclabel provider
+so satellites of a hard-pruned object leave the managed view with an
+`excluded-by-cascade` diagnostic. In-PR: assumed-schema owner
+discriminator is skipped when the policy names no `assumedRoles` (custom
+profiles keep the previous all-reference-only behavior); `plan` keeps
+desired-side identities that the source already marked reference-only, so a
+shadow-seeded `auth.users` that re-extracts as `postgres` is not hard-pruned
+(`postgres` cannot `OWNER TO supabase_admin` at seed replay); `assumedExtensions`
+is included in the seed gate like `assumedPublications`. Parked:
+
+- **Deferred — cascade diagnostics on export / `diff` (P2).**
+  `excludedByCascadeDiagnostics` is attached from `plan()`. `schema
+  export` and database `diff` project through `resolveView` without
+  collecting suppressions, so a view over a hard-pruned wrappers /
+  pgsodium object is omitted with only extraction diagnostics. Pre-
+  existing: those frontends never surfaced projection-suppression
+  info. Threading suppressions through every projection-only path is
+  a frontend contract change, not required for the CLI-2300 / CLI-2342
+  plan/apply fix.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1619,3 +1619,42 @@ is included in the seed gate like `assumedPublications`. Parked:
   info. Threading suppressions through every projection-only path is
   a frontend contract change, not required for the CLI-2300 / CLI-2342
   plan/apply fix.
+- **Deferred — extension-only seed emptiness guard (P2, round 2).**
+  `assumedExtensions` now opens the seed gate and emits `CREATE
+  EXTENSION`, but `seed.schemas` still comes from non-member seed facts,
+  so an extension-only custom profile returns `[]` and `schema-plan.ts`
+  omits `seededSchemas`. A real `CREATE EXTENSION` that creates
+  relations can then fail `shadow database is not empty`. The supabase
+  profile always names `assumedSchemas` (`graphql`, `extensions`,
+  `vault`, …), so those install schemas are already exempt. Completing
+  this needs install/member schema names on the seed and a plan/load
+  e2e, not the unit pin that only asserts seed SQL.
+- **Deferred — `keepAssumedIds` vs a declared baseline (P2, round 2).**
+  `keepAssumedIds` reads `physicalSource.referenceOnly` after baseline
+  subtraction. A baseline-identical `auth.users` is therefore absent
+  from that set, and a shadow-seeded applier-owned copy can still be
+  hard-pruned. The supabase policy's baseline is intentionally UNSET
+  (`supabase.ts`); Phase 2b seed derivation already documents that
+  landing a snapshot must revisit this composition. Not reachable on
+  the current supabase / CLI-2300 path.
+- **Deferred — cascade diagnostics for skipped subobjects (P2, round 2).**
+  `CASCADE_DIAG_SKIP` / `isSatelliteId` hide column, default, constraint,
+  and satellite cascade info so a hard-pruned parent does not spam one
+  diagnostic per descendant. An independently cascaded default or
+  seclabel on a *kept* table is therefore silent. CLI-2342 still emits
+  diagnostics for the view / function / trigger TCE artefacts and omits
+  the default from the plan. Tightening the filter is observability
+  polish, not a plan/apply defect.
+- **Deferred — publication reverse-depends over-cascade (P1, round 2).**
+  Extract resolves `pg_publication_rel` deps onto the parent
+  `publication` id (`dependencies.ts` `pubrel` CTE) so the publication
+  shell inherits member edges; seed treats those as shell-inherited
+  because `CREATE PUBLICATION` without `FOR TABLE` needs none of them
+  (#370). The new reverse-depends walk would `take()` that whole
+  publication — and every `publicationRel` child — if any one member
+  table is hard-pruned. The assumed `supabase_realtime` path with only
+  managed memberships is unaffected. Mixed membership (a hard-pruned
+  wrappers / pgsodium / `schema_migrations` table plus managed tables
+  in the same publication) is unusual. Fixing it means re-attributing
+  those edges at `publicationRel` grain, which changes the seed shell
+  contract; not a special-case in `expandDependentClosure` for this PR.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1713,3 +1713,14 @@ planId. Parked:
   The unit pin reconstructs with the same `keepAssumedIds` + `alignedIds`
   recipe `provePlan` uses; it does not call `provePlan` (that path needs a
   pool). A fake-`reextract` prove test would catch the wiring being deleted.
+- **Deferred — source-fingerprint witness for cascade-aligned ids (P1, round 5).**
+  Alignment strips XOR reverse-depends victims from both reconstructed
+  views before `physicalSource` is hashed, and apply/prove replay that
+  strip so a one-catalog reconstruct matches. A later DROP/ALTER of that
+  leave-as-is object therefore does not trip the source gate. Witnessing
+  those identities while still suppressing their deltas needs a split
+  fingerprint (unstripped source hash, stripped diff) and a different
+  apply/prove recipe than the one-catalog reconstruct this PR landed.
+  Same class as any fact already reverse-depends-removed from source at
+  reconstruct time. Not required for CLI-2300 / CLI-2342 (don't
+  CREATE/DROP the still-existing object).

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1648,7 +1648,8 @@ shadow-seeded `auth.users` that re-extracts as `postgres` is not hard-pruned
 is included in the seed gate like `assumedPublications`. Round 3: reverse-depends
 cascade roots present on exactly one unaligned side (`Plan.cascadeAlignedIds`)
 so a definition change that only one side depends on an excluded object is not
-DROP/CREATE; apply/prove replay the list; `provePlan` reconstructs desired
+DROP/CREATE — including `managedBy` / capability reverse-depends, not only
+`policyScopeRule`; apply/prove replay the list; `provePlan` reconstructs desired
 with the clone's reference-only set; empty `cascadeAlignedIds` is omitted from
 planId. Parked:
 
@@ -1708,13 +1709,6 @@ planId. Parked:
   therefore emit `COMMENT ON EXTENSION`. Suppressing those satellites
   is a policy-filter / grain change, not required for CLI-2300 / CLI-2342
   cascade alignment.
-- **Deferred — `managedBy` / capability reverse-depends alignment (P2, round 3).**
-  `cascadeAlignedIdsFrom` keeps `policyScopeRule` + `EXCLUDED_BY_CASCADE_REASON`.
-  Pgmq/partman `managedBy` projection uses the same reverse-depends walk but
-  stage `managedBy`, so a user view over a queue table that only one side
-  still has can still plan CREATE/DROP. Expanding the stage filter is a
-  generic alignment generalization, not the pgsodium / schema_migrations
-  path this PR fixes.
 - **Deferred — `provePlan` e2e for `keepAssumedIds` (P2, round 3).**
   The unit pin reconstructs with the same `keepAssumedIds` + `alignedIds`
   recipe `provePlan` uses; it does not call `provePlan` (that path needs a

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -877,31 +877,12 @@ Two findings on the CLI-1470 fix. P1 was fixed in the PR; P2 is recorded here.
   "present on this target" from "assumed by name" and is the revisit path.
 
 - **Deferred (round 3, P1) — a kept user object over a suppressed wrapper
-  prerequisite plans SQL that fails at apply.** Tracked as CLI-2178 (pg-delta
-  1.0.0 stable release project). Reproduced (2026-08-11): a
-  `dsl_owner` view over a foreign table on a suppressed wrappers FDW plans
-  `CREATE VIEW public.paying_users AS SELECT … FROM stripe.customers` with no
-  prerequisite and no plan-time diagnostic — `excludeFactsAndDescendants`
-  prunes by parent descent only, and the view's `depends` edge drops with its
-  endpoint, so apply fails on any target lacking the dashboard integration.
-  Valid, but the gap is a PRE-EXISTING property of every policy suppression
-  of non-schema-keyed objects (an `supabase_admin`-owned FDW chain has the
-  identical behavior today); this PR widens its reach to the real Cloud
-  ownership rather than introducing it. The PR is still strictly net-positive:
-  before it, EVERY integration-bearing project planned unreplayable
-  `CREATE FOREIGN DATA WRAPPER` DDL; after it, only the dependent-view subset
-  still fails, and one step later. A principled fix is architecturally
-  significant and general, not wrappers-specific: either (a) reference-only
-  semantics for suppressed prerequisite chains + shadow-seed materialization
-  (the `auth.users`-trigger mechanism, but keyed on objects rather than
-  assumed schemas — needs seed-side support to materialize a foreign table
-  whose server/extension are also suppressed), or (b) a plan-time
-  "suppressed prerequisite" diagnostic: the projection-suppression collector
-  already records every suppressed fact with attribution, so `plan()` can
-  cross-check kept deltas' extraction-time edges against it and escalate
-  warning→fatal exactly when a delta touches a stranded consumer (the
-  `USER_MAPPING_UNREADABLE` precedent). Option (b) is the cheaper first step
-  and benefits every suppression rule, not just Rule 6c.
+  prerequisite plans SQL that fails at apply.** Tracked as CLI-2178. **Fixed
+  in the exclusion-cascade work (CLI-2300 / CLI-2342):** `computeExclusion`
+  now walks reverse `depends` edges, so a view over a suppressed foreign
+  table is projected out with an `excluded-by-cascade` diagnostic instead of
+  planning a CREATE that fails at apply. The wrappers-specific option (b)
+  "suppressed prerequisite" cross-check is no longer the first step.
 
 ## PR #403 review triage — the reserved `_custom/` folder
 

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -1645,7 +1645,12 @@ profiles keep the previous all-reference-only behavior); `plan` keeps
 desired-side identities that the source already marked reference-only, so a
 shadow-seeded `auth.users` that re-extracts as `postgres` is not hard-pruned
 (`postgres` cannot `OWNER TO supabase_admin` at seed replay); `assumedExtensions`
-is included in the seed gate like `assumedPublications`. Parked:
+is included in the seed gate like `assumedPublications`. Round 3: reverse-depends
+cascade roots present on exactly one unaligned side (`Plan.cascadeAlignedIds`)
+so a definition change that only one side depends on an excluded object is not
+DROP/CREATE; apply/prove replay the list; `provePlan` reconstructs desired
+with the clone's reference-only set; empty `cascadeAlignedIds` is omitted from
+planId. Parked:
 
 - **Deferred — cascade diagnostics on export / `diff` (P2).**
   `excludedByCascadeDiagnostics` is attached from `plan()`. `schema
@@ -1695,3 +1700,22 @@ is included in the seed gate like `assumedPublications`. Parked:
   in the same publication) is unusual. Fixing it means re-attributing
   those edges at `publicationRel` grain, which changes the seed shell
   contract; not a special-case in `expandDependentClosure` for this PR.
+- **Deferred — assumed-extension `COMMENT` children (P2, round 3).**
+  Moving `pg_graphql` / `pg_stat_statements` / `supabase_vault` to
+  `assumedExtensions` keeps the extension root reference-only, but
+  `comment` children still participate in the differ (Rule 10 matches
+  schema, not an extension target). Image-to-image comment drift can
+  therefore emit `COMMENT ON EXTENSION`. Suppressing those satellites
+  is a policy-filter / grain change, not required for CLI-2300 / CLI-2342
+  cascade alignment.
+- **Deferred — `managedBy` / capability reverse-depends alignment (P2, round 3).**
+  `cascadeAlignedIdsFrom` keeps `policyScopeRule` + `EXCLUDED_BY_CASCADE_REASON`.
+  Pgmq/partman `managedBy` projection uses the same reverse-depends walk but
+  stage `managedBy`, so a user view over a queue table that only one side
+  still has can still plan CREATE/DROP. Expanding the stage filter is a
+  generic alignment generalization, not the pgsodium / schema_migrations
+  path this PR fixes.
+- **Deferred — `provePlan` e2e for `keepAssumedIds` (P2, round 3).**
+  The unit pin reconstructs with the same `keepAssumedIds` + `alignedIds`
+  recipe `provePlan` uses; it does not call `provePlan` (that path needs a
+  pool). A fake-`reextract` prove test would catch the wiring being deleted.

--- a/packages/pg-delta/src/apply/apply.ts
+++ b/packages/pg-delta/src/apply/apply.ts
@@ -301,13 +301,18 @@ export async function apply(
                 }))
           ).factBase;
     // reconstruct the SAME managed-view-under-scope the plan fingerprinted
-    // (`reconstructManagedView` seals resolveView → scope; defaults cluster).
+    // (`reconstructManagedView` seals resolveView → scope → alignedIds;
+    // defaults cluster).
     const view = reconstructManagedView(raw, {
       policy: thePlan.policy,
       capability: thePlan.capability,
       baseline: options?.baseline,
       scope: thePlan.scope,
       defaultOwner: thePlan.defaultOwner,
+      alignedIds:
+        thePlan.cascadeAlignedIds !== undefined
+          ? new Set(thePlan.cascadeAlignedIds)
+          : undefined,
     });
     // KNOWN PITFALL (acknowledged, by design): the fingerprint folds the WHOLE
     // resolved view, INCLUDING `referenceOnly` assumed-schema facts (e.g.

--- a/packages/pg-delta/src/core/diagnostic.ts
+++ b/packages/pg-delta/src/core/diagnostic.ts
@@ -82,6 +82,11 @@ export const USER_MAPPING_UNREADABLE = "user-mapping-unreadable";
  *  without a cross-layer import. */
 export const VAULT_PRESENCE = "vault_presence";
 
+/** A fact was removed from the managed view because it depends on (or is a
+ *  child of) a policy-excluded object — not because a rule matched it
+ *  directly. Info: the plan proceeds without creating or dropping it. */
+export const EXCLUDED_BY_CASCADE = "excluded-by-cascade";
+
 /** Thrown by public API stubs for not-yet-implemented stages (stage 0). */
 export class NotImplementedError extends Error {
   constructor(feature: string) {

--- a/packages/pg-delta/src/frontends/schema-plan.ts
+++ b/packages/pg-delta/src/frontends/schema-plan.ts
@@ -551,11 +551,13 @@ export async function planSchemaFiles(
   if (options.seedAssumedSchemas === true) {
     const profileAssumedSchemas = flatProfile?.assumedSchemas ?? [];
     const profileAssumedPublications = flatProfile?.assumedPublications ?? [];
-    // gate on EITHER assumed kind: a profile assuming only publications still
-    // needs its shadow seeded (Codex review on #373)
+    const profileAssumedExtensions = flatProfile?.assumedExtensions ?? [];
+    // gate on any assumed kind: a profile assuming only publications or
+    // only extensions still needs its shadow seeded
     if (
       profileAssumedSchemas.length > 0 ||
-      profileAssumedPublications.length > 0
+      profileAssumedPublications.length > 0 ||
+      profileAssumedExtensions.length > 0
     ) {
       const seed = deriveAssumedSchemaSeed(targetResult.factBase, {
         ...(ctx.planOptions.policy ? { policy: ctx.planOptions.policy } : {}),
@@ -567,6 +569,7 @@ export async function planSchemaFiles(
           : {}),
         assumedSchemas: profileAssumedSchemas,
         assumedPublications: profileAssumedPublications,
+        assumedExtensions: profileAssumedExtensions,
         assumedRoles: [
           ...(flatProfile?.assumedRoles ?? []),
           ...assumedTargetRoles,

--- a/packages/pg-delta/src/frontends/seed-assumed-schemas.test.ts
+++ b/packages/pg-delta/src/frontends/seed-assumed-schemas.test.ts
@@ -597,4 +597,38 @@ describe("deriveAssumedSchemaSeed", () => {
     expect(seed.sql).not.toMatch(/ADD TABLE|FOR TABLE/i);
     expect(seed.facts).toBe(1);
   });
+
+  test("a profile assuming ONLY extensions still seeds CREATE EXTENSION", () => {
+    const extOnlyPolicy: Policy = {
+      id: "test-ext-only",
+      filter: [
+        {
+          match: { all: [{ kind: "extension" }, { name: "platform_ext" }] },
+          action: "exclude",
+        },
+      ],
+      assumedExtensions: ["platform_ext"],
+    };
+    const platformExt: StableId = { kind: "extension", name: "platform_ext" };
+    const target = buildFactBase(
+      [
+        f(schemaPublic),
+        f(platformExt, {
+          schema: "public",
+          version: "1.0",
+          _relocatable: false,
+        }),
+      ],
+      [],
+    );
+    const seed = deriveAssumedSchemaSeed(target, {
+      policy: extOnlyPolicy,
+      assumedSchemas: [],
+      assumedRoles: [],
+      assumedExtensions: ["platform_ext"],
+    });
+    expect(seed.sql).toMatch(/CREATE EXTENSION/i);
+    expect(seed.sql).toContain("platform_ext");
+    expect(seed.facts).toBe(1);
+  });
 });

--- a/packages/pg-delta/src/frontends/seed-assumed-schemas.ts
+++ b/packages/pg-delta/src/frontends/seed-assumed-schemas.ts
@@ -145,6 +145,10 @@ export function deriveAssumedSchemaSeed(
      *  profile assuming ONLY publications would short-circuit on the empty
      *  assumedSchemas and silently derive no seed (Codex review on #373). */
     assumedPublications?: string[];
+    /** Policy assumed extensions (e.g. `supabase_vault`). Same gate as
+     *  publications: a profile that assumes only extensions still needs the
+     *  empty shadow to `CREATE EXTENSION` so user SQL can reference members. */
+    assumedExtensions?: string[];
     /** Policy assumed roles PLUS the target's own role names — same cluster, so
      *  every owner/grant role reference in the seed is present at replay. */
     assumedRoles: string[];
@@ -163,7 +167,8 @@ export function deriveAssumedSchemaSeed(
   // platform-external, no seed.
   if (
     opts.assumedSchemas.length === 0 &&
-    (opts.assumedPublications ?? []).length === 0
+    (opts.assumedPublications ?? []).length === 0 &&
+    (opts.assumedExtensions ?? []).length === 0
   ) {
     return EMPTY;
   }

--- a/packages/pg-delta/src/plan/artifact.test.ts
+++ b/packages/pg-delta/src/plan/artifact.test.ts
@@ -1,6 +1,7 @@
 /** Plan artifact v1: lossless round-trip + version refusals (stage 6). */
 import { describe, expect, test } from "bun:test";
 import { buildFactBase } from "../core/fact.ts";
+import { contentHash, type Payload } from "../core/hash.ts";
 import {
   parsePlan,
   serializePlan,
@@ -130,6 +131,63 @@ describe("plan artifact v1", () => {
     expect(
       parsePlan(serializePlan(samplePlan)).projectionAudit,
     ).toBeUndefined();
+  });
+
+  test("round-trips cascadeAlignedIds and hashes them into planId", () => {
+    const withAligned: Plan = stampPlanId({
+      ...samplePlan,
+      cascadeAlignedIds: ["view:public.v"],
+    });
+    expect(parsePlan(serializePlan(withAligned)).cascadeAlignedIds).toEqual([
+      "view:public.v",
+    ]);
+    expect(withAligned.planId).not.toBe(samplePlan.planId);
+  });
+
+  test("absent cascadeAlignedIds is omitted from planId, not hashed as []", () => {
+    const hashedAsEmpty = contentHash({
+      formatVersion: samplePlan.formatVersion,
+      engineVersion: samplePlan.engineVersion,
+      source: { fingerprint: samplePlan.source.fingerprint },
+      target: { fingerprint: samplePlan.target.fingerprint },
+      preamble: samplePlan.preamble.map((entry) => ({
+        name: entry.name,
+        value: entry.value,
+      })),
+      acceptedRenames: samplePlan.acceptedRenames ?? [],
+      cascadeAlignedIds: [],
+      actions: samplePlan.actions.map((action) => ({
+        sql: action.sql,
+        verb: action.verb,
+        produces: action.produces,
+        consumes: action.consumes,
+        destroys: action.destroys,
+        releases: action.releases,
+        transactionality: action.transactionality,
+        lockClass: action.lockClass,
+        newSegmentBefore: action.newSegmentBefore,
+        dataLoss: action.dataLoss,
+        rewriteRisk: action.rewriteRisk,
+      })),
+      profile: samplePlan.profile,
+      scope: samplePlan.scope,
+      policy: samplePlan.policy as Payload | undefined,
+    });
+    expect(computePlanId(samplePlan)).not.toBe(hashedAsEmpty);
+    expect(stampPlanId({ ...samplePlan, cascadeAlignedIds: [] }).planId).toBe(
+      computePlanId(samplePlan),
+    );
+  });
+
+  test("rejects a non-string cascadeAlignedIds list", () => {
+    const artifact = JSON.parse(serializePlan(samplePlan)) as Record<
+      string,
+      unknown
+    >;
+    artifact["cascadeAlignedIds"] = [1];
+    expect(() => parsePlan(JSON.stringify(artifact))).toThrow(
+      /cascadeAlignedIds/,
+    );
   });
 
   test("round-trips an opaque PostgreSQL source-lineage stamp", () => {

--- a/packages/pg-delta/src/plan/artifact.ts
+++ b/packages/pg-delta/src/plan/artifact.ts
@@ -257,8 +257,10 @@ function reviver(_key: string, value: unknown): unknown {
  * includes `planId` itself. `undefined` profile/scope/policy (direct
  * library / cluster-default) are omitted by canonicalize, not replaced
  * with invented strings. Absent `acceptedRenames` hashes as `[]`.
- * The preamble is hashed because apply executes it per segment — it is
- * run content, exactly like the action list, not reporting metadata.
+ * Absent or empty `cascadeAlignedIds` is omitted so same-engine artifacts
+ * without the field keep their planId. The preamble is hashed because apply
+ * executes it per segment — it is run content, exactly like the action
+ * list, not reporting metadata.
  */
 export function computePlanId(plan: Omit<Plan, "planId">): string {
   const payload: Payload = {
@@ -271,6 +273,10 @@ export function computePlanId(plan: Omit<Plan, "planId">): string {
       value: entry.value,
     })),
     acceptedRenames: plan.acceptedRenames ?? [],
+    cascadeAlignedIds:
+      plan.cascadeAlignedIds !== undefined && plan.cascadeAlignedIds.length > 0
+        ? plan.cascadeAlignedIds
+        : undefined,
     actions: plan.actions.map((action) => ({
       sql: action.sql,
       verb: action.verb,
@@ -354,6 +360,16 @@ export function parsePlan(json: string): Plan {
       exactKeys(rename, ["from", "to"], [], `acceptedRenames[${index}]`);
       assertStableId(rename["from"], `acceptedRenames[${index}].from`);
       assertStableId(rename["to"], `acceptedRenames[${index}].to`);
+    });
+  }
+  if (artifact.cascadeAlignedIds !== undefined) {
+    if (!Array.isArray(artifact.cascadeAlignedIds)) {
+      fail("cascadeAlignedIds", "an array of encoded ids");
+    }
+    artifact.cascadeAlignedIds.forEach((id, index) => {
+      if (typeof id !== "string" || id.length === 0) {
+        fail(`cascadeAlignedIds[${index}]`, "a non-empty string");
+      }
     });
   }
   if (!record(artifact.source) || !record(artifact.target)) {

--- a/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
+++ b/packages/pg-delta/src/plan/assumed-schema-requirement.test.ts
@@ -17,13 +17,14 @@
  *    computed by plan() from the raw owner edges) → ambient, satisfied even when
  *    kept in `desired` and absent from `source` (e.g. Supabase's
  *    `supabase_functions.http_request()`, Sentry SUPABASE-API-8CX);
- *  - otherwise kept in `desired` (reference-only) but absent from `source` → the
- *    desired side wants something the target lacks and nothing will provision →
- *    NOT exempt → throws.
+ *  - otherwise a user-owned object in an assumed schema is hard-pruned and
+ *    its dependents cascade out of the view (CLI-2300) instead of remaining
+ *    as a kept consumer that throws missing-requirement.
  */
 import { describe, expect, test } from "bun:test";
+import { EXCLUDED_BY_CASCADE } from "../core/diagnostic.ts";
 import { buildFactBase, type Fact } from "../core/fact.ts";
-import type { StableId } from "../core/stable-id.ts";
+import { encodeId, type StableId } from "../core/stable-id.ts";
 import { supabasePolicy } from "../policy/supabase.ts";
 import { buildActionGraph } from "./internal.ts";
 import { type Action, plan } from "./plan.ts";
@@ -193,23 +194,37 @@ describe("plan() — platform-provisioned members of assumed schemas", () => {
     ).toBe(false);
   });
 
-  test("the fail-fast is preserved when the assumed-schema dependency is owned by the default owner", () => {
-    // A default-owner-owned (i.e. user-created) object in an assumed schema
-    // absent from the target still fails at plan time (PR #307 review P2) —
-    // nothing will provision it at apply time.
-    expect(() =>
-      plan(sourceBase(), desiredBase("postgres"), {
-        policy: supabasePolicy,
-      }),
-    ).toThrow(/missing requirement/);
+  test("a user-owned assumed-schema dependency cascades the consumer out instead of throwing", () => {
+    // postgres-owned (default owner) object in an assumed schema is user-
+    // created, not platform-provisioned — hard-pruned, and the public trigger
+    // that depends on it is skipped with a cascade diagnostic.
+    const p = plan(sourceBase(), desiredBase("postgres"), {
+      policy: supabasePolicy,
+    });
+    expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(false);
+    expect(
+      p.diagnostics?.some(
+        (d) =>
+          d.code === EXCLUDED_BY_CASCADE &&
+          d.subject !== undefined &&
+          encodeId(d.subject) === encodeId(trigger),
+      ),
+    ).toBe(true);
   });
 
-  test("the fail-fast is preserved when the assumed-schema dependency is owned by a user role", () => {
-    expect(() =>
-      plan(sourceBase(), desiredBase("app_admin"), {
-        policy: supabasePolicy,
-      }),
-    ).toThrow(/missing requirement/);
+  test("a user-role-owned assumed-schema dependency also cascades the consumer", () => {
+    const p = plan(sourceBase(), desiredBase("app_admin"), {
+      policy: supabasePolicy,
+    });
+    expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(false);
+    expect(
+      p.diagnostics?.some(
+        (d) =>
+          d.code === EXCLUDED_BY_CASCADE &&
+          d.subject !== undefined &&
+          encodeId(d.subject) === encodeId(trigger),
+      ),
+    ).toBe(true);
   });
 
   test("a custom options.defaultOwner does not turn default-owner-owned objects into platform ones", () => {
@@ -217,14 +232,14 @@ describe("plan() — platform-provisioned members of assumed schemas", () => {
     // The PROVENANCE judgment must stay the policy's own: `postgres` is the
     // supabase policy's declared default owner, so a postgres-owned object in
     // an assumed schema is user-created no matter what the run-level default
-    // owner is — nothing will provision it (Codex P1 #2 on PR #407).
-    expect(() =>
-      plan(sourceBase(), desiredBase("postgres"), {
-        policy: supabasePolicy,
-        scope: "database",
-        defaultOwner: "custom_owner",
-      }),
-    ).toThrow(/missing requirement/);
+    // owner is — dependents cascade out rather than planning a CREATE against
+    // a function nothing will provision.
+    const p = plan(sourceBase(), desiredBase("postgres"), {
+      policy: supabasePolicy,
+      scope: "database",
+      defaultOwner: "custom_owner",
+    });
+    expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(false);
   });
 
   test("the exemption covers descendants of a platform-provisioned object", () => {
@@ -314,13 +329,12 @@ describe("plan() — platform-provisioned members of assumed schemas", () => {
     // target through options.assumedRoles (schema-plan.ts) so grants/ownership
     // against filtered role objects resolve. That supplemental set must not
     // feed the platform-provisioned discriminator: an assumed-schema object
-    // owned by a pre-existing USER role is still user-created, and nothing
-    // will provision it on the target (Codex P1 on PR #407).
-    expect(() =>
-      plan(sourceBase(), desiredBase("app_admin"), {
-        policy: supabasePolicy,
-        assumedRoles: ["app_admin"],
-      }),
-    ).toThrow(/missing requirement/);
+    // owned by a pre-existing USER role is still user-created, so dependents
+    // cascade out rather than treating the function as ambient.
+    const p = plan(sourceBase(), desiredBase("app_admin"), {
+      policy: supabasePolicy,
+      assumedRoles: ["app_admin"],
+    });
+    expect(p.actions.some((a) => /CREATE TRIGGER/i.test(a.sql))).toBe(false);
   });
 });

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -27,6 +27,8 @@ import { defaultRulesForId, type FoldHint, type RulesForId } from "./rules.ts";
 import { renderGrantSql } from "./rules/helpers.ts";
 import { schemaCreateSql } from "./rules/schemas.ts";
 
+const FILTER_HIDDEN_HINT =
+  " — a filter may be hiding its creation (dependents of excluded facts are cascaded out of the view; this throw means a genuine missing producer)";
 const ROUTINE_KIND_SET = new Set<string>(ROUTINE_KINDS);
 const EVALUATED_KIND_SET = new Set<string>(EVALUATED_EXPRESSION_KINDS);
 /** parent kind -> child kinds the evaluator reachability walk descends into. */
@@ -76,10 +78,11 @@ export function buildActionGraph(
   // e.g. Supabase's `supabase_functions.http_request()` (the DB-webhook trigger
   // function, owned by `supabase_functions_admin`). The platform guarantee that
   // makes their schema assumed extends to them, so a kept dependent (a user
-  // webhook trigger) is valid even when the target lacks the object — unlike a
-  // USER-created object in an assumed schema, which stays a plan-time failure
-  // (see `isAmbient`). Computed by plan() (plan.ts); affects ONLY whether the
-  // missing-requirement guard fires, never ordering/edges.
+  // webhook trigger) is valid even when the target lacks the object. A
+  // USER-created object in an assumed schema is hard-pruned and its dependents
+  // cascade out of the view (see `isAmbient` for leftover consumers). Computed
+  // by plan() (plan.ts); affects ONLY whether the missing-requirement guard
+  // fires, never ordering/edges.
   assumedPresentIds: ReadonlySet<string> = new Set(),
   // OUT-param (optional): collects the indices of EVALUATOR actions — actions
   // that make PostgreSQL RUN a user expression while the statement applies.
@@ -346,7 +349,7 @@ export function buildActionGraph(
         !memberExtensionPresent(key)
       ) {
         throw new Error(
-          `missing requirement: action "${action.sql}" consumes ${key}, which neither exists on the target nor is produced by this plan${desired.has(id) ? " — a filter may be hiding its creation" : ""}`,
+          `missing requirement: action "${action.sql}" consumes ${key}, which neither exists on the target nor is produced by this plan${desired.has(id) ? FILTER_HIDDEN_HINT : ""}`,
         );
       }
     }
@@ -465,7 +468,7 @@ export function buildActionGraph(
             throw new Error(
               `missing requirement: action "${action.sql}" produces ${encodeId(id)}, ` +
                 `which depends on ${targetKey} — neither produced by this plan nor ` +
-                `present on the target${desired.has(edge.to) ? " (a filter may be hiding its creation)" : ""}`,
+                `present on the target${desired.has(edge.to) ? FILTER_HIDDEN_HINT : ""}`,
             );
           }
         }

--- a/packages/pg-delta/src/plan/phases/change-set.ts
+++ b/packages/pg-delta/src/plan/phases/change-set.ts
@@ -9,12 +9,14 @@
  */
 import { diff, type Delta } from "../../core/diff.ts";
 import type { Fact, FactBase } from "../../core/fact.ts";
-import { encodeId, type StableId } from "../../core/stable-id.ts";
+import { encodeId, parseId, type StableId } from "../../core/stable-id.ts";
 import { filterDeltas, validatePolicy } from "../../policy/policy.ts";
 import {
+  cascadeAlignedIdsFrom,
   reconstructManagedView,
   type TracedSuppression,
 } from "../../policy/reconstruct.ts";
+import { excludeIdentitiesAndChildren } from "../../policy/view.ts";
 import {
   buildRoleRenameMap,
   normalizeRoleIdentities,
@@ -64,6 +66,9 @@ export interface ChangeSet {
    * come first, matching the reconstruction order `auditManagedViewProjection`
    * uses standalone. */
   projectionSuppressions: TracedSuppression[];
+  /** Reverse-depends cascade roots present on exactly one unaligned side
+   *  (encoded). Empty when nothing was cascade-aligned. */
+  cascadeAlignedIds: string[];
 }
 
 function groupDeltas(deltas: readonly Delta[]): {
@@ -148,7 +153,7 @@ export function buildChangeSet(
   // both sides again for the projection audit): collecting is purely
   // observational — it never changes the FactBase a reconstruction returns.
   const projectionSuppressions: TracedSuppression[] = [];
-  const physicalSource = reconstructManagedView(rawSource, {
+  const physicalSourceRaw = reconstructManagedView(rawSource, {
     policy: options?.policy,
     capability: options?.capability,
     baseline: options?.baseline,
@@ -157,16 +162,31 @@ export function buildChangeSet(
     collectSuppression: (suppression) =>
       projectionSuppressions.push({ side: "source", suppression }),
   });
-  const physicalDesired = reconstructManagedView(rawDesired, {
+  const physicalDesiredRaw = reconstructManagedView(rawDesired, {
     policy: options?.policy,
     capability: options?.capability,
     baseline: options?.baseline,
     scope: options?.scope,
     defaultOwner: options?.defaultOwner,
-    keepAssumedIds: physicalSource.referenceOnly,
+    keepAssumedIds: physicalSourceRaw.referenceOnly,
     collectSuppression: (suppression) =>
       projectionSuppressions.push({ side: "desired", suppression }),
   });
+  const cascadeAlignedIds = [...cascadeAlignedIdsFrom(projectionSuppressions)]
+    .filter((id) => {
+      const sid = parseId(id);
+      return physicalSourceRaw.has(sid) !== physicalDesiredRaw.has(sid);
+    })
+    .sort();
+  const alignedSet = new Set(cascadeAlignedIds);
+  const physicalSource = excludeIdentitiesAndChildren(
+    physicalSourceRaw,
+    alignedSet,
+  );
+  const physicalDesired = excludeIdentitiesAndChildren(
+    physicalDesiredRaw,
+    alignedSet,
+  );
 
   const renameMode: RenameMode = options?.renames ?? "off";
   const renameCandidates: RenameCandidate[] = [];
@@ -293,5 +313,6 @@ export function buildChangeSet(
     renameCandidates,
     acceptedRenames,
     projectionSuppressions,
+    cascadeAlignedIds,
   };
 }

--- a/packages/pg-delta/src/plan/phases/change-set.ts
+++ b/packages/pg-delta/src/plan/phases/change-set.ts
@@ -163,6 +163,7 @@ export function buildChangeSet(
     baseline: options?.baseline,
     scope: options?.scope,
     defaultOwner: options?.defaultOwner,
+    keepAssumedIds: physicalSource.referenceOnly,
     collectSuppression: (suppression) =>
       projectionSuppressions.push({ side: "desired", suppression }),
   });

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -15,6 +15,7 @@ import { flattenPolicy, type Policy } from "../policy/policy.ts";
 import type { ApplierCapability } from "../policy/capability.ts";
 import {
   projectionAuditFrom,
+  excludedByCascadeDiagnostics,
   type ProjectionAudit,
 } from "../policy/reconstruct.ts";
 import type { ManagementScope } from "../policy/view.ts";
@@ -754,6 +755,8 @@ export function plan(
   });
 
   const vaultDiags = vaultPresenceDiagnostics(desired, finalActions);
+  const cascadeDiags = excludedByCascadeDiagnostics(projectionSuppressions);
+  const diagnostics = [...vaultDiags, ...cascadeDiags];
 
   return stampPlanId({
     formatVersion: 1,
@@ -817,6 +820,6 @@ export function plan(
     // CREATE/DROP EXTENSION supabase_vault is generic; the warning is that
     // secret values/keys are not schema state. Omitted when empty so corpus
     // artifacts stay byte-identical. Not hashed into planId.
-    ...(vaultDiags.length > 0 ? { diagnostics: vaultDiags } : {}),
+    ...(diagnostics.length > 0 ? { diagnostics } : {}),
   });
 }

--- a/packages/pg-delta/src/plan/plan.ts
+++ b/packages/pg-delta/src/plan/plan.ts
@@ -203,6 +203,12 @@ export interface Plan {
    *  Omitted when empty so corpus / direct-library artifacts stay byte-identical.
    *  Not part of planId — reporting metadata, not approved run content. */
   diagnostics?: Diagnostic[];
+  /** Encoded identities reverse-depends cascade removed on exactly one
+   *  unaligned side. Stripped from both managed views (parent-chain only) so
+   *  a one-sided dependency skip is not a DROP/CREATE. Omitted when empty.
+   *  Hashed into planId only when non-empty; apply/prove replay this list on
+   *  one-catalog reconstructs. */
+  cascadeAlignedIds?: string[];
 }
 
 export interface PlanOptions {
@@ -405,6 +411,7 @@ export function plan(
     renameCandidates,
     acceptedRenames,
     projectionSuppressions,
+    cascadeAlignedIds,
   } = buildChangeSet(rawSource, rawDesired, options, rulesForId);
 
   // The change set already reconstructed BOTH managed views under exactly these
@@ -821,5 +828,6 @@ export function plan(
     // secret values/keys are not schema state. Omitted when empty so corpus
     // artifacts stay byte-identical. Not hashed into planId.
     ...(diagnostics.length > 0 ? { diagnostics } : {}),
+    ...(cascadeAlignedIds.length > 0 ? { cascadeAlignedIds } : {}),
   });
 }

--- a/packages/pg-delta/src/policy/exclusion-cascade.test.ts
+++ b/packages/pg-delta/src/policy/exclusion-cascade.test.ts
@@ -142,6 +142,50 @@ describe("CLI-2300 — user trigger on an excluded user-owned system table", () 
     const p = plan(source, desiredAuth, { policy: supabasePolicy });
     expect(mentions(sqlOf(p), /CREATE TRIGGER/i)).toBe(true);
   });
+
+  test("a shadow-seeded postgres-owned copy of a live platform table still accepts a user trigger", () => {
+    const admin: StableId = { kind: "role", name: "supabase_admin" };
+    const postgres: StableId = { kind: "role", name: "postgres" };
+    const authSchema: StableId = { kind: "schema", name: "auth" };
+    const users: StableId = { kind: "table", schema: "auth", name: "users" };
+    const authTrigger: StableId = {
+      kind: "trigger",
+      schema: "auth",
+      table: "users",
+      name: "on_auth_user_created",
+    };
+    const live = buildFactBase(
+      [
+        f(admin),
+        f(authSchema),
+        f(users, authSchema, { persistence: "p" }),
+        f(publicSchema),
+      ],
+      [{ from: users, to: admin, kind: "owner" }],
+    );
+    const shadow = buildFactBase(
+      [
+        f(postgres),
+        f(authSchema),
+        f(users, authSchema, { persistence: "p" }),
+        f(publicSchema),
+        f(fn, publicSchema, {
+          def: "CREATE FUNCTION public.on_mig() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+          kind: "f",
+        }),
+        f(authTrigger, users, {
+          def: "CREATE TRIGGER on_auth_user_created AFTER INSERT ON auth.users FOR EACH ROW EXECUTE FUNCTION public.on_mig()",
+          enabled: "O",
+        }),
+      ],
+      [
+        { from: users, to: postgres, kind: "owner" },
+        { from: authTrigger, to: fn, kind: "depends" },
+      ],
+    );
+    const p = plan(live, shadow, { policy: supabasePolicy });
+    expect(mentions(sqlOf(p), /CREATE TRIGGER/i)).toBe(true);
+  });
 });
 
 describe("CLI-2342 — dependents of an excluded platform extension", () => {

--- a/packages/pg-delta/src/policy/exclusion-cascade.test.ts
+++ b/packages/pg-delta/src/policy/exclusion-cascade.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Policy exclusion must close over dependents (CLI-2300 / CLI-2342).
+ *
+ * Parent-chain cascade already removes children of a hard-pruned root.
+ * Dependents that are not children — a user trigger on a hard-pruned
+ * user-owned system table, a public view whose `depends` edge pointed at
+ * an excluded extension — used to stay managed after that edge was pruned.
+ */
+import { describe, expect, test } from "bun:test";
+import { EXCLUDED_BY_CASCADE } from "../core/diagnostic.ts";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import { encodeId, type StableId } from "../core/stable-id.ts";
+import { plan } from "../plan/plan.ts";
+import { supabasePolicy } from "./supabase.ts";
+
+const f = (
+  id: StableId,
+  parent?: StableId,
+  payload: Fact["payload"] = {},
+): Fact => (parent ? { id, parent, payload } : { id, payload });
+
+const sqlOf = (p: ReturnType<typeof plan>): string[] =>
+  p.actions.map((a) => a.sql);
+
+const mentions = (sql: string[], re: RegExp): boolean =>
+  sql.some((s) => re.test(s));
+
+describe("CLI-2300 — user trigger on an excluded user-owned system table", () => {
+  const postgres: StableId = { kind: "role", name: "postgres" };
+  const publicSchema: StableId = { kind: "schema", name: "public" };
+  const migSchema: StableId = { kind: "schema", name: "supabase_migrations" };
+  const migTable: StableId = {
+    kind: "table",
+    schema: "supabase_migrations",
+    name: "schema_migrations",
+  };
+  const fn: StableId = {
+    kind: "function",
+    schema: "public",
+    name: "on_mig",
+    args: [],
+  };
+  const trigger: StableId = {
+    kind: "trigger",
+    schema: "supabase_migrations",
+    table: "schema_migrations",
+    name: "block_writes",
+  };
+  const rls: StableId = {
+    kind: "policy",
+    schema: "supabase_migrations",
+    table: "schema_migrations",
+    name: "no_anon",
+  };
+
+  const triggerDef =
+    "CREATE TRIGGER block_writes BEFORE INSERT ON supabase_migrations.schema_migrations FOR EACH ROW EXECUTE FUNCTION public.on_mig()";
+
+  function desired(): ReturnType<typeof buildFactBase> {
+    return buildFactBase(
+      [
+        f(postgres),
+        f(publicSchema),
+        f(migSchema),
+        f(migTable, migSchema, { persistence: "p" }),
+        f(fn, publicSchema, {
+          def: "CREATE FUNCTION public.on_mig() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+          kind: "f",
+        }),
+        f(trigger, migTable, { def: triggerDef, enabled: "O" }),
+        f(rls, migTable, {
+          cmd: "a",
+          permissive: true,
+          usingExpr: null,
+          checkExpr: "false",
+          roles: ["anon"],
+        }),
+        f({ kind: "role", name: "anon" }),
+      ],
+      [
+        { from: migTable, to: postgres, kind: "owner" },
+        { from: trigger, to: fn, kind: "depends" },
+      ],
+    );
+  }
+
+  test("planning against an empty target does not throw; the trigger is skipped", () => {
+    const empty = buildFactBase([], []);
+    const p = plan(empty, desired(), { policy: supabasePolicy });
+    expect(mentions(sqlOf(p), /CREATE TRIGGER/i)).toBe(false);
+    expect(mentions(sqlOf(p), /CREATE POLICY/i)).toBe(false);
+    expect(mentions(sqlOf(p), /schema_migrations/i)).toBe(false);
+    expect(
+      p.diagnostics?.some(
+        (d) =>
+          d.code === EXCLUDED_BY_CASCADE &&
+          d.subject !== undefined &&
+          encodeId(d.subject) === encodeId(trigger),
+      ),
+    ).toBe(true);
+  });
+
+  test("a user trigger on a platform-owned assumed-schema table still plans", () => {
+    const admin: StableId = { kind: "role", name: "supabase_admin" };
+    const authSchema: StableId = { kind: "schema", name: "auth" };
+    const users: StableId = { kind: "table", schema: "auth", name: "users" };
+    const authTrigger: StableId = {
+      kind: "trigger",
+      schema: "auth",
+      table: "users",
+      name: "on_auth_user_created",
+    };
+    const source = buildFactBase(
+      [
+        f(admin),
+        f(authSchema),
+        f(users, authSchema, { persistence: "p" }),
+        f(publicSchema),
+      ],
+      [{ from: users, to: admin, kind: "owner" }],
+    );
+    const desiredAuth = buildFactBase(
+      [
+        f(admin),
+        f(authSchema),
+        f(users, authSchema, { persistence: "p" }),
+        f(publicSchema),
+        f(fn, publicSchema, {
+          def: "CREATE FUNCTION public.on_mig() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+          kind: "f",
+        }),
+        f(authTrigger, users, {
+          def: "CREATE TRIGGER on_auth_user_created AFTER INSERT ON auth.users FOR EACH ROW EXECUTE FUNCTION public.on_mig()",
+          enabled: "O",
+        }),
+      ],
+      [
+        { from: users, to: admin, kind: "owner" },
+        { from: authTrigger, to: fn, kind: "depends" },
+      ],
+    );
+    const p = plan(source, desiredAuth, { policy: supabasePolicy });
+    expect(mentions(sqlOf(p), /CREATE TRIGGER/i)).toBe(true);
+  });
+});
+
+describe("CLI-2342 — dependents of an excluded platform extension", () => {
+  const publicSchema: StableId = { kind: "schema", name: "public" };
+  const pgsodium: StableId = { kind: "extension", name: "pgsodium" };
+  const table: StableId = { kind: "table", schema: "public", name: "creds" };
+  const colId: StableId = {
+    kind: "column",
+    schema: "public",
+    table: "creds",
+    name: "id",
+  };
+  const colSecret: StableId = {
+    kind: "column",
+    schema: "public",
+    table: "creds",
+    name: "secret",
+  };
+  const colKey: StableId = {
+    kind: "column",
+    schema: "public",
+    table: "creds",
+    name: "key_id",
+  };
+  const defKey: StableId = {
+    kind: "default",
+    schema: "public",
+    table: "creds",
+    name: "key_id",
+  };
+  const view: StableId = {
+    kind: "view",
+    schema: "public",
+    name: "decrypted_creds",
+  };
+  const seclabel: StableId = {
+    kind: "securityLabel",
+    target: colSecret,
+    provider: "pgsodium",
+  };
+  const encryptFn: StableId = {
+    kind: "function",
+    schema: "public",
+    name: "creds_encrypt_secret_secret",
+    args: [],
+  };
+  const encryptTrig: StableId = {
+    kind: "trigger",
+    schema: "public",
+    table: "creds",
+    name: "creds_encrypt_secret_trigger_secret",
+  };
+
+  function tceFacts(withArtefacts: boolean): Fact[] {
+    const cols: Fact[] = [
+      f(colId, table, { type: "integer", notNull: true }),
+      f(colSecret, table, { type: "text", notNull: false }),
+      f(colKey, table, { type: "uuid", notNull: false }),
+    ];
+    if (!withArtefacts) {
+      return [
+        f(publicSchema),
+        f(table, publicSchema, { persistence: "p" }),
+        ...cols,
+      ];
+    }
+    return [
+      f(publicSchema),
+      f(pgsodium, undefined, { version: "3.1.8", _relocatable: false }),
+      f(table, publicSchema, { persistence: "p" }),
+      ...cols,
+      f(defKey, colKey, { expr: "(pgsodium.create_key()).id" }),
+      f(view, publicSchema, {
+        def: "SELECT pgsodium.crypto_aead_det_decrypt(secret) FROM public.creds",
+      }),
+      f(seclabel, colSecret, {
+        label: "ENCRYPT WITH KEY COLUMN key_id",
+      }),
+      f(encryptFn, publicSchema, {
+        def: "CREATE FUNCTION public.creds_encrypt_secret_secret() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+        kind: "f",
+      }),
+      f(encryptTrig, table, {
+        def: "CREATE TRIGGER creds_encrypt_secret_trigger_secret BEFORE INSERT ON public.creds FOR EACH ROW EXECUTE FUNCTION public.creds_encrypt_secret_secret()",
+        enabled: "O",
+      }),
+    ];
+  }
+
+  function tceEdges(): { from: StableId; to: StableId; kind: "depends" }[] {
+    return [
+      { from: defKey, to: pgsodium, kind: "depends" },
+      { from: view, to: pgsodium, kind: "depends" },
+      { from: encryptFn, to: pgsodium, kind: "depends" },
+      { from: encryptTrig, to: encryptFn, kind: "depends" },
+    ];
+  }
+
+  test("empty branch: table is planned without pgsodium defaults, views, labels, or CREATE EXTENSION", () => {
+    const empty = buildFactBase([f(publicSchema)], []);
+    const desired = buildFactBase(tceFacts(true), tceEdges());
+    const p = plan(empty, desired, { policy: supabasePolicy });
+    const sql = sqlOf(p);
+    expect(mentions(sql, /CREATE EXTENSION/i)).toBe(false);
+    expect(mentions(sql, /pgsodium/i)).toBe(false);
+    expect(mentions(sql, /CREATE VIEW/i)).toBe(false);
+    expect(mentions(sql, /SECURITY LABEL/i)).toBe(false);
+    expect(mentions(sql, /CREATE TRIGGER/i)).toBe(false);
+    expect(mentions(sql, /CREATE TABLE/i)).toBe(true);
+    expect(
+      p.diagnostics?.some(
+        (d) =>
+          d.code === EXCLUDED_BY_CASCADE &&
+          d.subject !== undefined &&
+          encodeId(d.subject) === encodeId(view),
+      ),
+    ).toBe(true);
+  });
+
+  test("live catalog vs table-only files: TCE artefacts are not dropped", () => {
+    const live = buildFactBase(tceFacts(true), tceEdges());
+    const files = buildFactBase(tceFacts(false), []);
+    const p = plan(live, files, { policy: supabasePolicy });
+    const sql = sqlOf(p);
+    expect(mentions(sql, /DROP VIEW/i)).toBe(false);
+    expect(mentions(sql, /DROP TRIGGER/i)).toBe(false);
+    expect(mentions(sql, /SECURITY LABEL/i)).toBe(false);
+    expect(mentions(sql, /DROP EXTENSION/i)).toBe(false);
+  });
+});
+
+describe("user extension members in an assumed schema stay reference-only", () => {
+  test("a public default over extensions.uuid_generate_v4 is still planned", () => {
+    const postgres: StableId = { kind: "role", name: "postgres" };
+    const publicSchema: StableId = { kind: "schema", name: "public" };
+    const extSchema: StableId = { kind: "schema", name: "extensions" };
+    const uuid: StableId = { kind: "extension", name: "uuid-ossp" };
+    const gen: StableId = {
+      kind: "function",
+      schema: "extensions",
+      name: "uuid_generate_v4",
+      args: [],
+    };
+    const table: StableId = { kind: "table", schema: "public", name: "items" };
+    const col: StableId = {
+      kind: "column",
+      schema: "public",
+      table: "items",
+      name: "id",
+    };
+    const def: StableId = {
+      kind: "default",
+      schema: "public",
+      table: "items",
+      name: "id",
+    };
+    const desired = buildFactBase(
+      [
+        f(postgres),
+        f(publicSchema),
+        f(extSchema),
+        f(uuid, undefined, {
+          version: "1.1",
+          schema: "extensions",
+          _relocatable: true,
+        }),
+        f(gen, extSchema, {
+          def: "CREATE FUNCTION extensions.uuid_generate_v4() RETURNS uuid LANGUAGE c AS 'uuid-ossp'",
+          kind: "f",
+        }),
+        f(table, publicSchema, { persistence: "p" }),
+        f(col, table, { type: "uuid", notNull: true }),
+        f(def, col, { expr: "extensions.uuid_generate_v4()" }),
+      ],
+      [
+        { from: gen, to: uuid, kind: "memberOfExtension" },
+        { from: gen, to: postgres, kind: "owner" },
+        { from: def, to: gen, kind: "depends" },
+      ],
+    );
+    const p = plan(buildFactBase([f(publicSchema)], []), desired, {
+      policy: supabasePolicy,
+    });
+    const sql = sqlOf(p);
+    expect(mentions(sql, /CREATE EXTENSION/i)).toBe(true);
+    expect(mentions(sql, /uuid_generate_v4/i)).toBe(true);
+    expect(mentions(sql, /CREATE FUNCTION/i)).toBe(false);
+  });
+});
+
+describe("image-provisioned excluded extensions stay reference-only", () => {
+  test("a user view over vault.decrypted_secrets is still planned", () => {
+    const publicSchema: StableId = { kind: "schema", name: "public" };
+    const vaultSchema: StableId = { kind: "schema", name: "vault" };
+    const vault: StableId = { kind: "extension", name: "supabase_vault" };
+    const secrets: StableId = {
+      kind: "view",
+      schema: "vault",
+      name: "decrypted_secrets",
+    };
+    const userView: StableId = {
+      kind: "view",
+      schema: "public",
+      name: "secrets_list",
+    };
+    const platform: Fact[] = [
+      f(publicSchema),
+      f(vaultSchema),
+      f(vault, undefined, { version: "0.3.1", _relocatable: false }),
+      f(secrets, vaultSchema, { def: "SELECT 1 AS secret" }),
+    ];
+    const platformEdges = [
+      { from: secrets, to: vault, kind: "memberOfExtension" as const },
+    ];
+    const source = buildFactBase(platform, platformEdges);
+    const desired = buildFactBase(
+      [
+        ...platform,
+        f(userView, publicSchema, {
+          def: "SELECT secret FROM vault.decrypted_secrets",
+        }),
+      ],
+      [...platformEdges, { from: userView, to: secrets, kind: "depends" }],
+    );
+    const p = plan(source, desired, { policy: supabasePolicy });
+    const sql = sqlOf(p);
+    expect(mentions(sql, /CREATE VIEW/i)).toBe(true);
+    expect(mentions(sql, /secrets_list/i)).toBe(true);
+    expect(mentions(sql, /CREATE EXTENSION/i)).toBe(false);
+  });
+
+  test("a user view over a wrappers foreign table still cascades out", () => {
+    const publicSchema: StableId = { kind: "schema", name: "public" };
+    const wrappers: StableId = { kind: "extension", name: "wrappers" };
+    const ft: StableId = {
+      kind: "foreignTable",
+      schema: "public",
+      name: "stripe_customers",
+    };
+    const userView: StableId = {
+      kind: "view",
+      schema: "public",
+      name: "customers",
+    };
+    const desired = buildFactBase(
+      [
+        f(publicSchema),
+        f(wrappers, undefined, { version: "0.5.0", _relocatable: true }),
+        f(ft, publicSchema),
+        f(userView, publicSchema, {
+          def: "SELECT 1 FROM public.stripe_customers",
+        }),
+      ],
+      [
+        { from: ft, to: wrappers, kind: "memberOfExtension" },
+        { from: userView, to: ft, kind: "depends" },
+      ],
+    );
+    const p = plan(buildFactBase([f(publicSchema)], []), desired, {
+      policy: supabasePolicy,
+    });
+    expect(mentions(sqlOf(p), /CREATE VIEW/i)).toBe(false);
+    expect(mentions(sqlOf(p), /CREATE EXTENSION/i)).toBe(false);
+  });
+});

--- a/packages/pg-delta/src/policy/exclusion-cascade.test.ts
+++ b/packages/pg-delta/src/policy/exclusion-cascade.test.ts
@@ -11,6 +11,7 @@ import { EXCLUDED_BY_CASCADE } from "../core/diagnostic.ts";
 import { buildFactBase, type Fact } from "../core/fact.ts";
 import { encodeId, type StableId } from "../core/stable-id.ts";
 import { plan } from "../plan/plan.ts";
+import { reconstructManagedView } from "./reconstruct.ts";
 import { supabasePolicy } from "./supabase.ts";
 
 const f = (
@@ -303,6 +304,9 @@ describe("CLI-2342 — dependents of an excluded platform extension", () => {
           encodeId(d.subject) === encodeId(view),
       ),
     ).toBe(true);
+    // Desired-only cascade victims are not stamped: apply would otherwise
+    // strip a later-created same-id object from the source fingerprint.
+    expect(p.cascadeAlignedIds ?? []).toEqual([]);
   });
 
   test("live catalog vs table-only files: TCE artefacts are not dropped", () => {
@@ -449,5 +453,161 @@ describe("image-provisioned excluded extensions stay reference-only", () => {
     });
     expect(mentions(sqlOf(p), /CREATE VIEW/i)).toBe(false);
     expect(mentions(sqlOf(p), /CREATE EXTENSION/i)).toBe(false);
+  });
+});
+
+describe("one-sided reverse-depends cascade aligns presence", () => {
+  const publicSchema: StableId = { kind: "schema", name: "public" };
+  const pgsodium: StableId = { kind: "extension", name: "pgsodium" };
+  const v: StableId = { kind: "view", schema: "public", name: "v" };
+  const w: StableId = { kind: "view", schema: "public", name: "w" };
+
+  const select1 = () =>
+    buildFactBase(
+      [f(publicSchema), f(v, publicSchema, { def: "SELECT 1 AS x" })],
+      [],
+    );
+  const selectPgsodium = () =>
+    buildFactBase(
+      [
+        f(publicSchema),
+        f(pgsodium, undefined, { version: "3.1.8", _relocatable: false }),
+        f(v, publicSchema, { def: "SELECT pgsodium.foo() AS x" }),
+      ],
+      [{ from: v, to: pgsodium, kind: "depends" }],
+    );
+
+  test("changing an existing view to depend on an excluded extension is not DROP VIEW", () => {
+    const p = plan(select1(), selectPgsodium(), { policy: supabasePolicy });
+    const sql = sqlOf(p);
+    expect(mentions(sql, /DROP VIEW/i)).toBe(false);
+    expect(mentions(sql, /CREATE VIEW/i)).toBe(false);
+    expect(mentions(sql, /CREATE EXTENSION/i)).toBe(false);
+    expect(
+      p.diagnostics?.some(
+        (d) =>
+          d.code === EXCLUDED_BY_CASCADE &&
+          d.subject !== undefined &&
+          encodeId(d.subject) === encodeId(v),
+      ),
+    ).toBe(true);
+    expect(p.cascadeAlignedIds).toContain(encodeId(v));
+    const unaligned = reconstructManagedView(select1(), {
+      policy: supabasePolicy,
+    });
+    expect(unaligned.rootHash).not.toBe(p.source.fingerprint);
+    const aligned = reconstructManagedView(select1(), {
+      policy: supabasePolicy,
+      alignedIds: new Set(p.cascadeAlignedIds ?? []),
+    });
+    expect(aligned.rootHash).toBe(p.source.fingerprint);
+    expect(aligned.get(v)).toBeUndefined();
+  });
+
+  test("a view that exists only on the desired side is skipped, not aligned", () => {
+    const p = plan(buildFactBase([f(publicSchema)], []), selectPgsodium(), {
+      policy: supabasePolicy,
+    });
+    expect(mentions(sqlOf(p), /CREATE VIEW/i)).toBe(false);
+    expect(p.cascadeAlignedIds ?? []).not.toContain(encodeId(v));
+  });
+
+  test("reversing that change is not CREATE VIEW of an object that still exists", () => {
+    const p = plan(selectPgsodium(), select1(), { policy: supabasePolicy });
+    const sql = sqlOf(p);
+    expect(mentions(sql, /CREATE VIEW/i)).toBe(false);
+    expect(mentions(sql, /DROP VIEW/i)).toBe(false);
+    expect(p.cascadeAlignedIds).toContain(encodeId(v));
+  });
+
+  test("aligning a cascaded view does not reverse-cascade a peer that only depends on it", () => {
+    const live = buildFactBase(
+      [
+        f(publicSchema),
+        f(v, publicSchema, { def: "SELECT 1 AS x" }),
+        f(w, publicSchema, { def: "SELECT 1 AS x" }),
+      ],
+      [{ from: w, to: v, kind: "depends" }],
+    );
+    const files = buildFactBase(
+      [
+        f(publicSchema),
+        f(pgsodium, undefined, { version: "3.1.8", _relocatable: false }),
+        f(v, publicSchema, { def: "SELECT pgsodium.foo() AS x" }),
+        f(w, publicSchema, { def: "SELECT 1 AS x" }),
+      ],
+      [{ from: v, to: pgsodium, kind: "depends" }],
+    );
+    const p = plan(live, files, { policy: supabasePolicy });
+    expect(mentions(sqlOf(p), /DROP VIEW/i)).toBe(false);
+    expect(mentions(sqlOf(p), /CREATE VIEW/i)).toBe(false);
+    const aligned = reconstructManagedView(live, {
+      policy: supabasePolicy,
+      alignedIds: new Set(p.cascadeAlignedIds ?? []),
+    });
+    expect(aligned.get(v)).toBeUndefined();
+    expect(aligned.get(w)).toBeDefined();
+  });
+
+  test("a shadow-seeded desired fingerprint needs the live peer's assumed ids", () => {
+    const admin: StableId = { kind: "role", name: "supabase_admin" };
+    const postgres: StableId = { kind: "role", name: "postgres" };
+    const authSchema: StableId = { kind: "schema", name: "auth" };
+    const users: StableId = { kind: "table", schema: "auth", name: "users" };
+    const fn: StableId = {
+      kind: "function",
+      schema: "public",
+      name: "on_mig",
+      args: [],
+    };
+    const authTrigger: StableId = {
+      kind: "trigger",
+      schema: "auth",
+      table: "users",
+      name: "on_auth_user_created",
+    };
+    const publicSchema: StableId = { kind: "schema", name: "public" };
+    const live = buildFactBase(
+      [
+        f(admin),
+        f(authSchema),
+        f(users, authSchema, { persistence: "p" }),
+        f(publicSchema),
+      ],
+      [{ from: users, to: admin, kind: "owner" }],
+    );
+    const shadow = buildFactBase(
+      [
+        f(postgres),
+        f(authSchema),
+        f(users, authSchema, { persistence: "p" }),
+        f(publicSchema),
+        f(fn, publicSchema, {
+          def: "CREATE FUNCTION public.on_mig() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+          kind: "f",
+        }),
+        f(authTrigger, users, {
+          def: "CREATE TRIGGER on_auth_user_created AFTER INSERT ON auth.users FOR EACH ROW EXECUTE FUNCTION public.on_mig()",
+          enabled: "O",
+        }),
+      ],
+      [
+        { from: users, to: postgres, kind: "owner" },
+        { from: authTrigger, to: fn, kind: "depends" },
+      ],
+    );
+    const p = plan(live, shadow, { policy: supabasePolicy });
+    expect(
+      reconstructManagedView(shadow, { policy: supabasePolicy }).rootHash,
+    ).not.toBe(p.target.fingerprint);
+    const sourceUnaligned = reconstructManagedView(live, {
+      policy: supabasePolicy,
+    });
+    const desired = reconstructManagedView(shadow, {
+      policy: supabasePolicy,
+      keepAssumedIds: sourceUnaligned.referenceOnly,
+      alignedIds: new Set(p.cascadeAlignedIds ?? []),
+    });
+    expect(desired.rootHash).toBe(p.target.fingerprint);
   });
 });

--- a/packages/pg-delta/src/policy/exclusion-cascade.test.ts
+++ b/packages/pg-delta/src/policy/exclusion-cascade.test.ts
@@ -549,6 +549,37 @@ describe("one-sided reverse-depends cascade aligns presence", () => {
     expect(aligned.get(w)).toBeDefined();
   });
 
+  test("changing a view off a managedBy table is not CREATE VIEW of an object that still exists", () => {
+    const pgmq: StableId = { kind: "extension", name: "pgmq" };
+    const pgmqSchema: StableId = { kind: "schema", name: "pgmq" };
+    const queue: StableId = {
+      kind: "table",
+      schema: "pgmq",
+      name: "q_jobs",
+    };
+    const live = buildFactBase(
+      [
+        f(publicSchema),
+        f(pgmqSchema),
+        f(pgmq, undefined, { version: "1.4.4", _relocatable: false }),
+        f(queue, pgmqSchema, { persistence: "p" }),
+        f(v, publicSchema, { def: "SELECT 1 FROM pgmq.q_jobs" }),
+      ],
+      [
+        { from: queue, to: pgmq, kind: "managedBy" },
+        { from: v, to: queue, kind: "depends" },
+      ],
+    );
+    const files = buildFactBase(
+      [f(publicSchema), f(v, publicSchema, { def: "SELECT 1 AS x" })],
+      [],
+    );
+    const p = plan(live, files);
+    expect(mentions(sqlOf(p), /CREATE VIEW/i)).toBe(false);
+    expect(mentions(sqlOf(p), /DROP VIEW/i)).toBe(false);
+    expect(p.cascadeAlignedIds).toContain(encodeId(v));
+  });
+
   test("a shadow-seeded desired fingerprint needs the live peer's assumed ids", () => {
     const admin: StableId = { kind: "role", name: "supabase_admin" };
     const postgres: StableId = { kind: "role", name: "postgres" };

--- a/packages/pg-delta/src/policy/policy.test.ts
+++ b/packages/pg-delta/src/policy/policy.test.ts
@@ -658,6 +658,29 @@ describe("flattenPolicy — extends composition", () => {
     const flat = flattenPolicy({ id: "no-assumed-schemas" });
     expect(flat.assumedSchemas).toEqual([]);
   });
+
+  test("assumedExtensions compose across extends and de-duplicate", () => {
+    const parent: Policy = {
+      id: "parent-assumed-exts",
+      assumedExtensions: ["supabase_vault", "pg_graphql"],
+    };
+    const child: Policy = {
+      id: "child-assumed-exts",
+      assumedExtensions: ["supabase_vault", "pg_stat_statements"],
+      extends: [parent],
+    };
+    const flat = flattenPolicy(child);
+    expect([...flat.assumedExtensions].sort()).toEqual([
+      "pg_graphql",
+      "pg_stat_statements",
+      "supabase_vault",
+    ]);
+  });
+
+  test("assumedExtensions defaults to empty array when unset", () => {
+    const flat = flattenPolicy({ id: "no-assumed-exts" });
+    expect(flat.assumedExtensions).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -1105,6 +1105,12 @@ export function resolveView(
   capability?: ApplierCapability,
   baseline?: FactBase,
   collectSuppression?: ProjectionSuppressionCollector,
+  /** Encoded ids that a peer catalog already kept reference-only. A
+   *  shadow-seeded copy of `auth.users` re-extracts as the applier
+   *  (`postgres`) and would otherwise be hard-pruned; if the live side kept
+   *  the same id, keep it reference-only here too so user triggers still
+   *  attach. */
+  keepAssumedIds?: ReadonlySet<string>,
 ): FactBase {
   // Identity fast path. With no policy, no capability and no baseline, every
   // stage below is already a no-op that hands `fb` back BY REFERENCE — but
@@ -1271,7 +1277,9 @@ export function resolveView(
   // (present via CREATE EXTENSION), and platform-provisioned members of
   // assumed schemas (system-role-owned, not the policy default owner).
   // No-owner facts stay reference-only — the same conservative default as
-  // before this discriminator existed.
+  // before this discriminator existed. A policy that never names assumedRoles
+  // cannot tell platform from user-created, so every assumed member stays
+  // reference-only (custom profiles, alpine fixtures).
   const keepAssumedReferenceOnly = (fact: Fact): boolean => {
     if (!isAssumed(fact.id)) return false;
     if (
@@ -1285,6 +1293,8 @@ export function resolveView(
     // user-owned relations. Hard-pruning them cascades public defaults /
     // views / columns off the member.
     if (memberRefOnly.has(encodeId(fact.id))) return true;
+    if (assumedRoleNames.size === 0) return true;
+    if (keepAssumedIds?.has(encodeId(fact.id))) return true;
     const owner = ownerName(fact);
     if (owner === undefined) return true;
     if (policyDefaultOwner !== undefined && owner === policyDefaultOwner) {

--- a/packages/pg-delta/src/policy/policy.ts
+++ b/packages/pg-delta/src/policy/policy.ts
@@ -315,6 +315,17 @@ export interface Policy {
    */
   assumedPublications?: string[];
   /**
+   * Extension names assumed to exist at apply time but NOT managed by this
+   * policy — platform-provisioned extensions (e.g. Supabase's
+   * `supabase_vault`) whose extension OBJECT is filtered out of the managed
+   * view, yet which remain present on every target. A scope-excluded
+   * extension named here is kept REFERENCE-ONLY instead of hard-pruned, so
+   * its members stay in the view and a user object that depends on them
+   * still plans. Extensions omitted from this list (Supabase `pgsodium`,
+   * `wrappers`) stay hard-pruned and their dependents cascade out.
+   */
+  assumedExtensions?: string[];
+  /**
    * The role whose object ownership stays IMPLICIT in a database-scope export:
    * `schema export` suppresses `ALTER … OWNER TO <defaultOwner>` (that role is the
    * expected applier), while every object owned by another role serializes its
@@ -744,6 +755,7 @@ export function flattenPolicy(policy: Policy): {
   assumedRoles: string[];
   assumedSchemas: string[];
   assumedPublications: string[];
+  assumedExtensions: string[];
   baseline?: string;
   defaultOwner?: string;
 } {
@@ -761,6 +773,7 @@ function flattenInner(
   assumedRoles: string[];
   assumedSchemas: string[];
   assumedPublications: string[];
+  assumedExtensions: string[];
   baseline?: string;
   defaultOwner?: string;
 } {
@@ -776,11 +789,13 @@ function flattenInner(
   const ownAssumedRoles: string[] = policy.assumedRoles ?? [];
   const ownAssumedSchemas: string[] = policy.assumedSchemas ?? [];
   const ownAssumedPublications: string[] = policy.assumedPublications ?? [];
+  const ownAssumedExtensions: string[] = policy.assumedExtensions ?? [];
   const parentFilter: FilterRule[] = [];
   const parentSerialize: SerializeRule[] = [];
   const parentAssumedRoles: string[] = [];
   const parentAssumedSchemas: string[] = [];
   const parentAssumedPublications: string[] = [];
+  const parentAssumedExtensions: string[] = [];
   // defaultOwner is scalar: own value wins, else the first parent that declares
   // one (own-before-extends, matching the rule-ordering convention).
   let parentDefaultOwner: string | undefined;
@@ -797,6 +812,7 @@ function flattenInner(
       parentAssumedRoles.push(...flat.assumedRoles);
       parentAssumedSchemas.push(...flat.assumedSchemas);
       parentAssumedPublications.push(...flat.assumedPublications);
+      parentAssumedExtensions.push(...flat.assumedExtensions);
       if (parentDefaultOwner === undefined && flat.defaultOwner !== undefined) {
         parentDefaultOwner = flat.defaultOwner;
       }
@@ -812,6 +828,7 @@ function flattenInner(
     assumedRoles: string[];
     assumedSchemas: string[];
     assumedPublications: string[];
+    assumedExtensions: string[];
     baseline?: string;
     defaultOwner?: string;
   } = {
@@ -825,6 +842,9 @@ function flattenInner(
     ],
     assumedPublications: [
       ...new Set([...ownAssumedPublications, ...parentAssumedPublications]),
+    ],
+    assumedExtensions: [
+      ...new Set([...ownAssumedExtensions, ...parentAssumedExtensions]),
     ],
   };
   if (policy.baseline !== undefined) {
@@ -1200,16 +1220,23 @@ export function resolveView(
   }
 
   // policy scope (non-`verb`) rules: hard-prune the facts they exclude, EXCEPT
-  // an excluded fact whose schema is an assumedSchema (e.g. Supabase's `auth`)
-  // or a publication named in assumedPublications (e.g. `supabase_realtime`),
-  // which is kept REFERENCE-ONLY so a managed dependent (a user trigger on
-  // `auth.users`, a `publicationRel` membership) resolves its parent while the
-  // assumed object itself is never diffed. `verb` rules are left to the delta
-  // filter.
+  // an excluded fact that is a platform assumed object — an assumed SCHEMA /
+  // PUBLICATION / EXTENSION, or an object in an assumed schema owned by a
+  // policy assumed role other than `defaultOwner` (e.g. Supabase `auth.users`
+  // owned by `supabase_admin`). Those stay REFERENCE-ONLY so a managed
+  // dependent (a user trigger on `auth.users`, a `publicationRel` membership,
+  // a view over `vault.decrypted_secrets`) resolves its parent. A user-owned
+  // object in an assumed schema (`postgres`-owned
+  // `supabase_migrations.schema_migrations`) is hard-pruned so its include-
+  // protected satellites cascade out instead of consuming a parent the empty
+  // target will never have. `verb` rules are left to the delta filter.
   const flat = policy ? flattenPolicy(policy) : undefined;
   const rules = flat?.filter ?? [];
   const assumed = new Set(flat?.assumedSchemas ?? []);
   const assumedPubs = new Set(flat?.assumedPublications ?? []);
+  const assumedExts = new Set(flat?.assumedExtensions ?? []);
+  const assumedRoleNames = new Set(flat?.assumedRoles ?? []);
+  const policyDefaultOwner = flat?.defaultOwner;
   const assumedSchemaOf = (id: StableId): string | undefined =>
     id.kind === "schema" ? getName(id) : getSchema(id);
   const isAssumed = (id: StableId): boolean => {
@@ -1217,8 +1244,47 @@ export function resolveView(
       const name = getName(id);
       return name !== undefined && assumedPubs.has(name);
     }
+    if (id.kind === "extension") {
+      const name = getName(id);
+      return name !== undefined && assumedExts.has(name);
+    }
     const schema = assumedSchemaOf(id);
     return schema !== undefined && assumed.has(schema);
+  };
+  const ownerName = (fact: Fact): string | undefined => {
+    const ownerEdge = base
+      .outgoingEdges(fact.id)
+      .find((e) => e.kind === "owner");
+    if (ownerEdge?.to.kind === "role") {
+      return (ownerEdge.to as { kind: "role"; name: string }).name;
+    }
+    const payload = fact.payload["owner"];
+    return typeof payload === "string" ? payload : undefined;
+  };
+  // Schema/publication/extension objects, extension members in assumed schemas
+  // (present via CREATE EXTENSION), and platform-provisioned members of
+  // assumed schemas (system-role-owned, not the policy default owner).
+  // No-owner facts stay reference-only — the same conservative default as
+  // before this discriminator existed.
+  const keepAssumedReferenceOnly = (fact: Fact): boolean => {
+    if (!isAssumed(fact.id)) return false;
+    if (
+      fact.id.kind === "schema" ||
+      fact.id.kind === "publication" ||
+      fact.id.kind === "extension"
+    )
+      return true;
+    // Members of a user-managed extension installed into an assumed schema
+    // (`uuid-ossp` in `extensions`) are present via CREATE EXTENSION, not
+    // user-owned relations. Hard-pruning them cascades public defaults /
+    // views / columns off the member.
+    if (memberRefOnly.has(encodeId(fact.id))) return true;
+    const owner = ownerName(fact);
+    if (owner === undefined) return true;
+    if (policyDefaultOwner !== undefined && owner === policyDefaultOwner) {
+      return false;
+    }
+    return assumedRoleNames.has(owner);
   };
   const hardRoots = new Set<string>();
   const policyRefOnly = new Set<string>();
@@ -1233,7 +1299,7 @@ export function resolveView(
       flat?.id ?? policy?.id ?? "unknown",
       exclusion,
     );
-    if (isAssumed(fact.id)) {
+    if (keepAssumedReferenceOnly(fact)) {
       policyRefOnly.add(encodeId(fact.id));
       policyRootAttribution.set(encodeId(fact.id), attribution);
     } else {

--- a/packages/pg-delta/src/policy/reconstruct.test.ts
+++ b/packages/pg-delta/src/policy/reconstruct.test.ts
@@ -1,8 +1,9 @@
 /**
  * Guard + pin (V1): the full managed-view composition
- * (`resolveView` → `projectManagementScope`) must live in exactly one module.
- * Call sites that need both steps go through `reconstructManagedView`; bare
- * `resolveView` alone remains allowed (diff / seed paths).
+ * (`resolveView` → `projectManagementScope`, then optional `alignedIds`
+ * parent-chain strip) must live in exactly one module. Call sites that need
+ * both policy steps go through `reconstructManagedView`; bare `resolveView`
+ * alone remains allowed (diff / seed paths). Omitted `alignedIds` is identity.
  *
  * Import/call-based per module — not a nested-call grep. schema-export used to
  * compose via an intermediate variable, which a

--- a/packages/pg-delta/src/policy/reconstruct.ts
+++ b/packages/pg-delta/src/policy/reconstruct.ts
@@ -2,7 +2,8 @@
  * Single reconstruction entry point for the managed view under management scope
  * (docs/architecture/managed-view-architecture.md; agent track V1).
  *
- * Order is fixed: `resolveView` THEN `projectManagementScope`. A policy
+ * Order is fixed: `resolveView` THEN `projectManagementScope`, then an
+ * optional parent-chain strip of `alignedIds` (`Plan.cascadeAlignedIds`). A policy
  * owner-exclusion rule reads the `owner` edge, and database-scope role pruning
  * removes those edges with the role facts — projecting scope first would strip
  * the edge the policy needs and wrongly plan a DROP of a platform object owned
@@ -27,6 +28,7 @@ import type { ApplierCapability } from "./capability.ts";
 import { resolveView, type Policy } from "./policy.ts";
 import {
   EXCLUDED_BY_CASCADE_REASON,
+  excludeIdentitiesAndChildren,
   projectManagementScope,
   type ManagementScope,
   type ProjectionAuditClassification,
@@ -52,11 +54,15 @@ interface ReconstructManagedViewOptions {
     | undefined;
   /** Encoded ids the peer catalog kept reference-only (see `resolveView`). */
   keepAssumedIds?: ReadonlySet<string> | undefined;
+  /** Encoded ids to strip after policy/scope (parent-chain only). Replay of
+   *  `Plan.cascadeAlignedIds` so apply/prove match the plan fingerprints. */
+  alignedIds?: ReadonlySet<string> | undefined;
 }
 
 /**
  * Rebuild the managed-view-under-scope: policy/capability/baseline projection,
- * then management-scope role pruning.
+ * then management-scope role pruning, then optional `alignedIds` parent-chain
+ * strip.
  */
 export function reconstructManagedView(
   fb: FactBase,
@@ -71,7 +77,7 @@ export function reconstructManagedView(
     opts.collectSuppression,
     opts.keepAssumedIds,
   );
-  return projectManagementScope(view, scope, {
+  const scoped = projectManagementScope(view, scope, {
     ...(opts.defaultOwner !== undefined
       ? { defaultOwner: opts.defaultOwner }
       : {}),
@@ -79,6 +85,7 @@ export function reconstructManagedView(
       ? { collectSuppression: opts.collectSuppression }
       : {}),
   });
+  return excludeIdentitiesAndChildren(scoped, opts.alignedIds);
 }
 
 export interface ProjectionAuditEntry {
@@ -431,6 +438,23 @@ export function auditManagedViewProjection(
 export interface TracedSuppression {
   side: "source" | "desired";
   suppression: ProjectionSuppression;
+}
+
+/** Reverse-depends cascade victims (not parent-chain kids of a policy exclude).
+ *  The planner keeps those present on exactly one unaligned side so a
+ *  one-sided dependency skip is not a presence change, and a desired-only
+ *  skip is not stamped onto apply's source fingerprint. */
+export function cascadeAlignedIdsFrom(
+  suppressions: readonly TracedSuppression[],
+): Set<string> {
+  const ids = new Set<string>();
+  for (const { suppression } of suppressions) {
+    if (suppression.subject.kind !== "fact") continue;
+    if (suppression.stage !== "policyScopeRule") continue;
+    if (suppression.reasonCode !== EXCLUDED_BY_CASCADE_REASON) continue;
+    ids.add(encodeId(suppression.subject.id));
+  }
+  return ids;
 }
 
 const CASCADE_DIAG_SKIP = new Set(["column", "default", "constraint"]);

--- a/packages/pg-delta/src/policy/reconstruct.ts
+++ b/packages/pg-delta/src/policy/reconstruct.ts
@@ -440,17 +440,16 @@ export interface TracedSuppression {
   suppression: ProjectionSuppression;
 }
 
-/** Reverse-depends cascade victims (not parent-chain kids of a policy exclude).
- *  The planner keeps those present on exactly one unaligned side so a
- *  one-sided dependency skip is not a presence change, and a desired-only
- *  skip is not stamped onto apply's source fingerprint. */
+/** Reverse-depends cascade victims (not parent-chain kids of a hard exclude).
+ *  Stage-agnostic: policy, `managedBy`, and capability all use the same
+ *  reverse-`depends` walk. The planner keeps those present on exactly one
+ *  unaligned side so a one-sided skip is not a presence change. */
 export function cascadeAlignedIdsFrom(
   suppressions: readonly TracedSuppression[],
 ): Set<string> {
   const ids = new Set<string>();
   for (const { suppression } of suppressions) {
     if (suppression.subject.kind !== "fact") continue;
-    if (suppression.stage !== "policyScopeRule") continue;
     if (suppression.reasonCode !== EXCLUDED_BY_CASCADE_REASON) continue;
     ids.add(encodeId(suppression.subject.id));
   }

--- a/packages/pg-delta/src/policy/reconstruct.ts
+++ b/packages/pg-delta/src/policy/reconstruct.ts
@@ -50,6 +50,8 @@ interface ReconstructManagedViewOptions {
   collectSuppression?:
     | ((suppression: ProjectionSuppression) => void)
     | undefined;
+  /** Encoded ids the peer catalog kept reference-only (see `resolveView`). */
+  keepAssumedIds?: ReadonlySet<string> | undefined;
 }
 
 /**
@@ -67,6 +69,7 @@ export function reconstructManagedView(
     opts.capability,
     opts.baseline,
     opts.collectSuppression,
+    opts.keepAssumedIds,
   );
   return projectManagementScope(view, scope, {
     ...(opts.defaultOwner !== undefined

--- a/packages/pg-delta/src/policy/reconstruct.ts
+++ b/packages/pg-delta/src/policy/reconstruct.ts
@@ -14,12 +14,19 @@
  * Bare `resolveView` (without scope) stays legitimate for diff/seed paths.
  */
 import { diff, subjectOf, type Delta } from "../core/diff.ts";
+import { EXCLUDED_BY_CASCADE, type Diagnostic } from "../core/diagnostic.ts";
 import type { DependencyEdge, FactBase } from "../core/fact.ts";
 import type { PayloadValue } from "../core/hash.ts";
-import { encodeId, parseId, type StableId } from "../core/stable-id.ts";
+import {
+  encodeId,
+  isSatelliteId,
+  parseId,
+  type StableId,
+} from "../core/stable-id.ts";
 import type { ApplierCapability } from "./capability.ts";
 import { resolveView, type Policy } from "./policy.ts";
 import {
+  EXCLUDED_BY_CASCADE_REASON,
   projectManagementScope,
   type ManagementScope,
   type ProjectionAuditClassification,
@@ -421,6 +428,41 @@ export function auditManagedViewProjection(
 export interface TracedSuppression {
   side: "source" | "desired";
   suppression: ProjectionSuppression;
+}
+
+const CASCADE_DIAG_SKIP = new Set(["column", "default", "constraint"]);
+
+/** Info diagnostics for facts skipped because a policy-excluded parent or
+ *  dependency pulled them out of the view. Deduped across sides. */
+export function excludedByCascadeDiagnostics(
+  suppressions: readonly TracedSuppression[],
+): Diagnostic[] {
+  const seen = new Set<string>();
+  const out: Diagnostic[] = [];
+  for (const { suppression } of suppressions) {
+    if (suppression.subject.kind !== "fact") continue;
+    if (suppression.stage !== "policyScopeRule") continue;
+    const cascaded =
+      suppression.reasonCode === EXCLUDED_BY_CASCADE_REASON ||
+      suppression.viaDescendantOf !== undefined;
+    if (!cascaded) continue;
+    const id = suppression.subject.id;
+    if (isSatelliteId(id) || CASCADE_DIAG_SKIP.has(id.kind)) continue;
+    const key = encodeId(id);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const via = suppression.viaDescendantOf;
+    out.push({
+      code: EXCLUDED_BY_CASCADE,
+      severity: "info",
+      subject: id,
+      message:
+        via === undefined
+          ? `${key} excluded by cascade`
+          : `${key} excluded by cascade from ${encodeId(via)}`,
+    });
+  }
+  return out;
 }
 
 /** Freshly allocated each call — `entries` is a mutable array the caller owns. */

--- a/packages/pg-delta/src/policy/supabase-extensions.test.ts
+++ b/packages/pg-delta/src/policy/supabase-extensions.test.ts
@@ -1,11 +1,9 @@
 /**
  * supabase/cli#5555: a declarative sync must not drop platform-managed
- * extensions (the reported `DROP EXTENSION pg_graphql`). The supabase policy
- * projects those extensions out of the managed view entirely — so an extension
- * present on the target but absent from the declarative source produces no
- * remove delta and thus no DROP — while leaving user-declarable extensions
- * (pg_trgm, …) fully managed. Before the fix, pg_graphql was kept in the view
- * and would be dropped. Pure policy level — no DB.
+ * extensions (the reported `DROP EXTENSION pg_graphql`). Image-provisioned
+ * ones (`pg_graphql`, …) stay REFERENCE-ONLY — present so members resolve,
+ * never a create/drop delta. `pgsodium` / `wrappers` hard-prune. User
+ * extensions (pg_trgm, …) stay fully managed. Pure policy level — no DB.
  */
 import { describe, expect, test } from "bun:test";
 import { buildFactBase, type Fact } from "../core/fact.ts";
@@ -22,16 +20,18 @@ const pgTrgm: StableId = { kind: "extension", name: "pg_trgm" };
 const wrappers: StableId = { kind: "extension", name: "wrappers" };
 
 describe("supabase policy — platform extensions", () => {
-  test("projects out pg_graphql but keeps a user extension", () => {
+  test("keeps pg_graphql reference-only and a user extension managed", () => {
     const fb = buildFactBase(
       [ext("pg_graphql", "graphql"), ext("pg_trgm", "extensions")],
       [],
     );
     const view = resolveView(fb, supabasePolicy);
-    // platform-managed → invisible → never dropped (the #5555 fix)
-    expect(view.get(pgGraphql)).toBeUndefined();
+    // platform-provisioned → reference-only → never dropped (the #5555 fix)
+    expect(view.get(pgGraphql)).toBeDefined();
+    expect(view.isReferenceOnly(pgGraphql)).toBe(true);
     // user-declarable → still managed
     expect(view.get(pgTrgm)).toBeDefined();
+    expect(view.isReferenceOnly(pgTrgm)).toBe(false);
   });
 
   test("projects out the wrappers extension (dashboard-installed, CLI-1470)", () => {

--- a/packages/pg-delta/src/policy/supabase.ts
+++ b/packages/pg-delta/src/policy/supabase.ts
@@ -145,7 +145,16 @@ export const SUPABASE_SYSTEM_ROLES = [
  *  (pg_net, pg_cron, pgmq, pgcrypto, uuid-ossp, …) are intentionally absent so
  *  users can still manage them. The comprehensive mechanism is the committed
  *  Supabase baseline (a v1 gate — see the `baseline` note below); this name
- *  list mirrors SUPABASE_SYSTEM_SCHEMAS/ROLES until that lands. */
+ *  list mirrors SUPABASE_SYSTEM_SCHEMAS/ROLES until that lands.
+ *
+ *  `pgsodium` stays on this list even though current images no longer
+ *  provision it and `pg_available_extensions` may still list it. Hosted
+ *  installs exist only because platform bootstrap ran as superuser (role
+ *  grants, getkey script); a user-role `CREATE EXTENSION` cannot reproduce
+ *  that, the extension is schema-bound (CLI#3358), and TCE security labels
+ *  generate triggers/views as side effects (CLI#1024). Dependents cascade
+ *  out of the managed view rather than planning CREATE EXTENSION. Do not
+ *  emit a `version` clause (ignored with a warning since 2026-08-05). */
 export const SUPABASE_SYSTEM_EXTENSIONS = [
   "pg_graphql",
   "pg_stat_statements",
@@ -274,6 +283,15 @@ export const supabasePolicy: Policy = {
   // into the diff. Mirrors the system-schema exclusion list by construction.
   assumedSchemas: [...SUPABASE_SYSTEM_SCHEMAS],
 
+  // Platform-provisioned extensions assumed to exist at apply time. The
+  // system-extension exclude rule below projects the extension OBJECT out of
+  // the managed view, but naming it here downgrades that exclusion to
+  // REFERENCE-ONLY so members stay visible and a user view over
+  // `vault.decrypted_secrets` (or `pg_stat_statements`) still plans. `pgsodium`
+  // and `wrappers` are deliberately absent: they are not present on a fresh
+  // branch / are dashboard-conditional, and their dependents cascade out.
+  assumedExtensions: ["pg_graphql", "pg_stat_statements", "supabase_vault"],
+
   // Default owner for database-scope exports: Supabase hands users the
   // `postgres` role, so an object owned by `postgres` needs no `ALTER … OWNER
   // TO` — its ownership is implicit. Objects owned by a system role are already
@@ -332,8 +350,10 @@ export const supabasePolicy: Policy = {
     // general extension include below (first-match-wins) so it wins for these
     // names; all OTHER extensions still fall through to the include and stay
     // user-declarable. No `verb` clause → also suppresses spurious version
-    // (`set`) churn on a platform extension. The robust long-term mechanism is
-    // the committed Supabase baseline (the `baseline` note below).
+    // (`set`) churn on a platform extension. Names in `assumedExtensions` are
+    // kept reference-only (members stay); `pgsodium` / `wrappers` hard-prune
+    // and cascade their dependents. The robust long-term mechanism is the
+    // committed Supabase baseline (the `baseline` note below).
     {
       match: {
         all: [{ kind: "extension" }, { name: [...SUPABASE_SYSTEM_EXTENSIONS] }],

--- a/packages/pg-delta/src/policy/view.test.ts
+++ b/packages/pg-delta/src/policy/view.test.ts
@@ -49,12 +49,13 @@ describe("excludeByProvenance — generic fact-level projection", () => {
 
     const out = excludeByProvenance(fb, "memberOfExtension");
 
-    // member root + its column descendant are gone; user + public + ext stay
+    // member root + its column descendant are gone; a user object that depends
+    // on the member is cascaded out too (the depends edge would otherwise be
+    // pruned and leave a managed consumer with no producer).
     expect(out.get(memberTable)).toBeUndefined();
     expect(out.get(memberCol)).toBeUndefined();
-    expect(out.get(userTable)).toBeDefined();
+    expect(out.get(userTable)).toBeUndefined();
     expect(out.get(pub)).toBeDefined();
-    // the depends edge into the removed member is pruned
     expect(out.edges.some((e) => e.kind === "depends")).toBe(false);
   });
 

--- a/packages/pg-delta/src/policy/view.ts
+++ b/packages/pg-delta/src/policy/view.ts
@@ -298,16 +298,21 @@ export interface ComputedExclusion {
 
 /** Compute (without building) the exclusion of `rootIds` + descendants +
  *  reverse-depends closure. An empty `rootIds` keeps every fact and every
- *  edge — the identity projection. */
+ *  edge — the identity projection. `reverseDepends: false` is parent-chain
+ *  only — used to replay cross-side cascade alignment without walking
+ *  `depends` again (that walk would drop a peer that merely referenced a
+ *  cascaded identity). */
 export function computeExclusion(
   fb: FactBase,
   rootIds: ReadonlySet<string>,
+  options?: { reverseDepends?: boolean },
 ): ComputedExclusion {
   const removed = new Set<string>();
   const kept = new Set<string>();
   for (const fact of fb.facts())
     resolveRemoval(fb, rootIds, removed, kept, fact);
-  expandDependentClosure(fb, removed, kept);
+  if (options?.reverseDepends !== false)
+    expandDependentClosure(fb, removed, kept);
   const keptFacts: Fact[] = fb
     .facts()
     .filter((f) => !removed.has(encodeId(f.id)));
@@ -365,6 +370,19 @@ export function excludeFactsAndDescendants(
 ): FactBase {
   if (rootIds.size === 0) return fb;
   return buildExclusion(fb, computeExclusion(fb, rootIds));
+}
+
+/** Drop `rootIds` and their parent-chain children. Does not walk reverse
+ *  `depends` — see `computeExclusion` (`reverseDepends: false`). */
+export function excludeIdentitiesAndChildren(
+  fb: FactBase,
+  rootIds: ReadonlySet<string> | undefined,
+): FactBase {
+  if (rootIds === undefined || rootIds.size === 0) return fb;
+  return buildExclusion(
+    fb,
+    computeExclusion(fb, rootIds, { reverseDepends: false }),
+  );
 }
 
 /** Management scope of a declarative apply (target-architecture §scope). */

--- a/packages/pg-delta/src/policy/view.ts
+++ b/packages/pg-delta/src/policy/view.ts
@@ -60,10 +60,19 @@ export type ProjectionSuppressionAttribution = Omit<
 const edgeKey = (edge: DependencyEdge): string =>
   `${encodeId(edge.from)}|${edge.kind}|${encodeId(edge.to)}`;
 
+/** Reason code for a fact removed because it depends on an excluded object
+ *  (not because a scope rule matched it, and not parent-chain descent). */
+export const EXCLUDED_BY_CASCADE_REASON = "policy.excluded-by-cascade";
+
+function isCascadeEdge(kind: EdgeKind): boolean {
+  return kind === "depends" || kind === "memberOfExtension";
+}
+
 /** Emit fact + independently-pruned-edge suppression records for a projection.
  * The root map names the actual exclusion decisions; collateral descendants
- * point back to that decision through `viaDescendantOf`. Kept off the normal
- * projection hot path unless a caller explicitly supplies a collector. */
+ * and depends-cascaded facts point back to that decision through
+ * `viaDescendantOf`. Kept off the normal projection hot path unless a caller
+ * explicitly supplies a collector. */
 export function collectRemovedSuppressions(
   before: FactBase,
   after: FactBase,
@@ -80,6 +89,40 @@ export function collectRemovedSuppressions(
       const attribution = roots.get(encodeId(cursor));
       if (attribution !== undefined) return { id: cursor, attribution };
       cursor = before.get(cursor)?.parent;
+    }
+    const visited = new Set<string>();
+    const queue: StableId[] = [id];
+    // Children of a depends-cascaded fact have no outgoing cascade edge of
+    // their own; walk ancestors so attribution still reaches the excluded root.
+    let ancestor = before.get(id)?.parent;
+    while (ancestor !== undefined) {
+      queue.push(ancestor);
+      ancestor = before.get(ancestor)?.parent;
+    }
+    while (queue.length > 0) {
+      const current = queue.shift() as StableId;
+      const key = encodeId(current);
+      if (visited.has(key)) continue;
+      visited.add(key);
+      const attribution = roots.get(key);
+      if (attribution !== undefined) {
+        return {
+          id: current,
+          attribution: {
+            ...attribution,
+            reasonCode: EXCLUDED_BY_CASCADE_REASON,
+          },
+        };
+      }
+      for (const edge of before.outgoingEdges(current)) {
+        if (isCascadeEdge(edge.kind)) queue.push(edge.to);
+      }
+      if (current.kind === "securityLabel") {
+        queue.push({
+          kind: "extension",
+          name: (current as { provider: string }).provider,
+        });
+      }
     }
     return undefined;
   };
@@ -177,8 +220,67 @@ function resolveRemoval(
 }
 
 /**
+ * After parent-chain removal, also remove every fact that `depends` on (or is
+ * a `memberOfExtension` of) a removed fact, plus security labels whose
+ * provider is a removed extension. Fixpoint BFS. Owner edges are not walked.
+ */
+function expandDependentClosure(
+  fb: FactBase,
+  removed: Set<string>,
+  kept: Set<string>,
+): void {
+  if (removed.size === 0) return;
+
+  const seclabelsByProvider = new Map<string, StableId[]>();
+  for (const fact of fb.facts()) {
+    if (fact.id.kind !== "securityLabel") continue;
+    const provider = (fact.id as { provider: string }).provider;
+    const list = seclabelsByProvider.get(provider) ?? [];
+    list.push(fact.id);
+    seclabelsByProvider.set(provider, list);
+  }
+
+  const pending = [...removed];
+  const queued = new Set(removed);
+
+  const take = (id: StableId): void => {
+    const stack: StableId[] = [id];
+    while (stack.length > 0) {
+      const current = stack.pop() as StableId;
+      const key = encodeId(current);
+      const already = removed.has(key);
+      removed.add(key);
+      kept.delete(key);
+      if (!queued.has(key)) {
+        queued.add(key);
+        pending.push(key);
+      }
+      if (already) continue;
+      for (const child of fb.childrenOf(current)) stack.push(child.id);
+    }
+  };
+
+  while (pending.length > 0) {
+    const key = pending.pop() as string;
+    for (const edge of fb.incomingEdgesByEncoded(key)) {
+      if (isCascadeEdge(edge.kind)) take(edge.from);
+    }
+    const fact = fb.getByEncoded(key);
+    if (fact?.id.kind === "extension") {
+      const name = (fact.id as { name: string }).name;
+      for (const seclabel of seclabelsByProvider.get(name) ?? [])
+        take(seclabel);
+    }
+  }
+}
+
+/**
  * The exclusion of `rootIds` and their descendant subtrees, COMPUTED but not yet
- * built into a FactBase.
+ * built into a FactBase. The closure also includes facts that depend on a
+ * removed fact (`depends` / `memberOfExtension`) and security labels whose
+ * provider is a removed extension — otherwise those dependents stay managed
+ * after their edge is pruned and the planner either throws or emits
+ * unreplayable SQL.
  *
  * Split out so `resolveView` — which has to attach ADDITIONAL reference-only
  * marks on top of this projection — can do the whole thing in ONE
@@ -194,17 +296,21 @@ export interface ComputedExclusion {
   referenceOnly: Set<string>;
 }
 
-/** Compute (without building) the exclusion of `rootIds` + descendants. An empty
- *  `rootIds` keeps every fact and every edge — the identity projection. */
+/** Compute (without building) the exclusion of `rootIds` + descendants +
+ *  reverse-depends closure. An empty `rootIds` keeps every fact and every
+ *  edge — the identity projection. */
 export function computeExclusion(
   fb: FactBase,
   rootIds: ReadonlySet<string>,
 ): ComputedExclusion {
   const removed = new Set<string>();
   const kept = new Set<string>();
+  for (const fact of fb.facts())
+    resolveRemoval(fb, rootIds, removed, kept, fact);
+  expandDependentClosure(fb, removed, kept);
   const keptFacts: Fact[] = fb
     .facts()
-    .filter((f) => !resolveRemoval(fb, rootIds, removed, kept, f));
+    .filter((f) => !removed.has(encodeId(f.id)));
   const survives = new Set(keptFacts.map((f) => encodeId(f.id)));
   const keptEdges: DependencyEdge[] = fb.edges.filter((e) => {
     const fromSurvives = survives.has(encodeId(e.from));
@@ -248,9 +354,10 @@ export function buildExclusion(
 }
 
 /**
- * Return a new FactBase with `rootIds` and their entire descendant subtrees
- * removed; edges with a removed endpoint are pruned. If `rootIds` is empty, `fb`
- * is returned unchanged (referential identity preserved for cheap no-ops).
+ * Return a new FactBase with `rootIds`, their descendant subtrees, and facts
+ * that depend on them removed; edges with a removed endpoint are pruned. If
+ * `rootIds` is empty, `fb` is returned unchanged (referential identity
+ * preserved for cheap no-ops).
  */
 export function excludeFactsAndDescendants(
   fb: FactBase,
@@ -265,9 +372,10 @@ export type ManagementScope = "database" | "cluster";
 
 /**
  * Encoded ids removed by excluding `rootIds` and their descendant subtrees (a
- * fact is removed if it is a root or has a removed ancestor). Mirrors the
- * removal walk in `excludeFactsAndDescendants`; used by `projectManagementScope`
- * so it agrees on the removal closure while handling edges specially.
+ * fact is removed if it is a root or has a removed ancestor). Parent-chain
+ * only — unlike `computeExclusion`, this does not walk reverse `depends`.
+ * Used by `projectManagementScope` so role/membership exclusion does not
+ * cascade-remove every object that merely referenced a role.
  */
 function removedClosure(
   fb: FactBase,

--- a/packages/pg-delta/src/proof/prove.ts
+++ b/packages/pg-delta/src/proof/prove.ts
@@ -721,19 +721,31 @@ export async function provePlan(
         `as options.baseline so the proof compares the same view the plan diffed.`,
     );
   }
+  const alignedIds =
+    thePlan.cascadeAlignedIds !== undefined &&
+    thePlan.cascadeAlignedIds.length > 0
+      ? new Set(thePlan.cascadeAlignedIds)
+      : undefined;
   const viewOpts = {
     policy,
     capability,
     baseline: options.baseline,
     scope: thePlan.scope,
     defaultOwner: thePlan.defaultOwner,
+    ...(alignedIds !== undefined ? { alignedIds } : {}),
   };
   const reextractClone = (): Promise<{ factBase: FactBase }> =>
     options.reextract
       ? options.reextract(clonePool)
       : extract(clonePool, { redactSecrets: thePlan.redactSecrets ?? true });
-  const managedView = (factBase: FactBase): FactBase =>
-    reconstructManagedView(factBase, viewOpts);
+  const managedView = (
+    factBase: FactBase,
+    keepAssumedIds?: ReadonlySet<string>,
+  ): FactBase =>
+    reconstructManagedView(factBase, {
+      ...viewOpts,
+      ...(keepAssumedIds !== undefined ? { keepAssumedIds } : {}),
+    });
 
   // Validate every immutable input before table scans, auto-seeding, or DDL.
   // A stale/wrong desired snapshot used to be discovered only after the clone
@@ -767,7 +779,20 @@ export async function provePlan(
 
   // The plan target is the managed, projected desired view. Reconstruct it
   // exactly as the final convergence comparison does, but before mutation.
-  const target = managedView(projectTarget(desired, thePlan.filteredDeltas));
+  // Clone extract first: desired may need the live side's reference-only set
+  // (shadow-seeded platform tables re-extract as the applier).
+  const cloneRaw = (await reextractClone()).factBase;
+  const sourceUnaligned = reconstructManagedView(cloneRaw, {
+    policy,
+    capability,
+    baseline: options.baseline,
+    scope: thePlan.scope,
+    defaultOwner: thePlan.defaultOwner,
+  });
+  const target = managedView(
+    projectTarget(desired, thePlan.filteredDeltas),
+    sourceUnaligned.referenceOnly,
+  );
   if (target.rootHash !== thePlan.target.fingerprint) {
     return {
       ok: false,
@@ -785,7 +810,7 @@ export async function provePlan(
     };
   }
 
-  const initialClone = managedView((await reextractClone()).factBase);
+  const initialClone = managedView(cloneRaw);
   if (initialClone.rootHash !== thePlan.source.fingerprint) {
     return {
       ok: false,

--- a/packages/pg-delta/tests/assumed-schema-requirement.test.ts
+++ b/packages/pg-delta/tests/assumed-schema-requirement.test.ts
@@ -1,13 +1,10 @@
 /**
- * The assumed-schema ambient exemption must not cover objects that DON'T exist
- * on the target (PR #307 review #3499413404). A managed object that references a
- * NEW object in an assumed schema (e.g. `auth.extra`) which is absent from the
- * target is kept reference-only on the desired side, so its creation is
- * suppressed; the requirement guard previously treated any id in an assumed
- * schema as ambient and let the dependent plan through, only to fail at apply
- * time against the missing relation. It must instead fail at PLAN time like any
- * other filtered-away requirement. An existing assumed-schema object
- * (`auth.users`-style, present on the target) stays satisfied via `source.has`.
+ * A managed object that references a NEW user-owned object in an assumed schema
+ * (e.g. `auth.extra`) is hard-pruned with its dependents (CLI-2300): the view
+ * is skipped with `excluded-by-cascade` instead of planning a CREATE that would
+ * fail at apply against the missing relation. An existing platform-provisioned
+ * assumed-schema object (`auth.users`-style, present on the target) stays
+ * reference-only via `source.has`.
  *
  * The fail-fast must NOT cover PLATFORM-provisioned members of assumed schemas
  * (Sentry SUPABASE-API-8CX): a DB-webhook trigger depends on
@@ -20,6 +17,7 @@
  * Docker required.
  */
 import { afterAll, describe, expect, test } from "bun:test";
+import { EXCLUDED_BY_CASCADE } from "../src/core/diagnostic.ts";
 import { extract } from "../src/extract/extract.ts";
 import { plan } from "../src/plan/plan.ts";
 import { supabasePolicy } from "../src/policy/supabase.ts";
@@ -31,7 +29,7 @@ afterAll(async () => {
 });
 
 describe("assumed-schema requirement guard", () => {
-  test("a managed dependent on a non-existent assumed-schema object fails at plan time", async () => {
+  test("a managed dependent on a user-owned assumed-schema object is cascaded out", async () => {
     const cluster = await sharedCluster();
     const source = await cluster.createDb("assumed_req_src");
     const desired = await cluster.createDb("assumed_req_dst");
@@ -39,8 +37,8 @@ describe("assumed-schema requirement guard", () => {
 
     // target has the assumed schema but NOT `auth.extra`.
     await source.pool.query(`CREATE SCHEMA auth`);
-    // desired adds `auth.extra` (filtered to reference-only by the profile) and a
-    // managed public view that depends on it.
+    // desired adds a user-owned `auth.extra` (hard-pruned) and a public view
+    // that depends on it (cascaded out).
     await desired.pool.query(`
       CREATE SCHEMA auth;
       CREATE TABLE auth.extra (id integer);
@@ -52,14 +50,15 @@ describe("assumed-schema requirement guard", () => {
       extract(desired.pool),
     ]);
 
-    // RED before the fix: this does NOT throw — the view plans through because
-    // `auth.extra` is treated as ambient, and apply would later fail against the
-    // missing relation.
-    expect(() =>
-      plan(sourceState.factBase, desiredState.factBase, {
-        policy: supabasePolicy,
-      }),
-    ).toThrow(/missing requirement[\s\S]*auth.*extra/);
+    const thePlan = plan(sourceState.factBase, desiredState.factBase, {
+      policy: supabasePolicy,
+    });
+    expect(
+      thePlan.actions.some((a) => /needs_extra|CREATE VIEW/i.test(a.sql)),
+    ).toBe(false);
+    expect(
+      thePlan.diagnostics?.some((d) => d.code === EXCLUDED_BY_CASCADE),
+    ).toBe(true);
   }, 120_000);
 
   test("a DB-webhook trigger plans when the target lacks the platform's supabase_functions infra", async () => {

--- a/packages/pg-delta/tests/export-reference-only-parent.test.ts
+++ b/packages/pg-delta/tests/export-reference-only-parent.test.ts
@@ -35,8 +35,14 @@ describe("export: managed child under a reference-only assumed parent", () => {
     // The trigger's function lives in public, so the policy keeps the trigger as
     // a user-managed object on the reference-only auth.users.
     await src.pool.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_admin') THEN
+          CREATE ROLE supabase_admin;
+        END IF;
+      END $$;
       CREATE SCHEMA auth;
       CREATE TABLE auth.users (id uuid PRIMARY KEY, email text);
+      ALTER TABLE auth.users OWNER TO supabase_admin;
       CREATE FUNCTION public.handle_new_user() RETURNS trigger
         LANGUAGE plpgsql AS $$ BEGIN RETURN new; END; $$;
       CREATE TRIGGER on_auth_user_created

--- a/packages/pg-delta/tests/policy-filter-integration.test.ts
+++ b/packages/pg-delta/tests/policy-filter-integration.test.ts
@@ -232,3 +232,52 @@ describe.skipIf(skipSeclabelProof)("policy filter: security labels", () => {
     expect(sql.some((s) => /SECURITY LABEL FOR 'dummy'/.test(s))).toBe(false);
   }, 300_000);
 });
+
+describe("policy filter: exclusion cascades to dependents", () => {
+  test("a view over an excluded schema is skipped; apply does not reference it", async () => {
+    const cluster = await sharedCluster();
+    const main = await cluster.createDb("polf_cascade_main");
+    const desired = await cluster.createDb("polf_cascade_dst");
+    try {
+      await desired.pool.query(`
+        CREATE SCHEMA ops;
+        CREATE TABLE ops.events (id integer);
+        CREATE TABLE public.ok (id integer);
+        CREATE VIEW public.from_ops AS SELECT id FROM ops.events;
+      `);
+      const policy: Policy = {
+        id: "hide-ops",
+        filter: [
+          { match: { schema: ["ops"] }, action: "exclude" },
+          {
+            match: { all: [{ kind: "schema" }, { name: ["ops"] }] },
+            action: "exclude",
+          },
+        ],
+      };
+
+      const [s, d] = await Promise.all([
+        extract(main.pool),
+        extract(desired.pool),
+      ]);
+      const thePlan = plan(s.factBase, d.factBase, { policy });
+
+      expect(thePlan.actions.some((a) => /from_ops/.test(a.sql))).toBe(false);
+      expect(thePlan.actions.some((a) => /\bops\b/.test(a.sql))).toBe(false);
+      expect(
+        thePlan.actions.some(
+          (a) => /CREATE TABLE/.test(a.sql) && /ok/.test(a.sql),
+        ),
+      ).toBe(true);
+
+      const report = await apply(thePlan, main.pool, {
+        fingerprintGate: false,
+      });
+      expect(report.status).toBe("applied");
+      const after = await extract(main.pool);
+      expect(plan(after.factBase, d.factBase, { policy }).actions).toEqual([]);
+    } finally {
+      await Promise.all([main.drop(), desired.drop()]);
+    }
+  }, 60_000);
+});

--- a/packages/pg-delta/tests/supabase-applier-baseline.test.ts
+++ b/packages/pg-delta/tests/supabase-applier-baseline.test.ts
@@ -86,5 +86,105 @@ describe.skipIf(!runSupabaseBareTests)(
         await base.drop();
       }
     }, 120_000);
+
+    test("E3: user objects depending on excluded pgsodium apply without referencing it", async () => {
+      const branch: TestDb = await cluster.createDb("e3_branch");
+      const base: TestDb = await cluster.createDb("e3_base");
+      const applier = new pg.Pool({
+        connectionString: branch.postgresUri!,
+        max: 1,
+      });
+      applier.on("error", () => {});
+      try {
+        await base.pool.query(`CREATE EXTENSION IF NOT EXISTS pgsodium`);
+        await base.pool.query(`
+          CREATE TABLE public.creds (
+            id int primary key,
+            secret text,
+            key_id uuid default (pgsodium.create_key()).id,
+            nonce bytea default pgsodium.crypto_aead_det_noncegen());
+          SECURITY LABEL FOR pgsodium ON COLUMN public.creds.secret
+            IS 'ENCRYPT WITH KEY COLUMN key_id NONCE nonce';
+        `);
+
+        const profile = await resolveProfile(applier, supabaseProfile);
+        const [src, desired] = await Promise.all([
+          profile.extract(applier),
+          profile.extract(base.pool),
+        ]);
+        const migration = plan(src.factBase, desired.factBase, {
+          ...profile.planOptions,
+          renames: "off",
+          compact: true,
+        });
+        const report = await apply(migration, applier, {
+          ...profile.applyOptions,
+        });
+
+        expect(report.status).toBe("applied");
+        expect(migration.actions.some((a) => /pgsodium/i.test(a.sql))).toBe(
+          false,
+        );
+        expect(
+          migration.actions.some((a) => /CREATE EXTENSION/i.test(a.sql)),
+        ).toBe(false);
+      } finally {
+        await applier.end().catch(() => {});
+        await branch.drop();
+        await base.drop();
+      }
+    }, 120_000);
+
+    test("CLI-2300: user trigger on postgres-owned schema_migrations is not created on the branch", async () => {
+      const branch: TestDb = await cluster.createDb("cli2300_branch");
+      const base: TestDb = await cluster.createDb("cli2300_base");
+      const applier = new pg.Pool({
+        connectionString: branch.postgresUri!,
+        max: 1,
+      });
+      applier.on("error", () => {});
+      try {
+        await base.pool.query(`
+          CREATE SCHEMA IF NOT EXISTS supabase_migrations;
+          CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
+            version text PRIMARY KEY
+          );
+          ALTER TABLE supabase_migrations.schema_migrations OWNER TO postgres;
+          CREATE FUNCTION public.on_mig() RETURNS trigger LANGUAGE plpgsql
+            AS $$ BEGIN RETURN NEW; END $$;
+          CREATE TRIGGER block_writes
+            BEFORE INSERT ON supabase_migrations.schema_migrations
+            FOR EACH ROW EXECUTE FUNCTION public.on_mig();
+        `);
+
+        const profile = await resolveProfile(applier, supabaseProfile);
+        const [src, desired] = await Promise.all([
+          profile.extract(applier),
+          profile.extract(base.pool),
+        ]);
+        const migration = plan(src.factBase, desired.factBase, {
+          ...profile.planOptions,
+          renames: "off",
+          compact: true,
+        });
+        const report = await apply(migration, applier, {
+          ...profile.applyOptions,
+        });
+
+        expect(report.status).toBe("applied");
+        expect(
+          migration.actions.some(
+            (a) => /CREATE TRIGGER/i.test(a.sql) && /block_writes/i.test(a.sql),
+          ),
+        ).toBe(false);
+        expect(
+          migration.actions.some((a) => /schema_migrations/i.test(a.sql)),
+        ).toBe(false);
+      } finally {
+        await applier.end().catch(() => {});
+        await branch.drop();
+        await base.drop();
+      }
+    }, 120_000);
   },
 );


### PR DESCRIPTION
## Summary

Policy exclusion now closes over dependents (parent children and reverse `depends` / `memberOfExtension` / seclabel provider) so satellites of a hard-pruned object leave the managed view with an `excluded-by-cascade` diagnostic instead of throwing or planning unreplayable CREATE/DROP.

- **CLI-2300:** a user trigger on `postgres`-owned `supabase_migrations.schema_migrations` is skipped instead of throwing missing-requirement against an empty branch. Platform-owned assumed-schema tables (`auth.users`) stay reference-only, so user RLS/webhooks still plan.
- **CLI-2342:** TCE artefacts of excluded `pgsodium` (decrypted views, encrypt triggers, column defaults, security labels) are no longer planned as CREATE on a branch that never gets the extension, or as DROP against a live catalog.
- Image-provisioned system extensions (`pg_graphql`, `pg_stat_statements`, `supabase_vault`) are `assumedExtensions` (reference-only), so a user view over `vault.decrypted_secrets` still plans. `pgsodium` and `wrappers` stay hard-pruned; this also closes the CLI-2178 wrappers-view follow-up.

## Linked issue

CLI-2300, CLI-2342 (Linear). Also addresses CLI-2178.

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Test plan

- [ ] `cd packages/pg-delta && bun test src/policy/exclusion-cascade.test.ts src/policy/view.test.ts src/policy/supabase-extensions.test.ts src/plan/assumed-schema-requirement.test.ts src/policy/policy.test.ts`
- [ ] `cd packages/pg-delta && bun test tests/policy-filter-integration.test.ts`
- [ ] `PGDELTA_NEXT_SUPABASE_TESTS=1 bun test tests/supabase-applier-baseline.test.ts` (E3 + CLI-2300 apply-as-postgres)
- [ ] `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts` (full corpus; already 666/666 locally)