### PR TITLE
fix(pg-delta): keep PK-redundant UNIQUE as ALTER TABLE

### DIFF
--- a/.changeset/pk-redundant-unique-fold.md
+++ b/.changeset/pk-redundant-unique-fold.md
@@ -1,0 +1,10 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): keep a UNIQUE that matches a PK or another UNIQUE as ALTER TABLE
+
+Postgres silently drops a UNIQUE inlined in CREATE TABLE when its column list
+equals a PRIMARY KEY or another UNIQUE in the same statement
+(`transformIndexConstraints`). Compaction now leaves those UNIQUEs as
+`ALTER TABLE … ADD CONSTRAINT` so one apply pass converges.

--- a/packages/pg-delta/corpus/constraint-ops--pk-redundant-unique/a.sql
+++ b/packages/pg-delta/corpus/constraint-ops--pk-redundant-unique/a.sql
@@ -1,0 +1,1 @@
+-- empty starting state

--- a/packages/pg-delta/corpus/constraint-ops--pk-redundant-unique/b.sql
+++ b/packages/pg-delta/corpus/constraint-ops--pk-redundant-unique/b.sql
@@ -1,0 +1,24 @@
+-- UNIQUE whose column list equals the PRIMARY KEY: Postgres honours this
+-- when added via ALTER TABLE, and silently drops it when inlined in CREATE TABLE.
+CREATE SCHEMA test_schema;
+
+CREATE TABLE test_schema."companyIntegration" (
+  id integer NOT NULL,
+  "companyId" integer NOT NULL,
+  CONSTRAINT "companyIntegration_pkey" PRIMARY KEY (id, "companyId")
+);
+ALTER TABLE test_schema."companyIntegration"
+  ADD CONSTRAINT "companyIntegration_id_companyId_unique" UNIQUE (id, "companyId");
+
+-- control: UNIQUE on a different column set still folds into CREATE TABLE
+CREATE TABLE test_schema.u (
+  a integer NOT NULL,
+  c integer,
+  CONSTRAINT u_pkey PRIMARY KEY (a)
+);
+ALTER TABLE test_schema.u ADD CONSTRAINT u_c_unique UNIQUE (c);
+
+-- two UNIQUEs on the same columns: CREATE TABLE keeps only the first
+CREATE TABLE test_schema.dup_unique (a integer NOT NULL);
+ALTER TABLE test_schema.dup_unique ADD CONSTRAINT dup_u1 UNIQUE (a);
+ALTER TABLE test_schema.dup_unique ADD CONSTRAINT dup_u2 UNIQUE (a);

--- a/packages/pg-delta/src/extract/relations.ts
+++ b/packages/pg-delta/src/extract/relations.ts
@@ -263,7 +263,16 @@ const TABLE_CONSTRAINTS_SQL = `
            c.relkind AS table_kind,
            pg_get_constraintdef(con.oid) AS def,
            con.contype AS type, con.convalidated AS validated,
-           obj_description(con.oid, 'pg_constraint') AS comment
+           obj_description(con.oid, 'pg_constraint') AS comment,
+           CASE
+             WHEN con.contype NOT IN ('p', 'u') THEN NULL
+             WHEN con.conkey IS NULL OR 0 = ANY (con.conkey) THEN ARRAY[]::text[]
+             ELSE (
+               SELECT array_agg(a.attname::text ORDER BY k.ord)
+               FROM unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord)
+               JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = k.attnum
+             )
+           END AS key_columns
     FROM pg_constraint con
     JOIN pg_class c ON c.oid = con.conrelid
     JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -281,6 +290,8 @@ export const tableConstraintsFamily: CatalogFamily = {
   apply: (ctx, rowSets) => {
     const { pushWithMeta } = ctx;
     for (const row of rowSets[0]!) {
+      const type = String(row["type"]);
+      const keyColumns = row["key_columns"];
       pushWithMeta(
         {
           id: {
@@ -296,8 +307,18 @@ export const tableConstraintsFamily: CatalogFamily = {
           },
           payload: {
             def: String(row["def"]),
-            type: String(row["type"]),
+            type,
             validated: Boolean(row["validated"]),
+            // Planner-only: CREATE TABLE drops a UNIQUE whose conkey equals
+            // another index constraint in the same statement; `_` keeps this
+            // off the hash/diff surface.
+            ...(type === "p" || type === "u"
+              ? {
+                  _keyColumns: Array.isArray(keyColumns)
+                    ? keyColumns.map(String)
+                    : [],
+                }
+              : {}),
           },
         },
         row,

--- a/packages/pg-delta/src/plan/constraint-fold.test.ts
+++ b/packages/pg-delta/src/plan/constraint-fold.test.ts
@@ -61,7 +61,18 @@ const constraintFact = (
   def: string,
   type: string,
   validated = true,
-): Fact => f(constraint(tbl, name), { def, type, validated }, table(tbl));
+  keyColumns?: string[],
+): Fact =>
+  f(
+    constraint(tbl, name),
+    {
+      def,
+      type,
+      validated,
+      ...(keyColumns ? { _keyColumns: keyColumns } : {}),
+    },
+    table(tbl),
+  );
 
 /** table t with one integer column and one constraint. */
 const tableFacts = (tbl: string, ...constraints: Fact[]): Fact[] => [
@@ -185,5 +196,148 @@ describe("compaction folds self-contained constraints into CREATE TABLE", () => 
     expect(sqls(compacted)).toEqual([
       `ALTER TABLE "app"."t" ADD CONSTRAINT "t_pkey" PRIMARY KEY (id)`,
     ]);
+  });
+
+  test("PK + same-key UNIQUE still folds when _keyColumns is absent", () => {
+    const desired = buildFactBase(
+      [
+        f(schemaApp),
+        f(table("t"), tablePayload(), schemaApp),
+        f(column("t", "id"), columnPayload(1), table("t")),
+        f(column("t", "company_id"), columnPayload(2), table("t")),
+        constraintFact("t", "t_pkey", "PRIMARY KEY (id, company_id)", "p"),
+        constraintFact("t", "t_ab_unique", "UNIQUE (id, company_id)", "u"),
+      ],
+      [],
+    );
+    const compacted = plan(empty, desired);
+    const createTable = sqls(compacted).find((s) =>
+      s.startsWith(`CREATE TABLE "app"."t"`),
+    );
+    expect(createTable).toContain(
+      `CONSTRAINT "t_pkey" PRIMARY KEY (id, company_id)`,
+    );
+    expect(createTable).toContain(
+      `CONSTRAINT "t_ab_unique" UNIQUE (id, company_id)`,
+    );
+    expect(sqls(compacted).some((s) => s.includes("ADD CONSTRAINT"))).toBe(
+      false,
+    );
+  });
+
+  test("UNIQUE on the same columns as a co-created PRIMARY KEY stays an ALTER", () => {
+    const desired = buildFactBase(
+      [
+        f(schemaApp),
+        f(table("t"), tablePayload(), schemaApp),
+        f(column("t", "id"), columnPayload(1), table("t")),
+        f(column("t", "company_id"), columnPayload(2), table("t")),
+        constraintFact(
+          "t",
+          "t_pkey",
+          "PRIMARY KEY (id, company_id)",
+          "p",
+          true,
+          ["id", "company_id"],
+        ),
+        constraintFact(
+          "t",
+          "t_ab_unique",
+          "UNIQUE (id, company_id)",
+          "u",
+          true,
+          ["id", "company_id"],
+        ),
+      ],
+      [],
+    );
+    const compacted = plan(empty, desired);
+    const createTable = sqls(compacted).find((s) =>
+      s.startsWith(`CREATE TABLE "app"."t"`),
+    );
+    expect(createTable).toContain(
+      `CONSTRAINT "t_pkey" PRIMARY KEY (id, company_id)`,
+    );
+    expect(createTable).not.toContain("UNIQUE");
+    expect(sqls(compacted)).toContain(
+      `ALTER TABLE "app"."t" ADD CONSTRAINT "t_ab_unique" UNIQUE (id, company_id)`,
+    );
+  });
+
+  test("UNIQUE on different columns than the PRIMARY KEY still folds", () => {
+    const desired = buildFactBase(
+      [
+        f(schemaApp),
+        f(table("t"), tablePayload(), schemaApp),
+        f(column("t", "id"), columnPayload(1), table("t")),
+        f(column("t", "email"), columnPayload(2), table("t")),
+        constraintFact("t", "t_pkey", "PRIMARY KEY (id)", "p", true, ["id"]),
+        constraintFact("t", "t_email_key", "UNIQUE (email)", "u", true, [
+          "email",
+        ]),
+      ],
+      [],
+    );
+    const compacted = plan(empty, desired);
+    const createTable = sqls(compacted).find((s) =>
+      s.startsWith(`CREATE TABLE "app"."t"`),
+    );
+    expect(createTable).toContain(`CONSTRAINT "t_pkey" PRIMARY KEY (id)`);
+    expect(createTable).toContain(`CONSTRAINT "t_email_key" UNIQUE (email)`);
+    expect(sqls(compacted).some((s) => s.includes("ADD CONSTRAINT"))).toBe(
+      false,
+    );
+  });
+
+  test("a second UNIQUE on the same columns as a folded UNIQUE stays an ALTER", () => {
+    const desired = buildFactBase(
+      [
+        f(schemaApp),
+        f(table("t"), tablePayload(), schemaApp),
+        f(column("t", "id"), columnPayload(1), table("t")),
+        constraintFact("t", "t_u1", "UNIQUE (id)", "u", true, ["id"]),
+        constraintFact("t", "t_u2", "UNIQUE (id)", "u", true, ["id"]),
+      ],
+      [],
+    );
+    const compacted = plan(empty, desired);
+    const createTable = sqls(compacted).find((s) =>
+      s.startsWith(`CREATE TABLE "app"."t"`),
+    );
+    expect((createTable?.match(/UNIQUE/g) ?? []).length).toBe(1);
+    const alters = sqls(compacted).filter((s) => s.includes("ADD CONSTRAINT"));
+    expect(alters).toHaveLength(1);
+    expect(alters[0]).toMatch(/UNIQUE \(id\)/);
+    expect(sqls(compacted).some((s) => s.includes(`"t_u1"`))).toBe(true);
+    expect(sqls(compacted).some((s) => s.includes(`"t_u2"`))).toBe(true);
+  });
+
+  test("UNIQUE with the PK columns in a different order still folds", () => {
+    const desired = buildFactBase(
+      [
+        f(schemaApp),
+        f(table("t"), tablePayload(), schemaApp),
+        f(column("t", "a"), columnPayload(1), table("t")),
+        f(column("t", "b"), columnPayload(2), table("t")),
+        constraintFact("t", "t_pkey", "PRIMARY KEY (a, b)", "p", true, [
+          "a",
+          "b",
+        ]),
+        constraintFact("t", "t_ba_unique", "UNIQUE (b, a)", "u", true, [
+          "b",
+          "a",
+        ]),
+      ],
+      [],
+    );
+    const compacted = plan(empty, desired);
+    const createTable = sqls(compacted).find((s) =>
+      s.startsWith(`CREATE TABLE "app"."t"`),
+    );
+    expect(createTable).toContain(`CONSTRAINT "t_pkey" PRIMARY KEY (a, b)`);
+    expect(createTable).toContain(`CONSTRAINT "t_ba_unique" UNIQUE (b, a)`);
+    expect(sqls(compacted).some((s) => s.includes("ADD CONSTRAINT"))).toBe(
+      false,
+    );
   });
 });

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -665,6 +665,22 @@ export function compactColumnFolds(
       if (!targetPosOf.has(key)) targetPosOf.set(key, pos);
     }
   });
+  // CREATE TABLE's transformIndexConstraints drops a UNIQUE whose key list
+  // equals a PRIMARY KEY — or another UNIQUE — in the same statement. ALTER
+  // TABLE ADD CONSTRAINT UNIQUE does not. Refuse those folds so one pass
+  // still converges. PK keys are precomputed (a UNIQUE may sort before the PK);
+  // duplicate UNIQUEs are tracked as they fold so the first still inlines.
+  const pkKeysByFoldInto = new Map<string, readonly string[][]>();
+  for (let pos = 0; pos < orderedActions.length; pos++) {
+    const hint = foldHints[order[pos] as number];
+    if (hint?.constraintType !== "p") continue;
+    const keys = hint.indexKeyColumns;
+    if (keys === undefined || keys.length === 0) continue;
+    const target = encodeId(hint.foldInto);
+    const list = pkKeysByFoldInto.get(target) ?? [];
+    pkKeysByFoldInto.set(target, [...list, [...keys]]);
+  }
+  const foldedUniqueKeysByFoldInto = new Map<string, readonly string[][]>();
   const foldedPos = new Set<number>();
   const effectivePosOf = new Map<number, number>(); // orig idx -> post-fold pos
   for (let pos = 0; pos < orderedActions.length; pos++) {
@@ -691,6 +707,20 @@ export function compactColumnFolds(
         if (hint.executorSafe !== true) continue;
       } else if (foldConstraints.exclude?.has(encodeId(action.produces[0]!))) {
         continue;
+      }
+      if (hint.constraintType === "u") {
+        const foldTargetKey = encodeId(hint.foldInto);
+        const occupied = [
+          ...(pkKeysByFoldInto.get(foldTargetKey) ?? []),
+          ...(foldedUniqueKeysByFoldInto.get(foldTargetKey) ?? []),
+        ];
+        if (
+          occupied.some((keys) =>
+            sameIndexKeyColumns(hint.indexKeyColumns, keys),
+          )
+        ) {
+          continue;
+        }
       }
     }
     const targetPos = targetPosOf.get(encodeId(hint.foldInto));
@@ -743,10 +773,33 @@ export function compactColumnFolds(
     target.rewriteRisk = target.rewriteRisk || action.rewriteRisk;
     foldedPos.add(pos);
     effectivePosOf.set(origIndex, targetPos);
+    if (
+      isConstraintFold &&
+      hint.constraintType === "u" &&
+      hint.indexKeyColumns !== undefined &&
+      hint.indexKeyColumns.length > 0
+    ) {
+      const foldTargetKey = encodeId(hint.foldInto);
+      const list = foldedUniqueKeysByFoldInto.get(foldTargetKey) ?? [];
+      foldedUniqueKeysByFoldInto.set(foldTargetKey, [
+        ...list,
+        [...hint.indexKeyColumns],
+      ]);
+    }
   }
   return foldedPos.size > 0
     ? orderedActions.filter((_, pos) => !foldedPos.has(pos))
     : [...orderedActions];
+}
+
+function sameIndexKeyColumns(
+  a: readonly string[] | undefined,
+  b: readonly string[] | undefined,
+): boolean {
+  if (a === undefined || b === undefined || a.length !== b.length) {
+    return false;
+  }
+  return a.length > 0 && a.every((name, i) => name === b[i]);
 }
 
 /**

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -668,19 +668,17 @@ export function compactColumnFolds(
   // CREATE TABLE's transformIndexConstraints drops a UNIQUE whose key list
   // equals a PRIMARY KEY — or another UNIQUE — in the same statement. ALTER
   // TABLE ADD CONSTRAINT UNIQUE does not. Refuse those folds so one pass
-  // still converges. PK keys are precomputed (a UNIQUE may sort before the PK);
-  // duplicate UNIQUEs are tracked as they fold so the first still inlines.
-  const pkKeysByFoldInto = new Map<string, readonly string[][]>();
+  // still converges. Occupied keys: NUL-joined attnames (C-string names) in a
+  // Set per CREATE. PKs are pre-seeded (a UNIQUE may sort before the PK);
+  // UNIQUEs are added only after they fold so the first still inlines.
+  const occupiedIndexKeysByFoldInto = new Map<string, Set<string>>();
   for (let pos = 0; pos < orderedActions.length; pos++) {
     const hint = foldHints[order[pos] as number];
     if (hint?.constraintType !== "p") continue;
-    const keys = hint.indexKeyColumns;
-    if (keys === undefined || keys.length === 0) continue;
-    const target = encodeId(hint.foldInto);
-    const list = pkKeysByFoldInto.get(target) ?? [];
-    pkKeysByFoldInto.set(target, [...list, [...keys]]);
+    const sig = indexKeySig(hint.indexKeyColumns);
+    if (sig === undefined) continue;
+    occupyIndexKey(occupiedIndexKeysByFoldInto, encodeId(hint.foldInto), sig);
   }
-  const foldedUniqueKeysByFoldInto = new Map<string, readonly string[][]>();
   const foldedPos = new Set<number>();
   const effectivePosOf = new Map<number, number>(); // orig idx -> post-fold pos
   for (let pos = 0; pos < orderedActions.length; pos++) {
@@ -702,6 +700,7 @@ export function compactColumnFolds(
     //    folded into a CREATE TABLE that precedes the referenced table's
     //    CREATE would fail, so FK hints stay inert here.
     const isConstraintFold = action.produces[0]?.kind === "constraint";
+    let uniqueSigToOccupy: string | undefined;
     if (isConstraintFold) {
       if (foldConstraints === undefined) {
         if (hint.executorSafe !== true) continue;
@@ -709,15 +708,12 @@ export function compactColumnFolds(
         continue;
       }
       if (hint.constraintType === "u") {
-        const foldTargetKey = encodeId(hint.foldInto);
-        const occupied = [
-          ...(pkKeysByFoldInto.get(foldTargetKey) ?? []),
-          ...(foldedUniqueKeysByFoldInto.get(foldTargetKey) ?? []),
-        ];
+        uniqueSigToOccupy = indexKeySig(hint.indexKeyColumns);
         if (
-          occupied.some((keys) =>
-            sameIndexKeyColumns(hint.indexKeyColumns, keys),
-          )
+          uniqueSigToOccupy !== undefined &&
+          occupiedIndexKeysByFoldInto
+            .get(encodeId(hint.foldInto))
+            ?.has(uniqueSigToOccupy)
         ) {
           continue;
         }
@@ -773,18 +769,12 @@ export function compactColumnFolds(
     target.rewriteRisk = target.rewriteRisk || action.rewriteRisk;
     foldedPos.add(pos);
     effectivePosOf.set(origIndex, targetPos);
-    if (
-      isConstraintFold &&
-      hint.constraintType === "u" &&
-      hint.indexKeyColumns !== undefined &&
-      hint.indexKeyColumns.length > 0
-    ) {
-      const foldTargetKey = encodeId(hint.foldInto);
-      const list = foldedUniqueKeysByFoldInto.get(foldTargetKey) ?? [];
-      foldedUniqueKeysByFoldInto.set(foldTargetKey, [
-        ...list,
-        [...hint.indexKeyColumns],
-      ]);
+    if (uniqueSigToOccupy !== undefined) {
+      occupyIndexKey(
+        occupiedIndexKeysByFoldInto,
+        encodeId(hint.foldInto),
+        uniqueSigToOccupy,
+      );
     }
   }
   return foldedPos.size > 0
@@ -792,14 +782,19 @@ export function compactColumnFolds(
     : [...orderedActions];
 }
 
-function sameIndexKeyColumns(
-  a: readonly string[] | undefined,
-  b: readonly string[] | undefined,
-): boolean {
-  if (a === undefined || b === undefined || a.length !== b.length) {
-    return false;
-  }
-  return a.length > 0 && a.every((name, i) => name === b[i]);
+function indexKeySig(keys: readonly string[] | undefined): string | undefined {
+  if (keys === undefined || keys.length === 0) return undefined;
+  return keys.join("\0");
+}
+
+function occupyIndexKey(
+  occupied: Map<string, Set<string>>,
+  foldInto: string,
+  sig: string,
+): void {
+  const set = occupied.get(foldInto);
+  if (set) set.add(sig);
+  else occupied.set(foldInto, new Set([sig]));
 }
 
 /**

--- a/packages/pg-delta/src/plan/rules.ts
+++ b/packages/pg-delta/src/plan/rules.ts
@@ -34,6 +34,12 @@ export interface FoldHint {
   foldInto: StableId;
   clause: string;
   executorSafe?: boolean;
+  /** `p` / `u` — used with `indexKeyColumns` to refuse a CREATE TABLE fold
+   *  Postgres would drop as redundant with a co-created PRIMARY KEY or
+   *  another UNIQUE on the same key list. */
+  constraintType?: string;
+  /** `pg_constraint.conkey` attnames, in key order. */
+  indexKeyColumns?: readonly string[];
 }
 
 export interface ActionSpec {

--- a/packages/pg-delta/src/plan/rules/constraints.ts
+++ b/packages/pg-delta/src/plan/rules/constraints.ts
@@ -43,6 +43,10 @@ export const constraintRules: Record<string, KindRules> = {
       // verbatim def. Full rationale + the guarded design if ever revisited:
       // docs/roadmap/backlog.md § "Column-inline PRIMARY KEY compaction".
       const type = str(p(fact, "type"));
+      const rawKeyColumns = p(fact, "_keyColumns");
+      const indexKeyColumns = Array.isArray(rawKeyColumns)
+        ? rawKeyColumns.map(String)
+        : undefined;
       const foldHint =
         p(fact, "validated") === true && fact.parent?.kind === "table"
           ? {
@@ -51,6 +55,9 @@ export const constraintRules: Record<string, KindRules> = {
                 clause: `CONSTRAINT ${qid(id.name)} ${str(p(fact, "def"))}`,
                 ...(type === "p" || type === "u" || type === "c"
                   ? { executorSafe: true }
+                  : {}),
+                ...((type === "p" || type === "u") && indexKeyColumns
+                  ? { constraintType: type, indexKeyColumns }
                   : {}),
               },
             }


### PR DESCRIPTION
## Summary

Postgres's `transformIndexConstraints` silently drops a UNIQUE inlined in `CREATE TABLE` when its column list equals a PRIMARY KEY or another UNIQUE in the same statement. Compact plans were folding both into `CREATE TABLE`, so `apply()` succeeded while a re-diff still showed `ALTER TABLE … ADD CONSTRAINT`.

- Extract ordered key attnames from `pg_constraint.conkey` onto constraint facts (`_keyColumns`).
- Compaction skips folding a UNIQUE whose keys match the table's PRIMARY KEY or a UNIQUE already folded into the same `CREATE TABLE`, leaving it as `ALTER TABLE` so one apply pass converges.
- Matching is ordered attnames only (not INCLUDE / opclass / deferrable). A false-positive skip still emits a correct ALTER.

## Linked issue

Linear [CLI-2389](https://linear.app/supabase/issue/CLI-2389)

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

## Test plan

- [x] `cd packages/pg-delta && bun test src/plan/constraint-fold.test.ts`
- [x] `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts --test-name-pattern pk-redundant-unique`
- [x] `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts` (full corpus 670/670)
- [x] `bun run format-and-lint` and `bun run check-types`